### PR TITLE
Prevent physical exam systems from being disabled

### DIFF
--- a/hyperscribe/commands/physical_exam.py
+++ b/hyperscribe/commands/physical_exam.py
@@ -14,16 +14,5 @@ class PhysicalExam(BaseQuestionnaire):
     def include_skipped(self) -> bool:
         return True
 
-    def additional_instructions(self) -> list[str]:
-        return [
-            "The questionnaire pertains to a physical examination. Only include objective findings "
-            "from the provider's physical examination of the patient. This includes observations, "
-            'measurements, and results of maneuvers performed by the provider (e.g., "pupils equal, '
-            'round, and reactive to light", "abdomen soft, non-tender", "CN II-XII grossly '
-            'intact"). Do not include patient-reported symptoms, subjective complaints, diagnoses, '
-            "assessments, or treatment plans - these belong in other sections of the clinical note.",
-            "If the transcript does not contain any physical exam findings, do not modify the questionnaire values.",
-        ]
-
     def sdk_command(self) -> Type[PhysicalExamCommand]:
         return PhysicalExamCommand  # type: ignore

--- a/tests/hyperscribe/commands/test_physical_exam.py
+++ b/tests/hyperscribe/commands/test_physical_exam.py
@@ -1,4 +1,3 @@
-import hashlib
 from unittest.mock import MagicMock
 
 import pytest
@@ -94,14 +93,6 @@ def test_include_skipped():
     tested = helper_instance()
     result = tested.include_skipped()
     assert result is True
-
-
-def test_additional_instructions():
-    tested = helper_instance()
-    result = tested.additional_instructions()
-    assert len(result) == 2
-    assert hashlib.md5(result[0].encode()).hexdigest() == "33f81d66de9a03b65f6e71fcca4f93eb"
-    assert hashlib.md5(result[1].encode()).hexdigest() == "c55d9ae3fe7886276774f1b585335ee0"
 
 
 def test_sdk_command():


### PR DESCRIPTION
Clinicians have given the feedback that they want to carry forward previous physical exam findings from previous visits in their note. If there is an updated finding during the session, they want Hyperscribe to update the relevant body system. If there are no updated findings, they want Hyperscribe to leave the body system unedited (rather than resetting it and clearing the content). 