### PR TITLE
Default to transcript tab and approximate date of onset

### DIFF
--- a/hyperscribe/commands/diagnose.py
+++ b/hyperscribe/commands/diagnose.py
@@ -90,7 +90,7 @@ class Diagnose(Base):
                         },
                         "onsetDate": {
                             "type": "string",
-                            "description": "Onset date in YYYY-MM-DD.",
+                            "description": "Approximate onset date in YYYY-MM-DD.",
                             "format": "date",
                             "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
                         },
@@ -107,11 +107,11 @@ class Diagnose(Base):
 
     def instruction_description(self) -> str:
         return (
-            "Medical condition identified by the provider; the necessary information to report includes: "
+            "Medical condition identified by a provider; the necessary information to report includes: "
             "- the medical condition itself, "
             "- all reasoning explicitly mentioned in the transcript, "
             "- current detailed assessment as mentioned in the transcript, and "
-            "- onset date, even for today. "
+            "- the approximate date of onset if mentioned in the transcript. "
             "There is one and only one condition per instruction with all necessary information, "
             "and no instruction in the lack of."
         )

--- a/hyperscribe/templates/hyperscribe.html
+++ b/hyperscribe/templates/hyperscribe.html
@@ -409,13 +409,13 @@
         <div id="debugMessage" class="debug-message"></div>
 
         <div class="tabs">
-            <button class="tab active" onclick="switchTab('activity', this)">Activity</button>
-            <button class="tab" onclick="switchTab('transcript', this)">Transcript</button>
+            <button class="tab active" onclick="switchTab('transcript', this)">Transcript</button>
+            <button class="tab" onclick="switchTab('activity', this)">Activity</button>
             <button class="tab" onclick="switchTab('logs', this)">Logs</button>
             <button class="tab" onclick="switchTab('feedback', this)">Feedback</button>
         </div>
 
-        <div id="activity-container" class="table-container active">
+        <div id="activity-container" class="table-container">
             <div class="filter-controls">
                 <span id="duration" class="duration-display"></span>
             </div>
@@ -444,7 +444,7 @@
             </table>
         </div>
 
-        <div id="transcript-container" class="table-container">
+        <div id="transcript-container" class="table-container active">
             <div id="transcript-legend" class="legend" style="display: none;">
                 <div id="legend-content"></div>
             </div>
@@ -509,7 +509,7 @@
                 pendingTurns: [],
                 processingTurns: false
             },
-            activeTab: 'activity'
+            activeTab: 'transcript'
         };
 
         // Audio Recording Class

--- a/tests/hyperscribe/commands/test_diagnose.py
+++ b/tests/hyperscribe/commands/test_diagnose.py
@@ -188,7 +188,7 @@ def test_command_parameters_schemas():
 
     #
     schema_hash = md5(json.dumps(schema, sort_keys=True).encode()).hexdigest()
-    expected_hash = "5cc7c4535c62245fca9852966e5b326c"
+    expected_hash = "b764c1c5a596c1bd095c084b13658002"
     assert schema_hash == expected_hash
 
     tests = [
@@ -362,11 +362,11 @@ def test_instruction_description():
     tested = helper_instance()
     result = tested.instruction_description()
     expected = (
-        "Medical condition identified by the provider; the necessary information to report includes: "
+        "Medical condition identified by a provider; the necessary information to report includes: "
         "- the medical condition itself, "
         "- all reasoning explicitly mentioned in the transcript, "
         "- current detailed assessment as mentioned in the transcript, and "
-        "- onset date, even for today. "
+        "- the approximate date of onset if mentioned in the transcript. "
         "There is one and only one condition per instruction with all necessary information, "
         "and no instruction in the lack of."
     )


### PR DESCRIPTION
**Feedback** 
Users want visual confirmation that Hyperscribe is capturing the transcript and a cue if the audio set up isn't working (ex - patient audio not captured)

**Solution**
Hyperscribe currently defaults to the "activity" tab, which from a user perspective is duplicative of the commands generated in the note. By defaulting to the transcript tab, users will be confident their session is being transcribed.

**Feedback**
The "approximate date of onset" for a diagnosis is changed to today, even if the transcript mentions that the symptoms related to the diagnosed condition began months ago. 

**Solution**
While it make sense to assume a newly diagnosed condition could have started on the day of the visit, clarifying that the date of onset is the approximate date on which the symptoms began (and removing "today" from the prompt) should remove bias toward today when evidence that states otherwise is available in the transcript. 