### PR TITLE
Prevents medication statement denials from selecting medications

### DIFF
--- a/hyperscribe/commands/medication.py
+++ b/hyperscribe/commands/medication.py
@@ -35,8 +35,8 @@ class Medication(Base):
     ) -> InstructionWithCommand | None:
         result = MedicationStatementCommand(sig=instruction.parameters["sig"], note_uuid=self.identification.note_uuid)
         # retrieve existing medications defined in Canvas Science
-        expressions = instruction.parameters["keywords"].split(",")
-        if medications := CanvasScience.medication_details(expressions):
+        expressions = [e.strip() for e in instruction.parameters["keywords"].split(",") if e.strip()]
+        if expressions and (medications := CanvasScience.medication_details(expressions)):
             # retrieve the correct medication
             system_prompt = [
                 "The conversation is in the medical context.",

--- a/hyperscribe/libraries/canvas_science.py
+++ b/hyperscribe/libraries/canvas_science.py
@@ -69,7 +69,9 @@ class CanvasScience:
 
         params = {"format": "json", "limit": 10}
         all_concepts: list = [
-            cls.get_attempts(url, params | {"query": expression}, False) for expression in expressions
+            cls.get_attempts(url, params | {"query": expression}, False)
+            for expression in expressions
+            if expression.strip()
         ]
         for concepts in all_concepts:
             for concept in concepts:

--- a/tests/hyperscribe/commands/test_medication.py
+++ b/tests/hyperscribe/commands/test_medication.py
@@ -202,6 +202,19 @@ def test_command_from_json(add_code2description, medication_details):
     assert chatter.mock_calls == []
     reset_mocks()
 
+    # empty keywords -- no FDB search, no LLM call
+    for empty_keywords in ["", "  ", " , , "]:
+        empty_arguments = {**arguments, "parameters": {"keywords": empty_keywords, "sig": "theSig"}}
+        instruction_empty = InstructionWithParameters(**empty_arguments)
+        result = tested.command_from_json(instruction_empty, chatter)
+        command = MedicationStatementCommand(sig="theSig", note_uuid="noteUuid")
+        expected = InstructionWithCommand(**(empty_arguments | {"command": command}))
+        assert result == expected
+        assert add_code2description.mock_calls == []
+        assert medication_details.mock_calls == []
+        assert chatter.mock_calls == []
+        reset_mocks()
+
 
 def test_command_parameters():
     tested = helper_instance()

--- a/tests/hyperscribe/libraries/test_canvas_science.py
+++ b/tests/hyperscribe/libraries/test_canvas_science.py
@@ -316,6 +316,24 @@ def test_medical_concept(get_attempts):
         assert get_attempts.mock_calls == calls
         reset_mocks()
 
+    # empty/whitespace expressions are skipped
+    for empty_expressions in [[""], ["", "  ", " "], []]:
+        get_attempts.side_effect = []
+        result = tested.medical_concept(url, empty_expressions, MedicalConcept)
+        assert result == []
+        assert get_attempts.mock_calls == []
+        reset_mocks()
+
+    # mixed: only non-empty expressions trigger API calls
+    get_attempts.side_effect = [
+        [{"concept_id": 123, "term": "termA"}],
+    ]
+    result = tested.medical_concept(url, ["", "expression1", "  "], MedicalConcept)
+    assert result == [MedicalConcept(concept_id=123, term="termA")]
+    calls = [call(url, params | {"query": "expression1"}, False)]
+    assert get_attempts.mock_calls == calls
+    reset_mocks()
+
 
 @patch.object(CanvasScience, "get_attempts")
 def test_search_allergy(get_attempts):


### PR DESCRIPTION
Addresses issue #208 

Feedback: Scribe tried to add a medication statement for "flaxseed oil" which patient is not taking and was not mentioned.

Transcript contained clinician confirming that the patient was NOT taking any medication, which led to a selection of a non-medication