### PR TITLE
handles denials for pmh and psh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ evaluations.db
 local_env.sh
 **/.DS_Store
 .DS_Store
+.cpa-workflow-artifacts/
+artifacts/

--- a/hyperscribe/commands/medical_history.py
+++ b/hyperscribe/commands/medical_history.py
@@ -122,7 +122,12 @@ class MedicalHistory(Base):
         ]
 
     def instruction_description(self) -> str:
-        return "Any past condition. There can be only one condition per instruction, and no instruction in the lack of."
+        return (
+            "Any medical condition the patient confirms he or she has had or "
+            "been diagnosed with before the current visit. "
+            "There can be only one condition per instruction, and no instruction in the lack of. "
+            "Do NOT create this instruction for conditions the patient denies, negates, or states they do not have."
+        )
 
     def instruction_constraints(self) -> str:
         result = ""

--- a/hyperscribe/commands/surgery_history.py
+++ b/hyperscribe/commands/surgery_history.py
@@ -114,8 +114,10 @@ class SurgeryHistory(Base):
 
     def instruction_description(self) -> str:
         return (
-            "Any past surgery. There can be one and only one surgery per instruction, "
+            "Any surgery that the patient confirms he or she has had in the past. "
+            "There can be one and only one surgery per instruction, "
             "and no instruction in the lack of. "
+            "Do NOT create this instruction for surgeries the patient denies, negates, or states they have not had. "
             "Do not create instructions for vague references like 'multiple surgeries' "
             "only create instructions when a specific surgery type is mentioned."
         )

--- a/tests/hyperscribe/commands/test_medical_history.py
+++ b/tests/hyperscribe/commands/test_medical_history.py
@@ -417,7 +417,12 @@ def test_command_parameters_schemas():
 def test_instruction_description():
     tested = helper_instance()
     result = tested.instruction_description()
-    expected = "Any past condition. There can be only one condition per instruction, and no instruction in the lack of."
+    expected = (
+        "Any medical condition the patient confirms he or she has had or "
+        "been diagnosed with before the current visit. "
+        "There can be only one condition per instruction, and no instruction in the lack of. "
+        "Do NOT create this instruction for conditions the patient denies, negates, or states they do not have."
+    )
     assert result == expected
 
 

--- a/tests/hyperscribe/commands/test_surgery_history.py
+++ b/tests/hyperscribe/commands/test_surgery_history.py
@@ -335,8 +335,10 @@ def test_instruction_description():
     tested = helper_instance()
     result = tested.instruction_description()
     expected = (
-        "Any past surgery. There can be one and only one surgery per instruction, "
+        "Any surgery that the patient confirms he or she has had in the past. "
+        "There can be one and only one surgery per instruction, "
         "and no instruction in the lack of. "
+        "Do NOT create this instruction for surgeries the patient denies, negates, or states they have not had. "
         "Do not create instructions for vague references like 'multiple surgeries' "
         "only create instructions when a specific surgery type is mentioned."
     )


### PR DESCRIPTION
Addressing #200 

- Two prompt changes to prevent Hyperscribe from originating Past Medical History and Past Surgical History commands when a patient denies a condition or surgery. 
- Updated instruction_description() in both medical_history.py and surgery_history.py to explicitly require patient confirmation and reject denied/negated history.