### PR TITLE
Capture "missing" conditions 

### DIFF
--- a/hyperscribe/commands/diagnose.py
+++ b/hyperscribe/commands/diagnose.py
@@ -108,15 +108,14 @@ class Diagnose(Base):
     def instruction_description(self) -> str:
         return (
             "Medical condition identified, diagnosed, or referenced as pertaining to the patient "
-            "by a provider; the necessary information to report includes: "
-            "- the medical condition itself, "
-            "- all reasoning explicitly mentioned in the transcript, "
-            "- current detailed assessment as mentioned in the transcript, and "
-            "- the approximate date of onset if mentioned in the transcript. "
+            "by a provider. When available in the transcript, also include: "
+            "- all reasoning explicitly mentioned, "
+            "- current detailed assessment, and "
+            "- the approximate date of onset. "
             "If a condition is discussed in relation to the patient's treatment or medications "
             "(e.g., asking about a medication used for a specific condition), and that condition is not already "
             "in the patient's chart, create a Diagnose instruction for it. "
-            "There is one and only one condition per instruction with all necessary information, "
+            "There is one and only one condition per instruction, "
             "and no instruction in the lack of."
         )
 

--- a/tests/hyperscribe/commands/test_diagnose.py
+++ b/tests/hyperscribe/commands/test_diagnose.py
@@ -363,15 +363,14 @@ def test_instruction_description():
     result = tested.instruction_description()
     expected = (
         "Medical condition identified, diagnosed, or referenced as pertaining to the patient "
-        "by a provider; the necessary information to report includes: "
-        "- the medical condition itself, "
-        "- all reasoning explicitly mentioned in the transcript, "
-        "- current detailed assessment as mentioned in the transcript, and "
-        "- the approximate date of onset if mentioned in the transcript. "
+        "by a provider. When available in the transcript, also include: "
+        "- all reasoning explicitly mentioned, "
+        "- current detailed assessment, and "
+        "- the approximate date of onset. "
         "If a condition is discussed in relation to the patient's treatment or medications "
         "(e.g., asking about a medication used for a specific condition), and that condition is not already "
         "in the patient's chart, create a Diagnose instruction for it. "
-        "There is one and only one condition per instruction with all necessary information, "
+        "There is one and only one condition per instruction, "
         "and no instruction in the lack of."
     )
     assert result == expected


### PR DESCRIPTION
**Problem**
Clinicians are reporting "missed" commands when they expect Diagnose (not in the chart) or AssessCondition (already in the chart) to be originated. If a condition is in the chart but not active, Hyperscribe won't originate Diagnose or AssessCondition - meeting the condition discussed in the transcript is fully missed. 

**Fixes**
- Expand condition status filter to include relapse, remission, and investigative
- Add all_chart_conditions() to prevent duplicate diagnoses across all statuses
- Broaden Diagnose instruction_description to capture conditions referenced in treatment context (this prevents missed conditions when mentioned in an ambient dialogue context) 
- Add positive constraint nudge so second-pass LLM review catches missed diagnoses (working well in empirical testing)