### PR TITLE
clarify medication statement vs prescribe

### DIFF
--- a/hyperscribe/commands/medication.py
+++ b/hyperscribe/commands/medication.py
@@ -76,7 +76,7 @@ class Medication(Base):
 
     def instruction_description(self) -> str:
         return (
-            "Current medication. There can be only one medication per instruction, and no instruction in the lack of."
+            "Current medication being consumed by the patient, not a new prescription order. There can be only one medication per instruction, and no instruction in the lack of."
         )
 
     def instruction_constraints(self) -> str:

--- a/hyperscribe/commands/prescription.py
+++ b/hyperscribe/commands/prescription.py
@@ -115,7 +115,7 @@ class Prescription(BasePrescription):
 
     def instruction_description(self) -> str:
         return (
-            "Medication prescription, including the directions, the duration, the targeted condition and the dosage. "
+            "New prescription order, including the medication, the directions, the duration, the targeted condition and the dosage. "
             "Create as many instructions as necessary as there can be only one prescribed item per instruction, "
             "and no instruction in the lack of."
         )

--- a/tests/hyperscribe/commands/test_medication.py
+++ b/tests/hyperscribe/commands/test_medication.py
@@ -203,7 +203,7 @@ def test_instruction_description():
     tested = helper_instance()
     result = tested.instruction_description()
     expected = (
-        "Current medication. There can be only one medication per instruction, and no instruction in the lack of."
+        "Current medication being consumed by the patient, not a new prescription order. There can be only one medication per instruction, and no instruction in the lack of."
     )
     assert result == expected
 

--- a/tests/hyperscribe/commands/test_prescription.py
+++ b/tests/hyperscribe/commands/test_prescription.py
@@ -393,7 +393,7 @@ def test_instruction_description():
     tested = helper_instance()
     result = tested.instruction_description()
     expected = (
-        "Medication prescription, including the directions, the duration, the targeted condition and the dosage. "
+        "New prescription order, including the medication, the directions, the duration, the targeted condition and the dosage. "
         "Create as many instructions as necessary as there can be only one prescribed item per instruction, "
         "and no instruction in the lack of."
     )


### PR DESCRIPTION
Clarifying statements added to the instruction description prompts for medication statements and prescriptions in order to better differentiate new versus existing medications