### PR TITLE
Validate LLM index against name for conditions and goals

### DIFF
--- a/hyperscribe/commands/assess.py
+++ b/hyperscribe/commands/assess.py
@@ -34,9 +34,13 @@ class Assess(Base):
         chatter: LlmBase,
     ) -> InstructionWithCommand | None:
         condition_id: str | None = None
-        if 0 <= (idx := instruction.parameters["conditionIndex"]) < len(current := self.cache.current_conditions()):
-            condition_id = current[idx].uuid
-            self.add_code2description(current[idx].uuid, current[idx].label)
+        if matched := self.resolve_item_by_index(
+            self.cache.current_conditions(),
+            instruction.parameters["conditionIndex"],
+            instruction.parameters.get("condition"),
+        ):
+            condition_id = matched.uuid
+            self.add_code2description(matched.uuid, matched.label)
 
         # Get field values with template permission checks
         background = (

--- a/hyperscribe/commands/base.py
+++ b/hyperscribe/commands/base.py
@@ -34,6 +34,31 @@ class Base:
     def class_name(cls) -> str:
         return cls.__name__
 
+    @staticmethod
+    def resolve_item_by_index(
+        items: list[CodedItem],
+        index: int,
+        name: str | None,
+    ) -> CodedItem | None:
+        """Resolve an item by index, falling back to name-based search on mismatch.
+
+        LLMs can return a correct name but wrong index (off-by-one counting errors).
+        When the index and name disagree, the name is more reliable.
+        """
+        if 0 <= index < len(items):
+            if not name or items[index].label == name:
+                return items[index]
+            log.warning(
+                f"Index {index} ({items[index].label}) does not match name ({name}), falling back to name-based lookup"
+            )
+
+        if name:
+            for item in items:
+                if item.label == name:
+                    return item
+
+        return None
+
     @classmethod
     def command_type(cls) -> str:
         raise NotImplementedError

--- a/hyperscribe/commands/base.py
+++ b/hyperscribe/commands/base.py
@@ -51,6 +51,8 @@ class Base:
             log.warning(
                 f"Index {index} ({items[index].label}) does not match name ({name}), falling back to name-based lookup"
             )
+        else:
+            log.warning(f"Index {index} out of range for {len(items)} items, falling back to name-based lookup")
 
         if name:
             for item in items:

--- a/hyperscribe/commands/close_goal.py
+++ b/hyperscribe/commands/close_goal.py
@@ -39,10 +39,14 @@ class CloseGoal(Base):
         )
 
         goal_uuid = "0"
-        if 0 <= (idx := instruction.parameters["goalIndex"]) < len(current := self.cache.current_goals()):
-            # TODO should be  goal_uuid = current[idx].uuid, waiting for https://github.com/canvas-medical/canvas-plugins/issues/338
-            goal_uuid = current[idx].code
-            self.add_code2description(current[idx].code, current[idx].label)
+        if matched := self.resolve_item_by_index(
+            self.cache.current_goals(),
+            instruction.parameters["goalIndex"],
+            instruction.parameters.get("goal"),
+        ):
+            # TODO should be  goal_uuid = matched.uuid, waiting for https://github.com/canvas-medical/canvas-plugins/issues/338
+            goal_uuid = matched.code
+            self.add_code2description(matched.code, matched.label)
 
         return InstructionWithCommand.add_command(
             instruction,

--- a/hyperscribe/commands/prescription.py
+++ b/hyperscribe/commands/prescription.py
@@ -67,12 +67,17 @@ class Prescription(BasePrescription):
         if (
             "conditionIndex" in instruction.parameters
             and isinstance(instruction.parameters["conditionIndex"], int)
-            and 0 <= (idx := instruction.parameters["conditionIndex"]) < len(self.cache.current_conditions())
+            and (
+                matched := self.resolve_item_by_index(
+                    self.cache.current_conditions(),
+                    instruction.parameters["conditionIndex"],
+                    instruction.parameters.get("condition"),
+                )
+            )
         ):
-            targeted_condition = self.cache.current_conditions()[idx]
-            result.icd10_codes = [Helper.icd10_strip_dot(targeted_condition.code)]
-            condition = targeted_condition.label
-            self.add_code2description(targeted_condition.code, targeted_condition.label)
+            result.icd10_codes = [Helper.icd10_strip_dot(matched.code)]
+            condition = matched.label
+            self.add_code2description(matched.code, matched.label)
 
         # retrieve existing medications defined in Canvas Science
         search = MedicationSearch(

--- a/hyperscribe/commands/resolve_condition.py
+++ b/hyperscribe/commands/resolve_condition.py
@@ -34,9 +34,13 @@ class ResolveCondition(Base):
         chatter: LlmBase,
     ) -> InstructionWithCommand | None:
         condition_id = ""
-        if 0 <= (idx := instruction.parameters["conditionIndex"]) < len(current := self.cache.current_conditions()):
-            condition_id = current[idx].uuid
-            self.add_code2description(current[idx].uuid, current[idx].label)
+        if matched := self.resolve_item_by_index(
+            self.cache.current_conditions(),
+            instruction.parameters["conditionIndex"],
+            instruction.parameters.get("condition"),
+        ):
+            condition_id = matched.uuid
+            self.add_code2description(matched.uuid, matched.label)
 
         return InstructionWithCommand.add_command(
             instruction,

--- a/hyperscribe/commands/update_diagnose.py
+++ b/hyperscribe/commands/update_diagnose.py
@@ -56,13 +56,13 @@ class UpdateDiagnose(Base):
             narrative=narrative,
             note_uuid=self.identification.note_uuid,
         )
-        if (
-            0
-            <= (idx := instruction.parameters["previousConditionIndex"])
-            < len(current := self.cache.current_conditions())
+        if matched := self.resolve_item_by_index(
+            self.cache.current_conditions(),
+            instruction.parameters["previousConditionIndex"],
+            instruction.parameters.get("previousCondition"),
         ):
-            result.condition_code = Helper.icd10_strip_dot(current[idx].code)
-            self.add_code2description(current[idx].uuid, current[idx].label)
+            result.condition_code = Helper.icd10_strip_dot(matched.code)
+            self.add_code2description(matched.uuid, matched.label)
 
         # retrieve existing conditions defined in Canvas Science
         expressions = instruction.parameters["keywords"].split(",") + instruction.parameters["ICD10"].split(",")

--- a/hyperscribe/commands/update_goal.py
+++ b/hyperscribe/commands/update_goal.py
@@ -38,9 +38,13 @@ class UpdateGoal(Base):
         )
 
         goal_uuid = ""
-        if 0 <= (idx := instruction.parameters["goalIndex"]) < len(current := self.cache.current_goals()):
-            goal_uuid = current[idx].uuid
-            self.add_code2description(current[idx].uuid, current[idx].label)
+        if matched := self.resolve_item_by_index(
+            self.cache.current_goals(),
+            instruction.parameters["goalIndex"],
+            instruction.parameters.get("goal"),
+        ):
+            goal_uuid = matched.uuid
+            self.add_code2description(matched.uuid, matched.label)
 
         return InstructionWithCommand.add_command(
             instruction,

--- a/tests/hyperscribe/commands/test_assess.py
+++ b/tests/hyperscribe/commands/test_assess.py
@@ -116,11 +116,12 @@ def test_command_from_json(add_code2description, current_conditions):
         CodedItem(uuid="theUuid3", label="display3a", code="CODE98.76"),
     ]
     tests = [
-        (1, "theUuid2", [call("theUuid2", "display2a")]),
-        (2, "theUuid3", [call("theUuid3", "display3a")]),
-        (4, None, []),
+        ("display2a", 1, "theUuid2", [call("theUuid2", "display2a")]),
+        ("display2a", 2, "theUuid2", [call("theUuid2", "display2a")]),
+        ("display2a", 4, "theUuid2", [call("theUuid2", "display2a")]),
+        ("nonexistent", 4, None, []),
     ]
-    for idx, exp_uuid, exp_calls in tests:
+    for condition_name, idx, exp_uuid, exp_calls in tests:
         current_conditions.side_effect = [conditions, conditions]
         arguments = {
             "uuid": "theUuid",
@@ -132,7 +133,7 @@ def test_command_from_json(add_code2description, current_conditions):
             "previous_information": "thePreviousInformation",
             "parameters": {
                 "assessment": "theAssessment",
-                "condition": "display2a",
+                "condition": condition_name,
                 "conditionIndex": idx,
                 "rationale": "theRationale",
                 "status": "stable",

--- a/tests/hyperscribe/commands/test_base.py
+++ b/tests/hyperscribe/commands/test_base.py
@@ -252,6 +252,31 @@ def test_resolve_item_by_index(items, index, name, expected_label):
         assert result.label == expected_label
 
 
+@patch("hyperscribe.commands.base.log")
+def test_resolve_item_by_index_logs_warning_on_out_of_range(mock_log):
+    items = [CodedItem(uuid="uuid1", label="Condition A", code="A01")]
+    result = Base.resolve_item_by_index(items, 5, "Condition A")
+    assert result is not None
+    assert result.label == "Condition A"
+    assert mock_log.mock_calls == [
+        call.warning("Index 5 out of range for 1 items, falling back to name-based lookup"),
+    ]
+
+
+@patch("hyperscribe.commands.base.log")
+def test_resolve_item_by_index_logs_warning_on_name_mismatch(mock_log):
+    items = [
+        CodedItem(uuid="uuid1", label="Condition A", code="A01"),
+        CodedItem(uuid="uuid2", label="Condition B", code="B02"),
+    ]
+    result = Base.resolve_item_by_index(items, 0, "Condition B")
+    assert result is not None
+    assert result.label == "Condition B"
+    assert mock_log.mock_calls == [
+        call.warning("Index 0 (Condition A) does not match name (Condition B), falling back to name-based lookup"),
+    ]
+
+
 @patch("hyperscribe.commands.base.InstructionWithSummary")
 @patch.object(Base, "command_from_json")
 def test_command_from_json_with_summary(command_from_json, instruction_with_summary):

--- a/tests/hyperscribe/commands/test_base.py
+++ b/tests/hyperscribe/commands/test_base.py
@@ -7,6 +7,7 @@ from hyperscribe.commands.base import Base
 from hyperscribe.libraries.limited_cache import LimitedCache
 from hyperscribe.libraries.template_permissions import TemplatePermissions
 from hyperscribe.structures.access_policy import AccessPolicy
+from hyperscribe.structures.coded_item import CodedItem
 from hyperscribe.structures.identification_parameters import IdentificationParameters
 from hyperscribe.structures.instruction_with_command import InstructionWithCommand
 from hyperscribe.structures.instruction_with_parameters import InstructionWithParameters
@@ -173,6 +174,82 @@ def test_add_code2description():
         "code3": "description3",
     }
     assert tested._arguments_code2description == expected
+
+
+@pytest.mark.parametrize(
+    "items, index, name, expected_label",
+    [
+        # index matches name
+        (
+            [
+                CodedItem(uuid="uuid1", label="Condition A", code="A01"),
+                CodedItem(uuid="uuid2", label="Condition B", code="B02"),
+                CodedItem(uuid="uuid3", label="Condition C", code="C03"),
+            ],
+            1,
+            "Condition B",
+            "Condition B",
+        ),
+        # index and name mismatch — fallback to name
+        (
+            [
+                CodedItem(uuid="uuid1", label="Condition A", code="A01"),
+                CodedItem(uuid="uuid2", label="Condition B", code="B02"),
+                CodedItem(uuid="uuid3", label="Condition C", code="C03"),
+            ],
+            2,
+            "Condition B",
+            "Condition B",
+        ),
+        # index out of range — fallback to name
+        (
+            [
+                CodedItem(uuid="uuid1", label="Condition A", code="A01"),
+                CodedItem(uuid="uuid2", label="Condition B", code="B02"),
+            ],
+            5,
+            "Condition B",
+            "Condition B",
+        ),
+        # index valid, no name provided — trust index
+        (
+            [
+                CodedItem(uuid="uuid1", label="Condition A", code="A01"),
+                CodedItem(uuid="uuid2", label="Condition B", code="B02"),
+            ],
+            0,
+            None,
+            "Condition A",
+        ),
+        # index out of range, name not found — no match
+        (
+            [
+                CodedItem(uuid="uuid1", label="Condition A", code="A01"),
+            ],
+            5,
+            "Nonexistent",
+            None,
+        ),
+        # empty list — no match
+        ([], 0, "Condition A", None),
+        # negative index, name found — fallback to name
+        (
+            [
+                CodedItem(uuid="uuid1", label="Condition A", code="A01"),
+            ],
+            -1,
+            "Condition A",
+            "Condition A",
+        ),
+    ],
+)
+def test_resolve_item_by_index(items, index, name, expected_label):
+    result = Base.resolve_item_by_index(items, index, name)
+    if expected_label is None:
+        assert result is None
+    else:
+        assert result is not None
+        assert result.label == expected_label
 
 
 @patch("hyperscribe.commands.base.InstructionWithSummary")

--- a/tests/hyperscribe/commands/test_close_goal.py
+++ b/tests/hyperscribe/commands/test_close_goal.py
@@ -108,8 +108,13 @@ def test_command_from_json(add_code2description, current_goals):
         CodedItem(uuid="theUuid2", label="display2a", code="45"),
         CodedItem(uuid="theUuid3", label="display3a", code="9876"),
     ]
-    tests = [(1, 45), (2, 9876), (4, 0)]
-    for idx, exp_uuid in tests:
+    tests = [
+        ("display2a", 1, 45),
+        ("display2a", 2, 45),
+        ("display2a", 4, 45),
+        ("nonexistent", 4, 0),
+    ]
+    for goal_name, idx, exp_uuid in tests:
         current_goals.side_effect = [goals, goals]
         arguments = {
             "uuid": "theUuid",
@@ -120,7 +125,7 @@ def test_command_from_json(add_code2description, current_goals):
             "is_updated": True,
             "previous_information": "thePreviousInformation",
             "parameters": {
-                "goal": "display2a",
+                "goal": goal_name,
                 "goalIndex": idx,
                 "progressAndBarriers": "theProgressAndBarriers",
                 "status": "improving",

--- a/tests/hyperscribe/commands/test_prescription.py
+++ b/tests/hyperscribe/commands/test_prescription.py
@@ -200,11 +200,12 @@ def test_command_from_json(current_conditions, medications_from, set_medication_
 
     # with condition
     tests = [
-        (1, "display2a", ["CODE45"], [call(), call()], [call("CODE45", "display2a"), call("code369", "labelB")]),
-        (2, "display3a", ["CODE9876"], [call(), call()], [call("CODE98.76", "display3a"), call("code369", "labelB")]),
-        (4, "", [], [call()], [call("code369", "labelB")]),
+        ("display2a", 1, "display2a", ["CODE45"], [call("CODE45", "display2a"), call("code369", "labelB")]),
+        ("display2a", 2, "display2a", ["CODE45"], [call("CODE45", "display2a"), call("code369", "labelB")]),
+        ("display2a", 4, "display2a", ["CODE45"], [call("CODE45", "display2a"), call("code369", "labelB")]),
+        ("nonexistent", 4, "", [], [call("code369", "labelB")]),
     ]
-    for idx, condition_label, condition_icd10, condition_calls, exp_calls in tests:
+    for condition_name, idx, condition_label, condition_icd10, exp_calls in tests:
         current_conditions.side_effect = [conditions, conditions]
         medications_from.side_effect = [[medication]]
 
@@ -223,7 +224,7 @@ def test_command_from_json(current_conditions, medications_from, set_medication_
                 "suppliedDays": 11,
                 "substitution": "not_allowed",
                 "comment": "theComment",
-                "condition": "theCondition",
+                "condition": condition_name,
                 "conditionIndex": idx,
             },
         }
@@ -240,7 +241,7 @@ def test_command_from_json(current_conditions, medications_from, set_medication_
             command.icd10_codes = condition_icd10
         expected = InstructionWithCommand(**(arguments | {"command": command}))
         assert result == expected, f"----> {idx}"
-        assert current_conditions.mock_calls == condition_calls
+        assert current_conditions.mock_calls == [call()]
         calls = [
             call(
                 instruction,

--- a/tests/hyperscribe/commands/test_resolve_condition.py
+++ b/tests/hyperscribe/commands/test_resolve_condition.py
@@ -116,11 +116,12 @@ def test_command_from_json(add_code2description, current_conditions):
         CodedItem(uuid="theUuid3", label="display3a", code="CODE98.76"),
     ]
     tests = [
-        (1, "theUuid2", [call("theUuid2", "display2a")]),
-        (2, "theUuid3", [call("theUuid3", "display3a")]),
-        (4, "", []),
+        ("display2a", 1, "theUuid2", [call("theUuid2", "display2a")]),
+        ("display2a", 2, "theUuid2", [call("theUuid2", "display2a")]),
+        ("display2a", 4, "theUuid2", [call("theUuid2", "display2a")]),
+        ("nonexistent", 4, "", []),
     ]
-    for idx, exp_uuid, exp_calls in tests:
+    for condition_name, idx, exp_uuid, exp_calls in tests:
         current_conditions.side_effect = [conditions, conditions]
         arguments = {
             "uuid": "theUuid",
@@ -131,7 +132,7 @@ def test_command_from_json(add_code2description, current_conditions):
             "is_updated": True,
             "previous_information": "thePreviousInformation",
             "parameters": {
-                "condition": "display2a",
+                "condition": condition_name,
                 "conditionIndex": idx,
                 "rationale": "theRationale",
             },

--- a/tests/hyperscribe/commands/test_update_diagnose.py
+++ b/tests/hyperscribe/commands/test_update_diagnose.py
@@ -179,11 +179,12 @@ def test_command_from_json(add_code2description, current_conditions, search_cond
     tested = helper_instance()
 
     tests = [
-        (1, "CODE45", [call("theUuid2", "display2a"), call("code369", "labelB")]),
-        (2, "CODE9876", [call("theUuid3", "display3a"), call("code369", "labelB")]),
-        (4, None, [call("code369", "labelB")]),
+        ("display2a", 1, "CODE45", [call("theUuid2", "display2a"), call("code369", "labelB")]),
+        ("display2a", 2, "CODE45", [call("theUuid2", "display2a"), call("code369", "labelB")]),
+        ("display2a", 4, "CODE45", [call("theUuid2", "display2a"), call("code369", "labelB")]),
+        ("nonexistent", 4, None, [call("code369", "labelB")]),
     ]
-    for idx, exp_current_icd10, exp_calls in tests:
+    for condition_name, idx, exp_current_icd10, exp_calls in tests:
         arguments = {
             "uuid": "theUuid",
             "index": 7,
@@ -195,7 +196,7 @@ def test_command_from_json(add_code2description, current_conditions, search_cond
             "parameters": {
                 "keywords": "keyword1,keyword2,keyword3",
                 "ICD10": "ICD01,ICD02,ICD03",
-                "previousCondition": "theCondition",
+                "previousCondition": condition_name,
                 "previousConditionIndex": idx,
                 "rationale": "theRationale",
                 "assessment": "theAssessment",

--- a/tests/hyperscribe/commands/test_update_goal.py
+++ b/tests/hyperscribe/commands/test_update_goal.py
@@ -130,11 +130,12 @@ def test_command_from_json(add_code2description, current_goals):
         CodedItem(uuid="theUuid3", label="display3a", code="9876"),
     ]
     tests = [
-        (1, "theUuid2", [call("theUuid2", "display2a")]),
-        (2, "theUuid3", [call("theUuid3", "display3a")]),
-        (4, "", []),
+        ("display2a", 1, "theUuid2", [call("theUuid2", "display2a")]),
+        ("display2a", 2, "theUuid2", [call("theUuid2", "display2a")]),
+        ("display2a", 4, "theUuid2", [call("theUuid2", "display2a")]),
+        ("nonexistent", 4, "", []),
     ]
-    for idx, exp_uuid, exp_calls in tests:
+    for goal_name, idx, exp_uuid, exp_calls in tests:
         current_goals.side_effect = [goals, goals]
         arguments = {
             "uuid": "theUuid",
@@ -145,7 +146,7 @@ def test_command_from_json(add_code2description, current_goals):
             "is_updated": True,
             "previous_information": "thePreviousInformation",
             "parameters": {
-                "goal": "display2a",
+                "goal": goal_name,
                 "goalIndex": idx,
                 "dueDate": "2025-02-03",
                 "status": "improving",


### PR DESCRIPTION
When the LLM identifies a condition or goal from a list, it returns both a name (e.g., "Generalized edema") and an index (e.g., position 9). The name is almost always correct, but with long lists it's possible for the LLM to miscount the index. In these cases, an error that picks the wrong index by one (9 vs 10) means picking the wrong condition entirely (e.g., "Dry eye syndrome" instead of "Generalized edema").                                                                 
   
The fix checks if the index and name agree. If they don't, it falls back to the name, which is the more reliable signal. 

This applies to all 6 command types that do index-based lookups (Assess, ResolveCondition, Prescription, UpdateDiagnose, CloseGoal, UpdateGoal).

Addresses issue #216 