### PR TITLE
Add per-staff scribe pilot via ScribePilotStaffers secret

### DIFF
--- a/hyperscribe/CANVAS_MANIFEST.json
+++ b/hyperscribe/CANVAS_MANIFEST.json
@@ -218,6 +218,7 @@
     "NotionAPIKey",
     "NotionFeedbackDatabaseId",
     "ScribeBackend",
+    "ScribePilotStaffers",
     "StaffersList",
     "StaffersPolicy",
     "StructuredReasonForVisit",

--- a/hyperscribe/handlers/capture_button.py
+++ b/hyperscribe/handlers/capture_button.py
@@ -41,15 +41,15 @@ class CaptureButton(ActionButton):
 
     def visible(self) -> bool:
         settings = Settings.from_dictionary(self.secrets)
-        if settings.is_tuning or settings.modality == Constants.MODALITY_SCRIBE:
+        staff_id = self.context.get("user", {}).get("id", "")
+        # PILOT: replace is_scribe_modality with `settings.modality == Constants.MODALITY_SCRIBE`
+        if settings.is_tuning or settings.is_scribe_modality(staff_id):
             return False
 
         # DO NOT USE "CurrentStateChangeEvent" model. The view is too expensive.
         # It performs a max on id grouped by note for all notes, regardless of the note filter.
         if not Helper.editable_note(self.event.context["note_id"]):
             return False
-
-        staff_id = self.context.get("user", {}).get("id", "")
         visibility = False
         if settings.staffers_policy.is_allowed(staff_id):
             visibility = True

--- a/hyperscribe/handlers/reviewer_button.py
+++ b/hyperscribe/handlers/reviewer_button.py
@@ -29,11 +29,11 @@ class ReviewerButton(ActionButton):
 
     def visible(self) -> bool:
         settings = Settings.from_dictionary(self.secrets)
-
-        if settings.modality == Constants.MODALITY_SCRIBE:
-            return False
-
         staff_id = self.context.get("user", {}).get("id", "")
+
+        # PILOT: replace is_scribe_modality with `settings.modality == Constants.MODALITY_SCRIBE`
+        if settings.is_scribe_modality(staff_id):
+            return False
         result = False
         if settings.audit_llm and (not settings.is_tuning) and settings.staffers_policy.is_allowed(staff_id):
             result = Helper.editable_note(self.event.context["note_id"])

--- a/hyperscribe/handlers/transcript_button.py
+++ b/hyperscribe/handlers/transcript_button.py
@@ -29,11 +29,11 @@ class TranscriptButton(ActionButton):
 
     def visible(self) -> bool:
         settings = Settings.from_dictionary(self.secrets)
-
-        if settings.modality == Constants.MODALITY_SCRIBE:
-            return False
-
         staff_id = self.context.get("user", {}).get("id", "")
+
+        # PILOT: replace is_scribe_modality with `settings.modality == Constants.MODALITY_SCRIBE`
+        if settings.is_scribe_modality(staff_id):
+            return False
         result = False
         if (not settings.is_tuning) and settings.staffers_policy.is_allowed(staff_id):
             result = Helper.editable_note(self.event.context["note_id"])

--- a/hyperscribe/libraries/constants.py
+++ b/hyperscribe/libraries/constants.py
@@ -129,6 +129,8 @@ class Constants:
     SECRET_NOTION_API_KEY = "NotionAPIKey"
     SECRET_MODALITY = "Modality"
     MODALITY_SCRIBE = "scribe"
+    # PILOT: remove SECRET_SCRIBE_PILOT_STAFFERS when scribe pilot ends
+    SECRET_SCRIBE_PILOT_STAFFERS = "ScribePilotStaffers"
     SECRET_TRIAL_STAFFERS_LIST = "TrialStaffersList"
     # JSON credentials which take precedence over the secrets
     AWS_S3_CREDENTIALS_LOGS = "S3CredentialsLogs"

--- a/hyperscribe/scribe/application/debug_cache_app.py
+++ b/hyperscribe/scribe/application/debug_cache_app.py
@@ -3,6 +3,7 @@ from canvas_sdk.effects.launch_modal import LaunchModalEffect
 from canvas_sdk.handlers.application import NoteApplication
 
 from hyperscribe.libraries.constants import Constants
+from hyperscribe.structures.settings import Settings
 
 
 class ScribeCacheApp(NoteApplication):
@@ -13,8 +14,10 @@ class ScribeCacheApp(NoteApplication):
     PRIORITY = 1
 
     def visible(self) -> bool:
-        modality = self.secrets.get(Constants.SECRET_MODALITY, "").lower()
-        return bool(modality == Constants.MODALITY_SCRIBE)
+        # PILOT: revert to `self.secrets.get(Constants.SECRET_MODALITY, "").lower() == Constants.MODALITY_SCRIBE`
+        settings = Settings.from_dictionary(self.secrets)
+        staff_id = self.context.get("user", {}).get("id", "")
+        return settings.is_scribe_modality(staff_id)
 
     def handle(self) -> list[Effect]:
         from canvas_sdk.v1.data.note import Note

--- a/hyperscribe/scribe/application/summary_app.py
+++ b/hyperscribe/scribe/application/summary_app.py
@@ -3,6 +3,7 @@ from canvas_sdk.effects.launch_modal import LaunchModalEffect
 from canvas_sdk.handlers.application import NoteApplication
 
 from hyperscribe.libraries.constants import Constants
+from hyperscribe.structures.settings import Settings
 
 
 class SummaryApp(NoteApplication):
@@ -13,8 +14,10 @@ class SummaryApp(NoteApplication):
     PRIORITY = 1
 
     def visible(self) -> bool:
-        modality = self.secrets.get(Constants.SECRET_MODALITY, "").lower()
-        return bool(modality == Constants.MODALITY_SCRIBE)
+        # PILOT: revert to `self.secrets.get(Constants.SECRET_MODALITY, "").lower() == Constants.MODALITY_SCRIBE`
+        settings = Settings.from_dictionary(self.secrets)
+        staff_id = self.context.get("user", {}).get("id", "")
+        return settings.is_scribe_modality(staff_id)
 
     def handle(self) -> list[Effect]:
         from canvas_sdk.v1.data.note import Note

--- a/hyperscribe/scribe/application/transcript_app.py
+++ b/hyperscribe/scribe/application/transcript_app.py
@@ -3,6 +3,7 @@ from canvas_sdk.effects.launch_modal import LaunchModalEffect
 from canvas_sdk.handlers.application import NoteApplication
 
 from hyperscribe.libraries.constants import Constants
+from hyperscribe.structures.settings import Settings
 
 
 class ScribeApp(NoteApplication):
@@ -13,8 +14,10 @@ class ScribeApp(NoteApplication):
     PRIORITY = 1
 
     def visible(self) -> bool:
-        modality = self.secrets.get(Constants.SECRET_MODALITY, "").lower()
-        return bool(modality == Constants.MODALITY_SCRIBE)
+        # PILOT: revert to `self.secrets.get(Constants.SECRET_MODALITY, "").lower() == Constants.MODALITY_SCRIBE`
+        settings = Settings.from_dictionary(self.secrets)
+        staff_id = self.context.get("user", {}).get("id", "")
+        return settings.is_scribe_modality(staff_id)
 
     def handle(self) -> list[Effect]:
         from canvas_sdk.v1.data.note import Note

--- a/hyperscribe/structures/settings.py
+++ b/hyperscribe/structures/settings.py
@@ -28,6 +28,8 @@ class Settings(NamedTuple):
     cycle_transcript_overlap: int
     custom_prompts: list[CustomPrompt]
     modality: str = "copilot"
+    # PILOT: remove scribe_pilot_staffers when scribe pilot ends
+    scribe_pilot_staffers: list[str] = []
 
     @classmethod
     def from_dictionary(cls, dictionary: dict) -> Settings:
@@ -91,6 +93,10 @@ class Settings(NamedTuple):
                 json.loads(dictionary.get(Constants.SECRET_CUSTOM_PROMPTS) or "[]") or []
             ),
             modality=dictionary.get(Constants.SECRET_MODALITY, "copilot"),
+            # PILOT: remove scribe_pilot_staffers when scribe pilot ends
+            scribe_pilot_staffers=cls.list_from(
+                dictionary.get(Constants.SECRET_SCRIBE_PILOT_STAFFERS)
+            ),
         )
 
     @classmethod
@@ -110,6 +116,19 @@ class Settings(NamedTuple):
         if isinstance(string, str):
             return sorted(re.findall(r"[a-zA-Z0-9]+", string))
         return []
+
+    # PILOT: remove is_scribe_modality when scribe pilot ends; callers should
+    #        revert to checking `settings.modality == Constants.MODALITY_SCRIBE`
+    def is_scribe_modality(self, staff_id: str) -> bool:
+        """True when this staff member should use scribe mode.
+
+        Scribe mode applies when:
+        - the global modality is set to "scribe", OR
+        - the staff member's id is in the scribe_pilot_staffers list.
+        """
+        if self.modality == Constants.MODALITY_SCRIBE:
+            return True
+        return staff_id in self.scribe_pilot_staffers
 
     def llm_audio_model(self) -> str:
         result = Constants.OPENAI_CHAT_AUDIO

--- a/tests/hyperscribe/libraries/test_constants.py
+++ b/tests/hyperscribe/libraries/test_constants.py
@@ -135,6 +135,7 @@ def test_constants():
         "SECRET_SCRIBE_BACKEND": "ScribeBackend",
         "SECRET_NOTION_API_KEY": "NotionAPIKey",
         "SECRET_MODALITY": "Modality",
+        "SECRET_SCRIBE_PILOT_STAFFERS": "ScribePilotStaffers",
         "SECRET_TRIAL_STAFFERS_LIST": "TrialStaffersList",
         "MODALITY_SCRIBE": "scribe",
         #

--- a/tests/hyperscribe/scribe/application/test_summary_app.py
+++ b/tests/hyperscribe/scribe/application/test_summary_app.py
@@ -12,25 +12,36 @@ def test_constants() -> None:
     assert SummaryApp.IDENTIFIER == "hyperscribe__scribe_summary"
 
 
-def test_visible() -> None:
-    tests = [
-        ("scribe", True),
-        ("Scribe", True),
-        ("SCRIBE", True),
-        ("hyperscribe", False),
-        ("", False),
-    ]
-    for modality, expected in tests:
-        event = Event(EventRequest())
-        secrets = {"Modality": modality}
-        tested = SummaryApp(event, secrets)
-        assert tested.visible() is expected, f"modality={modality!r}"
+@patch("hyperscribe.scribe.application.summary_app.Settings")
+def test_visible(mock_settings_cls: MagicMock) -> None:
+    mock_settings = MagicMock()
+    mock_settings_cls.from_dictionary.return_value = mock_settings
+
+    # scribe modality for this staff → visible
+    mock_settings.is_scribe_modality.return_value = True
+    event = Event(EventRequest(context='{"user": {"id": "staff1"}}'))
+    tested = SummaryApp(event, {"Modality": "scribe"})
+    assert tested.visible() is True
+    mock_settings.is_scribe_modality.assert_called_with("staff1")
+
+    # not scribe modality for this staff → not visible
+    mock_settings.is_scribe_modality.return_value = False
+    event = Event(EventRequest(context='{"user": {"id": "staff2"}}'))
+    tested = SummaryApp(event, {"Modality": "copilot"})
+    assert tested.visible() is False
+    mock_settings.is_scribe_modality.assert_called_with("staff2")
 
 
-def test_visible_missing_secret() -> None:
+@patch("hyperscribe.scribe.application.summary_app.Settings")
+def test_visible_missing_user_context(mock_settings_cls: MagicMock) -> None:
+    mock_settings = MagicMock()
+    mock_settings_cls.from_dictionary.return_value = mock_settings
+    mock_settings.is_scribe_modality.return_value = False
+
     event = Event(EventRequest())
     tested = SummaryApp(event, {})
     assert tested.visible() is False
+    mock_settings.is_scribe_modality.assert_called_with("")
 
 
 @patch("canvas_sdk.v1.data.note.Note")

--- a/tests/hyperscribe/scribe/application/test_transcript_app.py
+++ b/tests/hyperscribe/scribe/application/test_transcript_app.py
@@ -19,25 +19,36 @@ def test_constants() -> None:
     assert ScribeApp.IDENTIFIER == "hyperscribe__scribe"
 
 
-def test_visible() -> None:
-    tests = [
-        ("scribe", True),
-        ("Scribe", True),
-        ("SCRIBE", True),
-        ("hyperscribe", False),
-        ("", False),
-    ]
-    for modality, expected in tests:
-        event = Event(EventRequest())
-        secrets = {"Modality": modality}
-        tested = ScribeApp(event, secrets)
-        assert tested.visible() is expected, f"modality={modality!r}"
+@patch("hyperscribe.scribe.application.transcript_app.Settings")
+def test_visible(mock_settings_cls: MagicMock) -> None:
+    mock_settings = MagicMock()
+    mock_settings_cls.from_dictionary.return_value = mock_settings
+
+    # scribe modality for this staff → visible
+    mock_settings.is_scribe_modality.return_value = True
+    event = Event(EventRequest(context='{"user": {"id": "staff1"}}'))
+    tested = ScribeApp(event, {"Modality": "scribe"})
+    assert tested.visible() is True
+    mock_settings.is_scribe_modality.assert_called_with("staff1")
+
+    # not scribe modality for this staff → not visible
+    mock_settings.is_scribe_modality.return_value = False
+    event = Event(EventRequest(context='{"user": {"id": "staff2"}}'))
+    tested = ScribeApp(event, {"Modality": "copilot"})
+    assert tested.visible() is False
+    mock_settings.is_scribe_modality.assert_called_with("staff2")
 
 
-def test_visible_missing_secret() -> None:
+@patch("hyperscribe.scribe.application.transcript_app.Settings")
+def test_visible_missing_user_context(mock_settings_cls: MagicMock) -> None:
+    mock_settings = MagicMock()
+    mock_settings_cls.from_dictionary.return_value = mock_settings
+    mock_settings.is_scribe_modality.return_value = False
+
     event = Event(EventRequest())
     tested = ScribeApp(event, {})
     assert tested.visible() is False
+    mock_settings.is_scribe_modality.assert_called_with("")
 
 
 @patch("canvas_sdk.v1.data.note.Note")

--- a/tests/hyperscribe/structures/test_settings.py
+++ b/tests/hyperscribe/structures/test_settings.py
@@ -30,6 +30,7 @@ def test_class():
         "cycle_transcript_overlap": int,
         "custom_prompts": list[CustomPrompt],
         "modality": str,
+        "scribe_pilot_staffers": list[str],
     }
     assert is_namedtuple(tested, fields)
 
@@ -113,6 +114,7 @@ def test__from_dict_base(is_true, clamp_int):
                 '{"command":"theCommand2","prompt":"thePrompt2","active":false},'
                 '{"command":"theCommand3","prompt":"thePrompt3"}]',
                 "Modality": "copilot",
+                "ScribePilotStaffers": "abc123 def456",
             },
             False,
         )
@@ -137,6 +139,7 @@ def test__from_dict_base(is_true, clamp_int):
             trial_staffers_policy=AccessPolicy(policy=True, items=[]),
             cycle_transcript_overlap=54,
             modality="copilot",
+            scribe_pilot_staffers=["abc123", "def456"],
         )
         assert result == expected
         calls = [call("rfv"), call("audit"), call("tuning"), call("commands"), call("staffers")]
@@ -197,6 +200,43 @@ def test__from_dict_base(is_true, clamp_int):
         ]
         assert clamp_int.mock_calls == calls
         reset_mocks()
+
+
+def test_is_scribe_modality():
+    """PILOT: remove this test when scribe pilot ends."""
+    base_kwargs = dict(
+        llm_text=VendorKey(vendor="v", api_key="k"),
+        llm_audio=VendorKey(vendor="v", api_key="k"),
+        structured_rfv=False,
+        audit_llm=False,
+        reasoning_llm=False,
+        custom_prompts=[],
+        is_tuning=False,
+        api_signing_key="key",
+        max_workers=3,
+        hierarchical_detection_threshold=5,
+        send_progress=False,
+        commands_policy=AccessPolicy(policy=False, items=[]),
+        staffers_policy=AccessPolicy(policy=False, items=[]),
+        trial_staffers_policy=AccessPolicy(policy=True, items=[]),
+        cycle_transcript_overlap=100,
+    )
+
+    # Global scribe mode → always True regardless of staff id
+    settings = Settings(**base_kwargs, modality="scribe", scribe_pilot_staffers=[])
+    assert settings.is_scribe_modality("anyone") is True
+    assert settings.is_scribe_modality("") is True
+
+    # Global copilot mode, no pilot list → always False
+    settings = Settings(**base_kwargs, modality="copilot", scribe_pilot_staffers=[])
+    assert settings.is_scribe_modality("staff1") is False
+
+    # Global copilot mode, staff in pilot list → True
+    settings = Settings(**base_kwargs, modality="copilot", scribe_pilot_staffers=["staff1", "staff2"])
+    assert settings.is_scribe_modality("staff1") is True
+    assert settings.is_scribe_modality("staff2") is True
+    assert settings.is_scribe_modality("staff3") is False
+    assert settings.is_scribe_modality("") is False
 
 
 def test_clamp_int():


### PR DESCRIPTION
Needed a way to allow a few staff members to try the new experience while everyone else stays on the old one.

## Summary
- New `ScribePilotStaffers` plugin secret: comma-separated staff IDs who should see scribe mode while global modality remains `copilot`
- Adds `Settings.is_scribe_modality(staff_id)` to resolve effective modality per-staff
- Updates all 6 `visible()` methods (3 copilot buttons + 3 scribe NoteApplications) to use per-staff modality resolution
- All pilot-specific code is marked with `# PILOT:` comments with revert instructions — run `grep -r "PILOT:" hyperscribe/` to find them

## How it works
- If `Modality=scribe` (global): everyone gets scribe (unchanged behavior)
- If `Modality=copilot` (default) and `ScribePilotStaffers=id1,id2`: only listed staff see scribe; everyone else sees copilot
- If neither secret is set: copilot for everyone (unchanged behavior)

## Test plan
- [x] `test_is_scribe_modality` covers global scribe, copilot with pilot list, copilot without pilot list
- [x] NoteApplication visibility tests updated to verify per-staff resolution
- [x] Constants and Settings field tests updated
- [ ] Manual: set `ScribePilotStaffers` to a staff ID, verify that staff sees scribe UI and others see copilot