### PR TITLE
surgery and refills

### DIFF
--- a/hyperscribe/CANVAS_MANIFEST.json
+++ b/hyperscribe/CANVAS_MANIFEST.json
@@ -1,6 +1,6 @@
 {
   "sdk_version": "0.64.0",
-  "plugin_version": "2025-10-19 v0.2.129 (next)",
+  "plugin_version": "2025-10-20 v0.2.128 (HEAD)",
   "name": "hyperscribe",
   "description": "Create commands based on the content of an audio discussion between a patient and a provider.",
   "url_permissions": [],
@@ -140,9 +140,10 @@
     "TrialStaffersList"
   ],
   "tags": {
-    "version_date": "2025-10-19",
-    "version_branch": "next",
-    "version_semantic": "0.2.129"
+    "version_date": "2025-10-20",
+    "version_commit_hash": "2e912046c20482d66bb062203bff04cc280f3e8a",
+    "version_branch": "HEAD",
+    "version_semantic": "0.2.128"
   },
   "references": [],
   "license": "",

--- a/hyperscribe/commands/refill.py
+++ b/hyperscribe/commands/refill.py
@@ -82,6 +82,7 @@ class Refill(Base):
         return (
             f"Refill of a current medication ({text}), including the directions, the duration, "
             f"the targeted condition and the dosage. "
+            "Only create when a refill is ordered during this visit, not when discussing refills already sent. "
             "There can be only one refill per instruction, and no instruction in the lack of."
         )
 

--- a/hyperscribe/commands/surgery_history.py
+++ b/hyperscribe/commands/surgery_history.py
@@ -111,7 +111,9 @@ class SurgeryHistory(Base):
     def instruction_description(self) -> str:
         return (
             "Any past surgery. There can be one and only one surgery per instruction, "
-            "and no instruction in the lack of."
+            "and no instruction in the lack of. "
+            "Do not create instructions for vague references like 'multiple surgeries' "
+            "only create instructions when a specific surgery type is mentioned."
         )
 
     def instruction_constraints(self) -> str:

--- a/tests/hyperscribe/commands/test_refill.py
+++ b/tests/hyperscribe/commands/test_refill.py
@@ -317,6 +317,7 @@ def test_instruction_description(current_medications):
     expected = (
         "Refill of a current medication (display1, display2, display3), "
         "including the directions, the duration, the targeted condition and the dosage. "
+        "Only create when a refill is ordered during this visit, not when discussing refills already sent. "
         "There can be only one refill per instruction, and no instruction in the lack of."
     )
     assert result == expected

--- a/tests/hyperscribe/commands/test_surgery_history.py
+++ b/tests/hyperscribe/commands/test_surgery_history.py
@@ -275,7 +275,10 @@ def test_instruction_description():
     tested = helper_instance()
     result = tested.instruction_description()
     expected = (
-        "Any past surgery. There can be one and only one surgery per instruction, and no instruction in the lack of."
+        "Any past surgery. There can be one and only one surgery per instruction, "
+        "and no instruction in the lack of. "
+        "Do not create instructions for vague references like 'multiple surgeries' "
+        "only create instructions when a specific surgery type is mentioned."
     )
     assert result == expected
 


### PR DESCRIPTION
Feedback:

Hyperscribe interpreted a vague summary statement as a distinct surgical procedure
Hyperscribe interpreted the confirmation of a refill previously sent as a request for a new refill
Updates:
Surgery History: added guidance to only record PSH if there is a specific surgery type mentioned
Refill: added temporal context to differentiate between new refill orders and refills already sent