### PR TITLE
Remove words with identical timestamps from transcript and alert users

### DIFF
--- a/hyperscribe/libraries/commander.py
+++ b/hyperscribe/libraries/commander.py
@@ -123,6 +123,16 @@ class Commander(BaseProtocol):
         response = chatter.combine_and_speaker_detection(audio_bytes, previous_transcript)
         if response.has_error is True:
             memory_log.output(f"--> transcript encountered: {response.error}")
+
+            # Send user-visible message about audio quality issue
+            messages = [
+                ProgressMessage(
+                    message="Audio quality issue detected",
+                    section=Constants.PROGRESS_SECTION_TECHNICAL,
+                )
+            ]
+            ProgressDisplay.send_to_user(chatter.identification, chatter.settings, messages)
+
             return previous_instructions, [], []  # <--- let's continue even if we were not able to get a transcript
 
         transcript = Line.load_from_json(response.content)

--- a/hyperscribe/libraries/transcript_validator.py
+++ b/hyperscribe/libraries/transcript_validator.py
@@ -1,0 +1,221 @@
+"""Transcript validation utilities to detect anomalies in transcription results."""
+
+from typing import Any, Dict, List, Optional, Tuple
+
+
+class TranscriptValidationError(Exception):
+    """Exception raised when transcript validation fails."""
+
+    pass
+
+
+class TimestampAnomalyDetector:
+    """Detects timestamp anomalies in transcription results that indicate hallucinated content."""
+
+    def __init__(
+        self,
+        min_consecutive_identical: int = 3,
+        min_word_duration: float = 0.001,
+    ):
+        """
+        Initialize the timestamp anomaly detector.
+
+        Args:
+            min_consecutive_identical: Minimum number of consecutive words with identical
+                timestamps to trigger an anomaly. Default is 3.
+            min_word_duration: Minimum expected duration for a word in seconds. Default is 0.001.
+        """
+        self.min_consecutive_identical = min_consecutive_identical
+        self.min_word_duration = min_word_duration
+
+    def validate_elevenlabs_words(
+        self, words: List[Dict[str, Any]], raise_on_anomaly: bool = True
+    ) -> Tuple[bool, Optional[str], Optional[Dict[str, Any]]]:
+        """
+        Validate word-level timestamps from ElevenLabs transcription results.
+
+        Detects anomalies that indicate hallucinated content, such as:
+        - Multiple consecutive words with identical timestamps
+        - Invalid timestamp ranges (start >= end)
+        - Negative timestamps
+
+        Args:
+            words: List of word dictionaries from ElevenLabs API response.
+                Each dict should have 'text', 'start', 'end', 'type', 'speaker_id' keys.
+            raise_on_anomaly: If True, raise TranscriptValidationError on anomaly.
+                If False, return validation results without raising.
+
+        Returns:
+            Tuple of (is_valid, error_message, anomaly_details)
+            - is_valid: True if no anomalies detected
+            - error_message: Description of the anomaly if found, None otherwise
+            - anomaly_details: Dict with details about the anomaly if found, None otherwise
+
+        Raises:
+            TranscriptValidationError: If raise_on_anomaly=True and an anomaly is detected.
+        """
+        if not words:
+            return True, None, None
+
+        # Track consecutive words with identical timestamps
+        consecutive_identical: List[Dict[str, Any]] = []
+        prev_timestamp = None
+
+        # Process only 'word' type entries (skip 'spacing' and 'audio_event')
+        word_entries = [w for w in words if w.get("type") == "word"]
+
+        for i, word in enumerate(word_entries):
+            start = word.get("start")
+            end = word.get("end")
+            text = word.get("text", "")
+
+            # Validate timestamp sanity
+            if start is None or end is None:
+                continue
+
+            if start < 0 or end < 0:
+                error_msg = f"Negative timestamp detected at word '{text}': start={start}, end={end}"
+                anomaly_details = {
+                    "type": "negative_timestamp",
+                    "word_index": i,
+                    "word_text": text,
+                    "start": start,
+                    "end": end,
+                }
+                if raise_on_anomaly:
+                    raise TranscriptValidationError(error_msg)
+                return False, error_msg, anomaly_details
+
+            if start > end:
+                error_msg = f"Invalid timestamp range at word '{text}': start={start} > end={end}"
+                anomaly_details = {
+                    "type": "invalid_range",
+                    "word_index": i,
+                    "word_text": text,
+                    "start": start,
+                    "end": end,
+                }
+                if raise_on_anomaly:
+                    raise TranscriptValidationError(error_msg)
+                return False, error_msg, anomaly_details
+
+            # Check for identical timestamps (hallucination indicator)
+            current_timestamp = (start, end)
+
+            if current_timestamp == prev_timestamp:
+                # Same timestamp as previous word
+                if not consecutive_identical:
+                    # Start new sequence
+                    consecutive_identical = [word_entries[i - 1], word]
+                else:
+                    # Continue sequence
+                    consecutive_identical.append(word)
+
+                # Check if we've hit the threshold
+                if len(consecutive_identical) >= self.min_consecutive_identical:
+                    hallucinated_text = " ".join([w.get("text", "") for w in consecutive_identical])
+                    error_msg = (
+                        f"Timestamp anomaly detected: {len(consecutive_identical)} consecutive "
+                        f"words with identical timestamp ({start}, {end}). "
+                        f"This indicates hallucinated content. Text: '{hallucinated_text}'"
+                    )
+                    anomaly_details = {
+                        "type": "identical_timestamps",
+                        "consecutive_count": len(consecutive_identical),
+                        "timestamp": {"start": start, "end": end},
+                        "hallucinated_text": hallucinated_text,
+                        "word_indices": list(range(i - len(consecutive_identical) + 1, i + 1)),
+                        "words": consecutive_identical,
+                    }
+                    if raise_on_anomaly:
+                        raise TranscriptValidationError(error_msg)
+                    return False, error_msg, anomaly_details
+            else:
+                # Different timestamp, reset consecutive counter
+                consecutive_identical = []
+
+            prev_timestamp = current_timestamp
+
+        # No anomalies detected
+        return True, None, None
+
+    def validate_transcript_segments(
+        self, segments: List[Dict[str, Any]], raise_on_anomaly: bool = True
+    ) -> Tuple[bool, Optional[str], Optional[Dict[str, Any]]]:
+        """
+        Validate speaker-level transcript segments for timestamp anomalies.
+
+        Args:
+            segments: List of transcript segments, each with 'speaker', 'text', 'start', 'end'.
+            raise_on_anomaly: If True, raise TranscriptValidationError on anomaly.
+
+        Returns:
+            Tuple of (is_valid, error_message, anomaly_details)
+
+        Raises:
+            TranscriptValidationError: If raise_on_anomaly=True and an anomaly is detected.
+        """
+        if not segments:
+            return True, None, None
+
+        prev_segment = None
+
+        for i, segment in enumerate(segments):
+            start = segment.get("start")
+            end = segment.get("end")
+            text = segment.get("text", "")
+            speaker = segment.get("speaker", "")
+
+            # Validate timestamp sanity
+            if start is None or end is None:
+                continue
+
+            if start < 0 or end < 0:
+                error_msg = f"Negative timestamp at segment {i} ({speaker}): start={start}, end={end}"
+                anomaly_details = {
+                    "type": "negative_timestamp",
+                    "segment_index": i,
+                    "speaker": speaker,
+                    "start": start,
+                    "end": end,
+                }
+                if raise_on_anomaly:
+                    raise TranscriptValidationError(error_msg)
+                return False, error_msg, anomaly_details
+
+            if start > end:
+                error_msg = f"Invalid timestamp range at segment {i} ({speaker}): start={start} > end={end}"
+                anomaly_details = {
+                    "type": "invalid_range",
+                    "segment_index": i,
+                    "speaker": speaker,
+                    "start": start,
+                    "end": end,
+                }
+                if raise_on_anomaly:
+                    raise TranscriptValidationError(error_msg)
+                return False, error_msg, anomaly_details
+
+            # Check for temporal consistency with previous segment
+            if prev_segment is not None:
+                prev_end = prev_segment.get("end")
+                if prev_end is not None and start < prev_end:
+                    error_msg = (
+                        f"Overlapping timestamps at segment {i}: current start={start} < previous end={prev_end}"
+                    )
+                    anomaly_details = {
+                        "type": "overlapping_segments",
+                        "segment_index": i,
+                        "current_speaker": speaker,
+                        "previous_speaker": prev_segment.get("speaker", ""),
+                        "current_start": start,
+                        "previous_end": prev_end,
+                    }
+                    if raise_on_anomaly:
+                        raise TranscriptValidationError(error_msg)
+                    return False, error_msg, anomaly_details
+
+            prev_segment = segment
+
+        # No anomalies detected
+        return True, None, None

--- a/tests/hyperscribe/libraries/test_transcript_validator.py
+++ b/tests/hyperscribe/libraries/test_transcript_validator.py
@@ -1,0 +1,231 @@
+"""Tests for transcript validation and timestamp anomaly detection."""
+
+import pytest
+
+from hyperscribe.libraries.transcript_validator import (
+    TimestampAnomalyDetector,
+    TranscriptValidationError,
+)
+
+
+class TestTimestampAnomalyDetector:
+    """Test suite for TimestampAnomalyDetector class."""
+
+    def test_valid_words_pass_validation(self):
+        """Test that valid word-level timestamps pass validation."""
+        detector = TimestampAnomalyDetector(min_consecutive_identical=3)
+
+        words = [
+            {"text": "Hello", "start": 0.0, "end": 0.5, "type": "word", "speaker_id": "speaker_0"},
+            {"text": "world", "start": 0.5, "end": 1.0, "type": "word", "speaker_id": "speaker_0"},
+            {"text": "test", "start": 1.0, "end": 1.5, "type": "word", "speaker_id": "speaker_0"},
+        ]
+
+        is_valid, error_msg, anomaly_details = detector.validate_elevenlabs_words(words, raise_on_anomaly=False)
+
+        assert is_valid is True
+        assert error_msg is None
+        assert anomaly_details is None
+
+    def test_empty_words_list_passes(self):
+        """Test that empty words list passes validation."""
+        detector = TimestampAnomalyDetector(min_consecutive_identical=3)
+
+        is_valid, error_msg, anomaly_details = detector.validate_elevenlabs_words([], raise_on_anomaly=False)
+
+        assert is_valid is True
+        assert error_msg is None
+        assert anomaly_details is None
+
+    def test_spacing_entries_ignored(self):
+        """Test that spacing entries don't affect validation."""
+        detector = TimestampAnomalyDetector(min_consecutive_identical=3)
+
+        words = [
+            {"text": "Hello", "start": 0.0, "end": 0.5, "type": "word", "speaker_id": "speaker_0"},
+            {"text": " ", "start": 0.5, "end": 0.5, "type": "spacing", "speaker_id": "speaker_0"},
+            {"text": "world", "start": 0.5, "end": 1.0, "type": "word", "speaker_id": "speaker_0"},
+        ]
+
+        is_valid, error_msg, anomaly_details = detector.validate_elevenlabs_words(words, raise_on_anomaly=False)
+
+        assert is_valid is True
+
+    def test_identical_timestamps_detected_real_case(self):
+        """Test detection of identical timestamps from real feedback case."""
+        detector = TimestampAnomalyDetector(min_consecutive_identical=3)
+
+        # Simulating the real feedback case where ElevenLabs hallucinated
+        # "and breast cancer removals, and she has a history of diabetes mellitus"
+        # All hallucinated words have timestamp 5.759
+        words = [
+            {"text": "Her", "start": 3.559, "end": 3.719, "type": "word", "speaker_id": "speaker_0"},
+            {"text": "past", "start": 3.759, "end": 3.959, "type": "word", "speaker_id": "speaker_0"},
+            {"text": "surgical", "start": 4.0, "end": 4.539, "type": "word", "speaker_id": "speaker_0"},
+            {"text": "history", "start": 4.579, "end": 5.059, "type": "word", "speaker_id": "speaker_0"},
+            {"text": "includes", "start": 5.119, "end": 5.579, "type": "word", "speaker_id": "speaker_0"},
+            {"text": "colon", "start": 5.639, "end": 5.759, "type": "word", "speaker_id": "speaker_0"},
+            # Hallucinated words all have the same timestamp
+            {"text": "and", "start": 5.759, "end": 5.759, "type": "word", "speaker_id": "speaker_0"},
+            {"text": "breast", "start": 5.759, "end": 5.759, "type": "word", "speaker_id": "speaker_0"},
+            {"text": "cancer", "start": 5.759, "end": 5.759, "type": "word", "speaker_id": "speaker_0"},
+            {"text": "removals", "start": 5.759, "end": 5.759, "type": "word", "speaker_id": "speaker_0"},
+            {"text": "and", "start": 5.759, "end": 5.759, "type": "word", "speaker_id": "speaker_0"},
+            {"text": "she", "start": 5.759, "end": 5.759, "type": "word", "speaker_id": "speaker_0"},
+            {"text": "has", "start": 5.759, "end": 5.759, "type": "word", "speaker_id": "speaker_0"},
+            {"text": "a", "start": 5.759, "end": 5.759, "type": "word", "speaker_id": "speaker_0"},
+            {"text": "history", "start": 5.759, "end": 5.759, "type": "word", "speaker_id": "speaker_0"},
+            {"text": "of", "start": 5.759, "end": 5.759, "type": "word", "speaker_id": "speaker_0"},
+            {"text": "diabetes", "start": 5.759, "end": 5.759, "type": "word", "speaker_id": "speaker_0"},
+            {"text": "mellitus", "start": 5.759, "end": 5.759, "type": "word", "speaker_id": "speaker_0"},
+        ]
+
+        is_valid, error_msg, anomaly_details = detector.validate_elevenlabs_words(words, raise_on_anomaly=False)
+
+        assert is_valid is False
+        assert error_msg is not None
+        assert "Timestamp anomaly detected" in error_msg
+        assert "consecutive words with identical timestamp" in error_msg
+        assert anomaly_details is not None
+        assert anomaly_details["type"] == "identical_timestamps"
+        assert anomaly_details["consecutive_count"] >= 3
+        assert "and breast cancer" in anomaly_details["hallucinated_text"]
+
+    def test_identical_timestamps_raises_exception(self):
+        """Test that identical timestamps raise exception when raise_on_anomaly=True."""
+        detector = TimestampAnomalyDetector(min_consecutive_identical=3)
+
+        words = [
+            {"text": "word1", "start": 1.0, "end": 1.0, "type": "word", "speaker_id": "speaker_0"},
+            {"text": "word2", "start": 1.0, "end": 1.0, "type": "word", "speaker_id": "speaker_0"},
+            {"text": "word3", "start": 1.0, "end": 1.0, "type": "word", "speaker_id": "speaker_0"},
+        ]
+
+        with pytest.raises(TranscriptValidationError) as exc_info:
+            detector.validate_elevenlabs_words(words, raise_on_anomaly=True)
+
+        assert "Timestamp anomaly detected" in str(exc_info.value)
+
+    def test_two_identical_timestamps_passes(self):
+        """Test that only 2 consecutive identical timestamps passes (below threshold)."""
+        detector = TimestampAnomalyDetector(min_consecutive_identical=3)
+
+        words = [
+            {"text": "word1", "start": 0.0, "end": 0.5, "type": "word", "speaker_id": "speaker_0"},
+            {"text": "word2", "start": 1.0, "end": 1.0, "type": "word", "speaker_id": "speaker_0"},
+            {"text": "word3", "start": 1.0, "end": 1.0, "type": "word", "speaker_id": "speaker_0"},
+            {"text": "word4", "start": 2.0, "end": 2.5, "type": "word", "speaker_id": "speaker_0"},
+        ]
+
+        is_valid, error_msg, anomaly_details = detector.validate_elevenlabs_words(words, raise_on_anomaly=False)
+
+        assert is_valid is True
+
+    def test_negative_timestamps_detected(self):
+        """Test that negative timestamps are detected."""
+        detector = TimestampAnomalyDetector(min_consecutive_identical=3)
+
+        words = [
+            {"text": "word1", "start": -1.0, "end": 0.5, "type": "word", "speaker_id": "speaker_0"},
+        ]
+
+        is_valid, error_msg, anomaly_details = detector.validate_elevenlabs_words(words, raise_on_anomaly=False)
+
+        assert is_valid is False
+        assert "Negative timestamp" in error_msg
+        assert anomaly_details["type"] == "negative_timestamp"
+
+    def test_invalid_range_detected(self):
+        """Test that start > end is detected."""
+        detector = TimestampAnomalyDetector(min_consecutive_identical=3)
+
+        words = [
+            {"text": "word1", "start": 2.0, "end": 1.0, "type": "word", "speaker_id": "speaker_0"},
+        ]
+
+        is_valid, error_msg, anomaly_details = detector.validate_elevenlabs_words(words, raise_on_anomaly=False)
+
+        assert is_valid is False
+        assert "Invalid timestamp range" in error_msg
+        assert anomaly_details["type"] == "invalid_range"
+
+    def test_custom_threshold(self):
+        """Test that custom threshold for consecutive identical timestamps works."""
+        detector = TimestampAnomalyDetector(min_consecutive_identical=5)
+
+        # 4 consecutive identical - should pass with threshold of 5
+        words = [
+            {"text": "word1", "start": 1.0, "end": 1.0, "type": "word", "speaker_id": "speaker_0"},
+            {"text": "word2", "start": 1.0, "end": 1.0, "type": "word", "speaker_id": "speaker_0"},
+            {"text": "word3", "start": 1.0, "end": 1.0, "type": "word", "speaker_id": "speaker_0"},
+            {"text": "word4", "start": 1.0, "end": 1.0, "type": "word", "speaker_id": "speaker_0"},
+        ]
+
+        is_valid, _, _ = detector.validate_elevenlabs_words(words, raise_on_anomaly=False)
+        assert is_valid is True
+
+        # 5 consecutive identical - should fail
+        words.append({"text": "word5", "start": 1.0, "end": 1.0, "type": "word", "speaker_id": "speaker_0"})
+
+        is_valid, _, _ = detector.validate_elevenlabs_words(words, raise_on_anomaly=False)
+        assert is_valid is False
+
+
+class TestTranscriptSegmentValidation:
+    """Test suite for transcript segment validation."""
+
+    def test_valid_segments_pass(self):
+        """Test that valid transcript segments pass validation."""
+        detector = TimestampAnomalyDetector()
+
+        segments = [
+            {"speaker": "Clinician", "text": "Hello", "start": 0.0, "end": 1.0},
+            {"speaker": "Patient", "text": "Hi", "start": 1.0, "end": 2.0},
+        ]
+
+        is_valid, error_msg, anomaly_details = detector.validate_transcript_segments(segments, raise_on_anomaly=False)
+
+        assert is_valid is True
+        assert error_msg is None
+        assert anomaly_details is None
+
+    def test_overlapping_segments_detected(self):
+        """Test that overlapping segments are detected."""
+        detector = TimestampAnomalyDetector()
+
+        segments = [
+            {"speaker": "Clinician", "text": "Hello", "start": 0.0, "end": 2.0},
+            {"speaker": "Patient", "text": "Hi", "start": 1.5, "end": 3.0},  # Overlaps with previous
+        ]
+
+        is_valid, error_msg, anomaly_details = detector.validate_transcript_segments(segments, raise_on_anomaly=False)
+
+        assert is_valid is False
+        assert "Overlapping timestamps" in error_msg
+        assert anomaly_details["type"] == "overlapping_segments"
+
+    def test_segment_negative_timestamp(self):
+        """Test that negative timestamps in segments are detected."""
+        detector = TimestampAnomalyDetector()
+
+        segments = [
+            {"speaker": "Clinician", "text": "Hello", "start": -1.0, "end": 1.0},
+        ]
+
+        is_valid, error_msg, anomaly_details = detector.validate_transcript_segments(segments, raise_on_anomaly=False)
+
+        assert is_valid is False
+        assert "Negative timestamp" in error_msg
+
+    def test_segment_invalid_range(self):
+        """Test that invalid ranges in segments are detected."""
+        detector = TimestampAnomalyDetector()
+
+        segments = [
+            {"speaker": "Clinician", "text": "Hello", "start": 2.0, "end": 1.0},
+        ]
+
+        is_valid, error_msg, anomaly_details = detector.validate_transcript_segments(segments, raise_on_anomaly=False)
+
+        assert is_valid is False
+        assert "Invalid timestamp range" in error_msg


### PR DESCRIPTION
**Feedback 62210a22**
Words in the transcript didn't originate from the recording

**Updates**
Anomaly detector removes extra words that are created with identical timestamps and alerts user to audio quality issues that are causing intermittent gaps and/or silences