### PR TITLE
Defer canvas_sdk.caching imports to avoid ImportError

### DIFF
--- a/hyperscribe/libraries/template_permissions.py
+++ b/hyperscribe/libraries/template_permissions.py
@@ -9,9 +9,6 @@ from logger import log
 
 from hyperscribe.libraries.constants import Constants
 
-from canvas_sdk.caching.base import Cache
-from canvas_sdk.caching.client import get_cache as _get_cache_client
-
 
 class TemplatePermissions:
     """Loads note-template edit permissions cached by the note_templates plugin.
@@ -23,8 +20,10 @@ class TemplatePermissions:
     PERMISSIONS: dict[str, dict[str, Any]] = {}
 
     @classmethod
-    def default_cache_getter(cls) -> Cache:
+    def default_cache_getter(cls) -> Any:
         """Default cache getter that uses a shared (non-plugin-scoped) cache prefix."""
+        from canvas_sdk.caching.client import get_cache as _get_cache_client
+
         return _get_cache_client(driver="plugins", prefix=Constants.TEMPLATE_SHARED_CACHE_PREFIX)
 
     def __init__(self, note_uuid: str) -> None:

--- a/tests/hyperscribe/libraries/test_template_permissions.py
+++ b/tests/hyperscribe/libraries/test_template_permissions.py
@@ -1,6 +1,5 @@
 from unittest.mock import MagicMock, call, patch
 
-from hyperscribe.libraries import template_permissions
 from hyperscribe.libraries.template_permissions import TemplatePermissions
 
 
@@ -168,40 +167,32 @@ def test_shared_class_cache_single_load(mock_cache_getter):
     TemplatePermissions.PERMISSIONS.clear()
 
 
-def test_default_cache_getter_with_sdk_available():
-    original_get_cache_client = template_permissions._get_cache_client
-    try:
-        mock_cache = MagicMock()
-        template_permissions._get_cache_client = MagicMock(return_value=mock_cache)
+@patch("canvas_sdk.caching.client.get_cache")
+def test_default_cache_getter_with_sdk_available(mock_get_cache):
+    mock_cache = MagicMock()
+    mock_get_cache.return_value = mock_cache
 
-        tested = TemplatePermissions
-        result = tested.default_cache_getter()
-        expected = mock_cache
-        assert result == expected
+    result = TemplatePermissions.default_cache_getter()
+    assert result is mock_cache
 
-        calls = [call(driver="plugins", prefix="note_template_permissions")]
-        assert template_permissions._get_cache_client.mock_calls == calls
-    finally:
-        template_permissions._get_cache_client = original_get_cache_client
+    calls = [call(driver="plugins", prefix="note_template_permissions")]
+    assert mock_get_cache.mock_calls == calls
 
 
-def test_template_permissions_uses_default_cache_getter():
-    original_get_cache = template_permissions._get_cache_client
-    try:
-        mock_cache = MagicMock()
-        mock_cache.get.return_value = {"TestCommand": {"plugin_can_edit": True}}
-        template_permissions._get_cache_client = MagicMock(return_value=mock_cache)
+@patch("canvas_sdk.caching.client.get_cache")
+def test_template_permissions_uses_default_cache_getter(mock_get_cache):
+    mock_cache = MagicMock()
+    mock_cache.get.return_value = {"TestCommand": {"plugin_can_edit": True}}
+    mock_get_cache.return_value = mock_cache
 
-        TemplatePermissions.PERMISSIONS.clear()
-        tested = TemplatePermissions("test-note-uuid")
-        result = tested.load_permissions()
-        expected = {"TestCommand": {"plugin_can_edit": True}}
-        assert result == expected
+    TemplatePermissions.PERMISSIONS.clear()
+    tested = TemplatePermissions("test-note-uuid")
+    result = tested.load_permissions()
+    expected = {"TestCommand": {"plugin_can_edit": True}}
+    assert result == expected
 
-        calls = [call(driver="plugins", prefix="note_template_permissions")]
-        assert template_permissions._get_cache_client.mock_calls == calls
-        calls = [call.get("note_template_cmd_perms_test-note-uuid", default={})]
-        assert mock_cache.mock_calls == calls
-    finally:
-        template_permissions._get_cache_client = original_get_cache
-        TemplatePermissions.PERMISSIONS.clear()
+    calls = [call(driver="plugins", prefix="note_template_permissions")]
+    assert mock_get_cache.call_args_list == calls
+    calls = [call.get("note_template_cmd_perms_test-note-uuid", default={})]
+    assert mock_cache.mock_calls == calls
+    TemplatePermissions.PERMISSIONS.clear()


### PR DESCRIPTION
The SDK didn't allow module-level imports of canvas_sdk.caching.base and canvas_sdk.caching.client, so this moves get_cache import inside default_cache_getter() so it only runs when called