### PR TITLE
allow empty string for approximate date

### DIFF
--- a/hyperscribe/commands/medical_history.py
+++ b/hyperscribe/commands/medical_history.py
@@ -73,10 +73,10 @@ class MedicalHistory(Base):
 
     def command_parameters(self) -> dict:
         return {
-            "keywords": "comma separated keywords of up to 5 synonyms of the condition",
-            "approximateStartDate": "YYYY-MM-DD or empty string if no date information is available in the transcript",
-            "approximateEndDate": "YYYY-MM-DD or empty string if no date information is available in the transcript",
-            "comments": "provided description of the patient specific history with the condition, as free text",
+            "keywords": "",
+            "approximateStartDate": None,
+            "approximateEndDate": None,
+            "comments": "",
         }
 
     def command_parameters_schemas(self) -> list[dict]:

--- a/hyperscribe/commands/surgery_history.py
+++ b/hyperscribe/commands/surgery_history.py
@@ -72,9 +72,9 @@ class SurgeryHistory(Base):
 
     def command_parameters(self) -> dict:
         return {
-            "keywords": "comma separated keywords of up to 5 synonyms of the surgery",
-            "approximateDate": "YYYY-MM-DD or empty string if no date information is available in the transcript",
-            "comment": "description of the surgery, as free text",
+            "keywords": "",
+            "approximateDate": None,
+            "comment": "",
         }
 
     def command_parameters_schemas(self) -> list[dict]:

--- a/tests/hyperscribe/commands/test_medical_history.py
+++ b/tests/hyperscribe/commands/test_medical_history.py
@@ -249,10 +249,10 @@ def test_command_parameters():
     tested = helper_instance()
     result = tested.command_parameters()
     expected = {
-        "keywords": "comma separated keywords of up to 5 synonyms of the condition",
-        "approximateStartDate": "YYYY-MM-DD or empty string if no date information is available in the transcript",
-        "approximateEndDate": "YYYY-MM-DD or empty string if no date information is available in the transcript",
-        "comments": "provided description of the patient specific history with the condition, as free text",
+        "keywords": "",
+        "approximateStartDate": None,
+        "approximateEndDate": None,
+        "comments": "",
     }
 
     assert result == expected

--- a/tests/hyperscribe/commands/test_surgery_history.py
+++ b/tests/hyperscribe/commands/test_surgery_history.py
@@ -229,9 +229,9 @@ def test_command_parameters():
     tested = helper_instance()
     result = tested.command_parameters()
     expected = {
-        "keywords": "comma separated keywords of up to 5 synonyms of the surgery",
-        "approximateDate": "YYYY-MM-DD or empty string if no date information is available in the transcript",
-        "comment": "description of the surgery, as free text",
+        "keywords": "",
+        "approximateDate": None,
+        "comment": "",
     }
     assert result == expected
 


### PR DESCRIPTION
**Problem**
Hyperscribe was incorrectly assigning the date of dictation to past surgical histories when no date was explicitly mentioned in the transcript.

**Root Cause** 
The issue occurred in the create_sdk_command_parameters() method in audio_interpreter.py where:
The system prompt included the current timestamp: "Please, note that now is 2025-10-06T09:20:40.116111"
The command_parameters() for SurgeryHistory specified: "approximateDate": "YYYY-MM-DD" without guidance on what to do when no date is available
The LLM, seeing no date in the transcript but having the current date in context, incorrectly defaulted to using today's date

This violated the instruction at line 341 of audio_interpreter.py: "you must restrict your response to information explicitly present in the transcript or prior instructions"

**Updates**
Changed `command_parameters()` methods in command classes with approximate date to explicitly instruct the LLM to leave dates empty when not mentioned: "YYYY-MM-DD or empty string if no date information is available in the transcript"