### PR TITLE
Ad-hoc order forms for lab and imaging orders

### DIFF
--- a/hyperscribe/scribe/api/scribe_view.py
+++ b/hyperscribe/scribe/api/scribe_view.py
@@ -46,6 +46,7 @@ class ScribeView(StaffSessionAuthMixin, SimpleAPI):
                 "provider_name": provider_name,
                 "provider_photo_url": provider.photo_url,
                 "patient_name": patient_name,
+                "patient_id": str(note.patient.id),
             },
         )
         return [HTMLResponse(html)]

--- a/hyperscribe/scribe/api/scribe_view.py
+++ b/hyperscribe/scribe/api/scribe_view.py
@@ -47,6 +47,8 @@ class ScribeView(StaffSessionAuthMixin, SimpleAPI):
                 "provider_photo_url": provider.photo_url,
                 "patient_name": patient_name,
                 "patient_id": str(note.patient.id),
+                "staff_id": str(staff_id),
+                "staff_name": provider_name,
             },
         )
         return [HTMLResponse(html)]

--- a/hyperscribe/scribe/api/session_view.py
+++ b/hyperscribe/scribe/api/session_view.py
@@ -14,7 +14,9 @@ from canvas_sdk.handlers.simple_api import SimpleAPI, StaffSessionAuthMixin, api
 from canvas_sdk.commands.commands.allergy import AllergenType
 from canvas_sdk.v1.data.condition import Condition as ConditionModel, ConditionCoding
 from canvas_sdk.v1.data.lab import LabPartner, LabPartnerTest
-from canvas_sdk.v1.data.staff import Staff
+from canvas_sdk.v1.data.note import Note
+from canvas_sdk.v1.data.patient import PatientAddress
+from canvas_sdk.v1.data.staff import Staff, StaffRole
 from canvas_sdk.v1.data.team import Team
 
 from canvas_sdk.utils.http import science_http
@@ -593,4 +595,144 @@ class ScribeSessionView(StaffSessionAuthMixin, SimpleAPI):
             for r in sorted_results
             if r.get("icd10_code")
         ]
+        return [JSONResponse({"results": results}, status_code=HTTPStatus.OK)]
+
+    @api.get("/search-imaging")
+    def get_search_imaging(self) -> list[Union[Response, Effect]]:
+        """Search imaging codes via the science service."""
+        query = self.request.query_params.get("query", "").strip()
+        if not query:
+            return [JSONResponse({"results": []}, status_code=HTTPStatus.OK)]
+        try:
+            resp = science_http.get_json(
+                f"/parse-templates/imaging-reports/?query={query}&limit=25"
+            )
+            data = resp.json() or {}
+        except Exception:
+            log.exception("Imaging search failed")
+            return [JSONResponse({"results": []}, status_code=HTTPStatus.OK)]
+        results = []
+        for r in data.get("results", []):
+            name = r.get("name")
+            if not name:
+                continue
+            code_system = r.get("code_system")
+            code = r.get("code")
+            display = f"{name} ({code_system}: {code})" if code_system or code else name
+            results.append({"value": code or name, "display": display})
+        return [JSONResponse({"results": results}, status_code=HTTPStatus.OK)]
+
+    @api.get("/ordering-providers")
+    def get_ordering_providers(self) -> list[Union[Response, Effect]]:
+        """Return active staff who are prescribers, optionally filtered by search term."""
+        query = self.request.query_params.get("query", "").strip()
+        prescriber_staff_ids = (
+            StaffRole.objects
+            .filter(
+                role_type=StaffRole.RoleType.PROVIDER,
+                domain__in=StaffRole.RoleDomain.clinical_domains(),
+            )
+            .values_list("staff_id", flat=True)
+        )
+        qs = (
+            Staff.objects
+            .filter(active=True, pk__in=prescriber_staff_ids)
+            .order_by("last_name", "first_name")
+        )
+        if query:
+            first_matches = set(qs.filter(first_name__icontains=query).values_list("pk", flat=True)[:50])
+            last_matches = set(qs.filter(last_name__icontains=query).values_list("pk", flat=True)[:50])
+            qs = qs.filter(pk__in=first_matches | last_matches)
+        providers = [
+            {"id": str(s.id), "label": s.credentialed_name}
+            for s in qs[:50]
+        ]
+        return [JSONResponse({"providers": providers}, status_code=HTTPStatus.OK)]
+
+    @api.get("/search-imaging-centers")
+    def get_search_imaging_centers(self) -> list[Union[Response, Effect]]:
+        """Search for radiology imaging centers via the science service."""
+        query = self.request.query_params.get("query", "").strip()
+        if not query:
+            return [JSONResponse({"results": []}, status_code=HTTPStatus.OK)]
+
+        # Resolve zip codes: patient address first, then note location as fallback.
+        zip_codes: list[str] = []
+        patient_id = self.request.query_params.get("patient_id", "").strip()
+        note_id = self.request.query_params.get("note_id", "").strip()
+        if patient_id:
+            patient_zip = (
+                PatientAddress.objects
+                .filter(patient__id=patient_id)
+                .values_list("postal_code", flat=True)
+                .first()
+            )
+            if patient_zip:
+                zip_codes = [patient_zip]
+        if not zip_codes and note_id:
+            try:
+                note = Note.objects.select_related("location").get(id=note_id)
+                if note.location:
+                    loc_zip = (
+                        note.location.addresses
+                        .values_list("postal_code", flat=True)
+                        .first()
+                    )
+                    if loc_zip:
+                        zip_codes = [loc_zip]
+            except Note.DoesNotExist:
+                pass
+
+        params = f"?search={query}&job_title__icontains=radiology"
+        if zip_codes:
+            params += f"&business_postal_code__in={','.join(zip_codes)}"
+        try:
+            resp = science_http.get_json(f"/contacts/{params}")
+            data = resp.json() or {}
+        except Exception:
+            log.exception("Imaging center search failed")
+            return [JSONResponse({"results": []}, status_code=HTTPStatus.OK)]
+        results = []
+        for c in data.get("results", []):
+            first = c.get("firstName", "")
+            last = c.get("lastName", "")
+            practice = c.get("practiceName", "")
+            specialty = c.get("specialty", "")
+            # Build display name matching Canvas convention.
+            parts = []
+            if first and first != "(TBD)":
+                parts.append(first)
+            if last and last != first:
+                parts.append(last)
+            if practice and practice != "(TBD)":
+                parts.append(f"({practice}),")
+            if specialty and specialty not in (first, last, practice):
+                parts.append(specialty)
+            if first == "(TBD)":
+                parts.append(first)
+            name = " ".join(parts).strip()
+            # Build description with contact details.
+            desc_parts = []
+            phone = c.get("businessPhone")
+            fax = c.get("businessFax")
+            address = c.get("businessAddress")
+            if phone:
+                desc_parts.append(f"Phone: {phone}")
+            if fax:
+                desc_parts.append(f"Fax: {fax}")
+            if address:
+                desc_parts.append(f"Address: {address}")
+            results.append({
+                "name": name,
+                "description": " ".join(desc_parts),
+                "data": {
+                    "first_name": first,
+                    "last_name": last,
+                    "specialty": specialty,
+                    "practice_name": practice,
+                    "business_fax": fax,
+                    "business_phone": phone,
+                    "business_address": address,
+                },
+            })
         return [JSONResponse({"results": results}, status_code=HTTPStatus.OK)]

--- a/hyperscribe/scribe/api/session_view.py
+++ b/hyperscribe/scribe/api/session_view.py
@@ -12,8 +12,12 @@ from canvas_sdk.effects.simple_api import JSONResponse, Response
 from canvas_sdk.handlers.simple_api import SimpleAPI, StaffSessionAuthMixin, api
 
 from canvas_sdk.commands.commands.allergy import AllergenType
+from canvas_sdk.v1.data.condition import Condition as ConditionModel, ConditionCoding
+from canvas_sdk.v1.data.lab import LabPartner, LabPartnerTest
 from canvas_sdk.v1.data.staff import Staff
 from canvas_sdk.v1.data.team import Team
+
+from canvas_sdk.utils.http import science_http
 
 from hyperscribe.libraries.canvas_science import CanvasScience
 
@@ -32,6 +36,13 @@ from hyperscribe.scribe.backend import (
 from hyperscribe.scribe.commands.builder import annotate_duplicates, build_effects
 from hyperscribe.scribe.commands.extractor import extract_commands
 from hyperscribe.scribe.recommendations import recommend_commands
+
+
+def _format_icd10_code(raw: str) -> str:
+    code = raw.strip().upper()
+    if len(code) > 3:
+        return code[:3] + "." + code[3:]
+    return code
 
 
 _CACHE_KEY_PREFIX = "scribe_transcript:"
@@ -487,6 +498,31 @@ class ScribeSessionView(StaffSessionAuthMixin, SimpleAPI):
             )
         ]
 
+    @api.get("/lab-partners")
+    def get_lab_partners(self) -> list[Union[Response, Effect]]:
+        """Return active lab partners."""
+        partners = [
+            {"id": str(p["id"]), "name": p["name"]}
+            for p in LabPartner.objects.filter(active=True).order_by("name").values("id", "name")
+        ]
+        return [JSONResponse({"lab_partners": partners}, status_code=HTTPStatus.OK)]
+
+    @api.get("/lab-partner-tests")
+    def get_lab_partner_tests(self) -> list[Union[Response, Effect]]:
+        """Return tests for a lab partner, optionally filtered by search query."""
+        partner_id = self.request.query_params.get("partner_id", "").strip()
+        if not partner_id:
+            return [JSONResponse({"error": "partner_id is required"}, status_code=HTTPStatus.BAD_REQUEST)]
+        query = self.request.query_params.get("query", "").strip()
+        qs = LabPartnerTest.objects.filter(lab_partner__id=partner_id).order_by("order_name")
+        if query:
+            qs = qs.filter(order_name__icontains=query)
+        tests = [
+            {"order_code": t["order_code"], "order_name": t["order_name"]}
+            for t in qs.values("order_code", "order_name")[:50]
+        ]
+        return [JSONResponse({"tests": tests}, status_code=HTTPStatus.OK)]
+
     @api.get("/assignees")
     def get_assignees(self) -> list[Union[Response, Effect]]:
         """Return a merged list of active staff members and teams for task assignment."""
@@ -501,3 +537,60 @@ class ScribeSessionView(StaffSessionAuthMixin, SimpleAPI):
         for t in Team.objects.all().order_by("name").values("dbid", "name"):
             assignees.append({"type": "team", "id": t["dbid"], "label": t["name"]})
         return [JSONResponse({"assignees": assignees}, status_code=HTTPStatus.OK)]
+
+    @api.get("/patient-conditions")
+    def get_patient_conditions(self) -> list[Union[Response, Effect]]:
+        """Return committed, non-entered-in-error conditions for a patient."""
+        patient_id = self.request.query_params.get("patient_id", "").strip()
+        if not patient_id:
+            return [JSONResponse({"error": "patient_id is required"}, status_code=HTTPStatus.BAD_REQUEST)]
+        conditions = (
+            ConditionModel.objects
+            .active()
+            .for_patient(patient_id)
+            .prefetch_related("codings")
+            .order_by("-onset_date")
+        )
+        results = []
+        for c in conditions:
+            codings = list(c.codings.all())
+            if not codings:
+                continue
+            icd10 = next(
+                (coding for coding in codings if "icd" in (coding.system or "").lower()),
+                None,
+            )
+            chosen = icd10 or codings[0]
+            results.append({
+                "code": chosen.code,
+                "formatted_code": _format_icd10_code(chosen.code),
+                "display": chosen.display or c.clinical_status,
+                "system": chosen.system,
+            })
+        return [JSONResponse({"conditions": results}, status_code=HTTPStatus.OK)]
+
+    @api.get("/search-diagnoses")
+    def get_search_diagnoses(self) -> list[Union[Response, Effect]]:
+        """Search ICD-10 diagnosis codes via the science service."""
+        query = self.request.query_params.get("query", "").strip()
+        if not query:
+            return [JSONResponse({"results": []}, status_code=HTTPStatus.OK)]
+        try:
+            resp = science_http.get_json(
+                f"/search/condition/?query={query}&limit=25"
+            )
+            data = resp.json() or {}
+        except Exception:
+            log.exception("Diagnosis search failed")
+            return [JSONResponse({"results": []}, status_code=HTTPStatus.OK)]
+        sorted_results = sorted(data.get("results", []), key=lambda r: r.get("score", 0), reverse=True)
+        results = [
+            {
+                "code": r["icd10_code"],
+                "display": r.get("icd10_text", ""),
+                "formatted_code": _format_icd10_code(r["icd10_code"]),
+            }
+            for r in sorted_results
+            if r.get("icd10_code")
+        ]
+        return [JSONResponse({"results": results}, status_code=HTTPStatus.OK)]

--- a/hyperscribe/scribe/commands/imaging_order.py
+++ b/hyperscribe/scribe/commands/imaging_order.py
@@ -4,6 +4,7 @@ from typing import Any
 
 from canvas_sdk.commands.base import _BaseCommand
 from canvas_sdk.commands.commands.imaging_order import ImagingOrderCommand
+from canvas_sdk.commands.constants import ServiceProvider
 
 from hyperscribe.scribe.commands.base import CommandParser
 
@@ -23,9 +24,27 @@ class ImagingOrderParser(CommandParser):
         elif raw_priority == "Urgent":
             priority = ImagingOrderCommand.Priority.URGENT
 
+        service_provider = None
+        sp_data = data.get("service_provider")
+        if sp_data and isinstance(sp_data, dict):
+            service_provider = ServiceProvider(
+                first_name=sp_data.get("first_name") or "",
+                last_name=sp_data.get("last_name") or "",
+                specialty=sp_data.get("specialty") or "",
+                practice_name=sp_data.get("practice_name") or "",
+                business_fax=sp_data.get("business_fax"),
+                business_phone=sp_data.get("business_phone"),
+                business_address=sp_data.get("business_address"),
+            )
+
         return ImagingOrderCommand(
+            image_code=data.get("image_code") or None,
+            diagnosis_codes=data.get("diagnosis_codes") or None,
+            additional_details=data.get("additional_details") or None,
             comment=data.get("comment") or None,
             priority=priority,
+            ordering_provider_key=data.get("ordering_provider_id") or None,
+            service_provider=service_provider,
             note_uuid=note_uuid,
             command_uuid=command_uuid,
         )

--- a/hyperscribe/scribe/commands/lab_order.py
+++ b/hyperscribe/scribe/commands/lab_order.py
@@ -14,6 +14,10 @@ class LabOrderParser(CommandParser):
 
     def build(self, data: dict[str, Any], note_uuid: str, command_uuid: str) -> _BaseCommand:
         return LabOrderCommand(
+            lab_partner=data.get("lab_partner") or None,
+            tests_order_codes=data.get("tests_order_codes") or [],
+            diagnosis_codes=data.get("diagnosis_codes") or [],
+            fasting_required=bool(data.get("fasting_required")),
             comment=data.get("comment") or None,
             note_uuid=note_uuid,
             command_uuid=command_uuid,

--- a/hyperscribe/scribe/static/allergy-row.js
+++ b/hyperscribe/scribe/static/allergy-row.js
@@ -20,6 +20,7 @@ export function AllergyRow({ command, commandIndex, onEdit, onDelete, readOnly }
   const [query, setQuery] = useState(command.data.allergy_text || '');
   const [results, setResults] = useState([]);
   const [searching, setSearching] = useState(false);
+  const [searched, setSearched] = useState(false);
   const [selectedConceptId, setSelectedConceptId] = useState(command.data.concept_id || null);
   const [selectedConceptIdType, setSelectedConceptIdType] = useState(command.data.concept_id_type || null);
   const [selectedDisplay, setSelectedDisplay] = useState(command.data.allergy_text || '');
@@ -51,6 +52,7 @@ export function AllergyRow({ command, commandIndex, onEdit, onDelete, readOnly }
   const doSearch = useCallback(async (q) => {
     if (!q || q.length < 2) {
       setResults([]);
+      setSearched(false);
       return;
     }
     setSearching(true);
@@ -65,6 +67,7 @@ export function AllergyRow({ command, commandIndex, onEdit, onDelete, readOnly }
       setResults([]);
     } finally {
       setSearching(false);
+      setSearched(true);
     }
   }, []);
 
@@ -85,6 +88,7 @@ export function AllergyRow({ command, commandIndex, onEdit, onDelete, readOnly }
     setSelectedDisplay(result.description);
     setQuery(result.description);
     setResults([]);
+    setSearched(false);
   };
 
   const handleSave = () => {
@@ -163,6 +167,11 @@ export function AllergyRow({ command, commandIndex, onEdit, onDelete, readOnly }
                   ${r.description}
                 </div>
               `)}
+            </div>
+          `}
+          ${!searching && searched && results.length === 0 && query.length >= 2 && html`
+            <div class="allergy-search-dropdown">
+              <div class="allergy-search-result search-no-results">No allergies found</div>
             </div>
           `}
         </div>

--- a/hyperscribe/scribe/static/app.js
+++ b/hyperscribe/scribe/static/app.js
@@ -9,7 +9,7 @@ const html = htm.bind(h);
 
 const API_BASE = '/plugin-io/api/hyperscribe/scribe-session';
 
-export function App({ noteId, view, providerName, providerPhotoUrl, patientName, patientId }) {
+export function App({ noteId, view, providerName, providerPhotoUrl, patientName, patientId, staffId, staffName }) {
   const [saved, setSaved] = useState(false);
   const [saveError, setSaveError] = useState(null);
 
@@ -37,7 +37,7 @@ export function App({ noteId, view, providerName, providerPhotoUrl, patientName,
   }, [noteId]);
 
   if (view === 'summary') {
-    return html`<${Summary} noteId=${noteId} patientId=${patientId} />`;
+    return html`<${Summary} noteId=${noteId} patientId=${patientId} staffId=${staffId} staffName=${staffName} />`;
   }
 
   if (view === 'debug') {

--- a/hyperscribe/scribe/static/app.js
+++ b/hyperscribe/scribe/static/app.js
@@ -9,7 +9,7 @@ const html = htm.bind(h);
 
 const API_BASE = '/plugin-io/api/hyperscribe/scribe-session';
 
-export function App({ noteId, view, providerName, providerPhotoUrl, patientName }) {
+export function App({ noteId, view, providerName, providerPhotoUrl, patientName, patientId }) {
   const [saved, setSaved] = useState(false);
   const [saveError, setSaveError] = useState(null);
 
@@ -37,7 +37,7 @@ export function App({ noteId, view, providerName, providerPhotoUrl, patientName 
   }, [noteId]);
 
   if (view === 'summary') {
-    return html`<${Summary} noteId=${noteId} />`;
+    return html`<${Summary} noteId=${noteId} patientId=${patientId} />`;
   }
 
   if (view === 'debug') {

--- a/hyperscribe/scribe/static/index.html
+++ b/hyperscribe/scribe/static/index.html
@@ -48,6 +48,7 @@
       providerName: '{{ provider_name }}',
       providerPhotoUrl: '{{ provider_photo_url }}',
       patientName: '{{ patient_name }}',
+      patientId: '{{ patient_id }}',
     };
     render(h(App, config), document.getElementById('app'));
   </script>

--- a/hyperscribe/scribe/static/index.html
+++ b/hyperscribe/scribe/static/index.html
@@ -49,6 +49,8 @@
       providerPhotoUrl: '{{ provider_photo_url }}',
       patientName: '{{ patient_name }}',
       patientId: '{{ patient_id }}',
+      staffId: '{{ staff_id }}',
+      staffName: '{{ staff_name }}',
     };
     render(h(App, config), document.getElementById('app'));
   </script>

--- a/hyperscribe/scribe/static/medication-row.js
+++ b/hyperscribe/scribe/static/medication-row.js
@@ -26,6 +26,7 @@ export function MedicationRow({ command, commandIndex, onEdit, onDelete, readOnl
   const [query, setQuery] = useState(command.data.medication_text || '');
   const [results, setResults] = useState([]);
   const [searching, setSearching] = useState(false);
+  const [searched, setSearched] = useState(false);
   const [selectedFdb, setSelectedFdb] = useState(
     isFdbStructured(command.data.fdb_code) ? command.data.fdb_code : null
   );
@@ -57,6 +58,7 @@ export function MedicationRow({ command, commandIndex, onEdit, onDelete, readOnl
   const doSearch = useCallback(async (q) => {
     if (!q || q.length < 2) {
       setResults([]);
+      setSearched(false);
       return;
     }
     setSearching(true);
@@ -71,6 +73,7 @@ export function MedicationRow({ command, commandIndex, onEdit, onDelete, readOnl
       setResults([]);
     } finally {
       setSearching(false);
+      setSearched(true);
     }
   }, []);
 
@@ -89,6 +92,7 @@ export function MedicationRow({ command, commandIndex, onEdit, onDelete, readOnl
     setSelectedDisplay(result.description);
     setQuery(result.description);
     setResults([]);
+    setSearched(false);
   };
 
   const handleSave = () => {
@@ -163,6 +167,11 @@ export function MedicationRow({ command, commandIndex, onEdit, onDelete, readOnl
                   ${r.description}
                 </div>
               `)}
+            </div>
+          `}
+          ${!searching && searched && results.length === 0 && query.length >= 2 && html`
+            <div class="medication-search-dropdown">
+              <div class="medication-search-result search-no-results">No medications found</div>
             </div>
           `}
         </div>

--- a/hyperscribe/scribe/static/order-row.js
+++ b/hyperscribe/scribe/static/order-row.js
@@ -47,14 +47,18 @@ function buildDisplay(type, data) {
   }
   if (type === 'imaging_order') {
     const parts = [];
+    if (data.image_display) parts.push(data.image_display);
+    if (data.additional_details) parts.push(data.additional_details);
     if (data.comment) parts.push(data.comment);
     if (data.priority) parts.push(data.priority);
+    if (data.ordering_provider_name) parts.push(data.ordering_provider_name);
+    if (data.service_provider_name) parts.push(data.service_provider_name);
     return parts.join(' | ') || '';
   }
   return '';
 }
 
-export function OrderRow({ command, commandIndex, onEdit, onDelete, readOnly, patientId }) {
+export function OrderRow({ command, commandIndex, onEdit, onDelete, readOnly, patientId, noteId, staffId, staffName }) {
   const isNew = !command.display;
   const [editing, setEditing] = useState(isNew);
   const [activeTab, setActiveTab] = useState(command.command_type || 'prescribe');
@@ -105,8 +109,43 @@ export function OrderRow({ command, commandIndex, onEdit, onDelete, readOnly, pa
   const diagInputRef = useRef(null);
 
   // Imaging state
+  const [imagingQuery, setImagingQuery] = useState(command.data.image_display || '');
+  const [imagingResults, setImagingResults] = useState([]);
+  const [imagingSearching, setImagingSearching] = useState(false);
+  const [imagingSearched, setImagingSearched] = useState(false);
+  const [selectedImageCode, setSelectedImageCode] = useState(command.data.image_code || null);
+  const [selectedImageDisplay, setSelectedImageDisplay] = useState(command.data.image_display || '');
+  const [imagingDiagnoses, setImagingDiagnoses] = useState(
+    (command.data.diagnosis_codes || []).map((code, i) => ({
+      code,
+      display: (command.data.diagnosis_displays || [])[i] || code,
+      formatted_code: (command.data.diagnosis_formatted || [])[i] || code,
+    }))
+  );
+  const [imagingDiagQuery, setImagingDiagQuery] = useState('');
+  const [imagingDiagResults, setImagingDiagResults] = useState([]);
+  const [imagingDiagSearching, setImagingDiagSearching] = useState(false);
+  const [imagingDiagSearched, setImagingDiagSearched] = useState(false);
+  const [imagingDiagFocused, setImagingDiagFocused] = useState(false);
+  const [imagingDetails, setImagingDetails] = useState(command.data.additional_details || '');
   const [imagingComment, setImagingComment] = useState(command.data.comment || '');
   const [imagingPriority, setImagingPriority] = useState(command.data.priority || 'Routine');
+  const [orderingProviderId, setOrderingProviderId] = useState(command.data.ordering_provider_id || staffId || '');
+  const [orderingProviderName, setOrderingProviderName] = useState(command.data.ordering_provider_name || staffName || '');
+  const [providerQuery, setProviderQuery] = useState('');
+  const [providerResults, setProviderResults] = useState([]);
+  const [providerSearching, setProviderSearching] = useState(false);
+  const [providerSearched, setProviderSearched] = useState(false);
+  const [centerQuery, setCenterQuery] = useState('');
+  const [centerResults, setCenterResults] = useState([]);
+  const [centerSearching, setCenterSearching] = useState(false);
+  const [centerSearched, setCenterSearched] = useState(false);
+  const [selectedCenter, setSelectedCenter] = useState(command.data.service_provider || null);
+  const [selectedCenterName, setSelectedCenterName] = useState(command.data.service_provider_name || '');
+  const imagingInputRef = useRef(null);
+  const imagingDiagInputRef = useRef(null);
+  const providerInputRef = useRef(null);
+  const centerInputRef = useRef(null);
 
   const medInputRef = useRef(null);
   const containerRef = useRef(null);
@@ -117,21 +156,23 @@ export function OrderRow({ command, commandIndex, onEdit, onDelete, readOnly, pa
     }
   }, [editing, activeTab]);
 
-  // Load lab partners and patient conditions when lab tab is active.
+  // Load lab partners when lab tab is active.
   useEffect(() => {
-    if (activeTab !== 'lab_order') return;
-    if (labPartners.length === 0) {
-      fetch(`${API_BASE}/lab-partners`)
-        .then(r => r.json())
-        .then(d => setLabPartners(d.lab_partners || []))
-        .catch(() => {});
-    }
-    if (patientId && patientConditions.length === 0) {
-      fetch(`${API_BASE}/patient-conditions?patient_id=${encodeURIComponent(patientId)}`)
-        .then(r => r.json())
-        .then(d => setPatientConditions(d.conditions || []))
-        .catch(() => {});
-    }
+    if (activeTab !== 'lab_order' || labPartners.length > 0) return;
+    fetch(`${API_BASE}/lab-partners`)
+      .then(r => r.json())
+      .then(d => setLabPartners(d.lab_partners || []))
+      .catch(() => {});
+  }, [activeTab]);
+
+  // Load patient conditions when lab or imaging tab is active.
+  useEffect(() => {
+    if (activeTab !== 'lab_order' && activeTab !== 'imaging_order') return;
+    if (!patientId || patientConditions.length > 0) return;
+    fetch(`${API_BASE}/patient-conditions?patient_id=${encodeURIComponent(patientId)}`)
+      .then(r => r.json())
+      .then(d => setPatientConditions(d.conditions || []))
+      .catch(() => {});
   }, [activeTab]);
 
   const doLabTestSearch = useCallback(async (q) => {
@@ -228,6 +269,156 @@ export function OrderRow({ command, commandIndex, onEdit, onDelete, readOnly, pa
     return [];
   })();
 
+  // Imaging code search.
+  const doImagingSearch = useCallback(async (q) => {
+    if (!q || q.length < 2) { setImagingResults([]); setImagingSearched(false); return; }
+    setImagingSearching(true);
+    try {
+      const res = await fetch(`${API_BASE}/search-imaging?query=${encodeURIComponent(q)}`);
+      const data = await res.json();
+      setImagingResults(data.results || []);
+    } catch (err) {
+      setImagingResults([]);
+    } finally {
+      setImagingSearching(false);
+      setImagingSearched(true);
+    }
+  }, []);
+
+  const debouncedImagingSearch = useDebounce(doImagingSearch, DEBOUNCE_MS);
+
+  const handleImagingInput = (e) => {
+    const val = e.target.value;
+    setImagingQuery(val);
+    setSelectedImageCode(null);
+    setSelectedImageDisplay(val);
+    debouncedImagingSearch(val);
+  };
+
+  const handleImagingSelect = (result) => {
+    setSelectedImageCode(result.value);
+    setSelectedImageDisplay(result.display);
+    setImagingQuery(result.display);
+    setImagingResults([]);
+    setImagingSearched(false);
+  };
+
+  // Imaging diagnosis search.
+  const doImagingDiagSearch = useCallback(async (q) => {
+    if (!q || q.length < 2) { setImagingDiagResults([]); setImagingDiagSearched(false); return; }
+    setImagingDiagSearching(true);
+    try {
+      const res = await fetch(`${API_BASE}/search-diagnoses?query=${encodeURIComponent(q)}`);
+      const data = await res.json();
+      const alreadySelected = new Set(imagingDiagnoses.map(d => d.code));
+      setImagingDiagResults((data.results || []).filter(d => !alreadySelected.has(d.code)));
+    } catch (err) {
+      setImagingDiagResults([]);
+    } finally {
+      setImagingDiagSearching(false);
+      setImagingDiagSearched(true);
+    }
+  }, [imagingDiagnoses]);
+
+  const debouncedImagingDiagSearch = useDebounce(doImagingDiagSearch, DEBOUNCE_MS);
+
+  const handleImagingDiagInput = (e) => {
+    const val = e.target.value;
+    setImagingDiagQuery(val);
+    debouncedImagingDiagSearch(val);
+  };
+
+  const handleImagingDiagSelect = (diag) => {
+    setImagingDiagnoses([...imagingDiagnoses, diag]);
+    setImagingDiagQuery('');
+    setImagingDiagResults([]);
+    setImagingDiagSearched(false);
+    if (imagingDiagInputRef.current) imagingDiagInputRef.current.focus();
+  };
+
+  const handleImagingDiagRemove = (code) => {
+    setImagingDiagnoses(imagingDiagnoses.filter(d => d.code !== code));
+  };
+
+  const imagingDiagSuggestions = (() => {
+    if (!imagingDiagQuery && patientConditions.length > 0) {
+      const alreadySelected = new Set(imagingDiagnoses.map(d => d.code));
+      return patientConditions.filter(c => !alreadySelected.has(c.code));
+    }
+    return [];
+  })();
+
+  // Ordering provider search.
+  const doProviderSearch = useCallback(async (q) => {
+    if (!q || q.length < 2) { setProviderResults([]); setProviderSearched(false); return; }
+    setProviderSearching(true);
+    try {
+      const res = await fetch(`${API_BASE}/ordering-providers?query=${encodeURIComponent(q)}`);
+      const data = await res.json();
+      setProviderResults(data.providers || []);
+    } catch (err) {
+      setProviderResults([]);
+    } finally {
+      setProviderSearching(false);
+      setProviderSearched(true);
+    }
+  }, []);
+
+  const debouncedProviderSearch = useDebounce(doProviderSearch, DEBOUNCE_MS);
+
+  const handleProviderInput = (e) => {
+    const val = e.target.value;
+    setProviderQuery(val);
+    setOrderingProviderId('');
+    setOrderingProviderName(val);
+    debouncedProviderSearch(val);
+  };
+
+  const handleProviderSelect = (provider) => {
+    setOrderingProviderId(provider.id);
+    setOrderingProviderName(provider.label);
+    setProviderQuery('');
+    setProviderResults([]);
+    setProviderSearched(false);
+  };
+
+  // Imaging center search.
+  const doCenterSearch = useCallback(async (q) => {
+    if (!q || q.length < 2) { setCenterResults([]); setCenterSearched(false); return; }
+    setCenterSearching(true);
+    try {
+      let url = `${API_BASE}/search-imaging-centers?query=${encodeURIComponent(q)}`;
+      if (patientId) url += `&patient_id=${encodeURIComponent(patientId)}`;
+      if (noteId) url += `&note_id=${encodeURIComponent(noteId)}`;
+      const res = await fetch(url);
+      const data = await res.json();
+      setCenterResults(data.results || []);
+    } catch (err) {
+      setCenterResults([]);
+    } finally {
+      setCenterSearching(false);
+      setCenterSearched(true);
+    }
+  }, [patientId, noteId]);
+
+  const debouncedCenterSearch = useDebounce(doCenterSearch, DEBOUNCE_MS);
+
+  const handleCenterInput = (e) => {
+    const val = e.target.value;
+    setCenterQuery(val);
+    setSelectedCenter(null);
+    setSelectedCenterName(val);
+    debouncedCenterSearch(val);
+  };
+
+  const handleCenterSelect = (result) => {
+    setSelectedCenter(result.data);
+    setSelectedCenterName(result.name);
+    setCenterQuery('');
+    setCenterResults([]);
+    setCenterSearched(false);
+  };
+
   // Close dropdown on outside click.
   useEffect(() => {
     if (!editing) return;
@@ -237,6 +428,11 @@ export function OrderRow({ command, commandIndex, onEdit, onDelete, readOnly, pa
         setLabTestResults([]);
         setDiagResults([]);
         setDiagFocused(false);
+        setImagingResults([]);
+        setImagingDiagResults([]);
+        setImagingDiagFocused(false);
+        setProviderResults([]);
+        setCenterResults([]);
       }
     };
     document.addEventListener('mousedown', handler);
@@ -302,7 +498,20 @@ export function OrderRow({ command, commandIndex, onEdit, onDelete, readOnly, pa
         comment: labComment || null,
       };
     } else if (activeTab === 'imaging_order') {
-      data = { comment: imagingComment, priority: imagingPriority };
+      data = {
+        image_code: selectedImageCode || null,
+        image_display: selectedImageDisplay || null,
+        diagnosis_codes: imagingDiagnoses.map(d => d.code),
+        diagnosis_displays: imagingDiagnoses.map(d => d.display),
+        diagnosis_formatted: imagingDiagnoses.map(d => d.formatted_code || d.code),
+        additional_details: imagingDetails || null,
+        comment: imagingComment || null,
+        priority: imagingPriority,
+        ordering_provider_id: orderingProviderId || null,
+        ordering_provider_name: orderingProviderName || null,
+        service_provider: selectedCenter || null,
+        service_provider_name: selectedCenterName || null,
+      };
     }
     onEdit(commandIndex, data, activeTab);
     setEditing(false);
@@ -532,15 +741,181 @@ export function OrderRow({ command, commandIndex, onEdit, onDelete, readOnly, pa
             `}
             ${activeTab === 'imaging_order' && html`
               <div class="order-imaging-form">
-                <textarea
-                  class="order-textarea"
-                  value=${imagingComment}
-                  onInput=${(e) => setImagingComment(e.target.value)}
-                  placeholder="Imaging order details..."
-                />
-                <div class="order-priority">
+                <div class="imaging-search-wrapper">
+                  <div class="labeled-field" style="width:100%">
+                    <span class="labeled-field-label">Imaging</span>
+                    <input
+                      ref=${imagingInputRef}
+                      type="text"
+                      class="labeled-field-input"
+                      value=${imagingQuery}
+                      onInput=${handleImagingInput}
+                      placeholder="Search imaging..."
+                    />
+                  </div>
+                  ${imagingSearching && html`<span class="imaging-search-spinner">Searching...</span>`}
+                  ${imagingResults.length > 0 && html`
+                    <div class="imaging-search-dropdown">
+                      ${imagingResults.map((r, i) => html`
+                        <div
+                          key=${i}
+                          class="imaging-search-result"
+                          onMouseDown=${(e) => { e.preventDefault(); handleImagingSelect(r); }}
+                        >${r.display}</div>
+                      `)}
+                    </div>
+                  `}
+                  ${!imagingSearching && imagingSearched && imagingResults.length === 0 && imagingQuery.length >= 2 && html`
+                    <div class="imaging-search-dropdown">
+                      <div class="imaging-search-result search-no-results">No imaging codes found</div>
+                    </div>
+                  `}
+                </div>
+                <div class="order-rx-row">
+                  <div class="diag-search-wrapper" style="flex:1">
+                    <div class="labeled-field" style="width:100%">
+                      <span class="labeled-field-label">Dx</span>
+                      <input
+                        ref=${imagingDiagInputRef}
+                        class="labeled-field-input"
+                        type="text"
+                        value=${imagingDiagQuery}
+                        onInput=${handleImagingDiagInput}
+                        onFocus=${() => setImagingDiagFocused(true)}
+                        onBlur=${() => setTimeout(() => setImagingDiagFocused(false), 150)}
+                        placeholder="Search diagnoses..."
+                      />
+                    </div>
+                    ${imagingDiagSearching && html`<span class="diag-search-spinner">Searching...</span>`}
+                    ${imagingDiagResults.length > 0 && html`
+                      <div class="diag-search-dropdown">
+                        ${imagingDiagResults.map(d => html`
+                          <div
+                            key=${d.code}
+                            class="diag-search-result"
+                            onMouseDown=${(e) => { e.preventDefault(); handleImagingDiagSelect(d); }}
+                          >${d.formatted_code || d.code} — ${d.display}</div>
+                        `)}
+                      </div>
+                    `}
+                    ${!imagingDiagSearching && imagingDiagSearched && imagingDiagResults.length === 0 && imagingDiagQuery.length >= 2 && html`
+                      <div class="diag-search-dropdown">
+                        <div class="diag-search-result search-no-results">No diagnoses found</div>
+                      </div>
+                    `}
+                    ${imagingDiagFocused && !imagingDiagQuery && imagingDiagSuggestions.length > 0 && html`
+                      <div class="diag-search-dropdown">
+                        <div class="diag-suggestion-header">Patient conditions</div>
+                        ${imagingDiagSuggestions.map(d => html`
+                          <div
+                            key=${d.code}
+                            class="diag-search-result"
+                            onMouseDown=${(e) => { e.preventDefault(); handleImagingDiagSelect(d); }}
+                          >${d.formatted_code || d.code} — ${d.display}</div>
+                        `)}
+                      </div>
+                    `}
+                  </div>
+                </div>
+                ${imagingDiagnoses.length > 0 && html`
+                  <div class="lab-selected-tests">
+                    ${imagingDiagnoses.map(d => html`
+                      <span class="lab-test-chip" key=${d.code}>
+                        ${d.formatted_code || d.code}
+                        <button type="button" class="lab-test-chip-remove" onClick=${() => handleImagingDiagRemove(d.code)}>×</button>
+                      </span>
+                    `)}
+                  </div>
+                `}
+                <div class="order-rx-row">
+                  <div class="labeled-field" style="flex:1">
+                    <span class="labeled-field-label">Order Details</span>
+                    <input
+                      class="labeled-field-input"
+                      type="text"
+                      value=${imagingDetails}
+                      onInput=${(e) => setImagingDetails(e.target.value)}
+                    />
+                  </div>
+                </div>
+                <div class="order-rx-row">
+                  <div class="labeled-field" style="flex:1">
+                    <span class="labeled-field-label">Comment</span>
+                    <input
+                      class="labeled-field-input"
+                      type="text"
+                      value=${imagingComment}
+                      onInput=${(e) => setImagingComment(e.target.value)}
+                    />
+                  </div>
+                </div>
+                <div class="order-rx-row">
                   <button type="button" class="task-quick-btn${imagingPriority === 'Routine' ? ' active' : ''}" onClick=${() => setImagingPriority('Routine')}>Routine</button>
                   <button type="button" class="task-quick-btn${imagingPriority === 'Urgent' ? ' active' : ''}" onClick=${() => setImagingPriority('Urgent')}>Urgent</button>
+                </div>
+                <div class="imaging-search-wrapper">
+                  <div class="labeled-field" style="width:100%">
+                    <span class="labeled-field-label">Ordering Provider</span>
+                    <input
+                      ref=${providerInputRef}
+                      type="text"
+                      class="labeled-field-input"
+                      value=${providerQuery || orderingProviderName}
+                      onInput=${handleProviderInput}
+                      onFocus=${() => { if (orderingProviderName) { setProviderQuery(orderingProviderName); debouncedProviderSearch(orderingProviderName); } }}
+                      placeholder="Search providers..."
+                    />
+                  </div>
+                  ${providerSearching && html`<span class="imaging-search-spinner">Searching...</span>`}
+                  ${providerResults.length > 0 && html`
+                    <div class="imaging-search-dropdown">
+                      ${providerResults.map(p => html`
+                        <div
+                          key=${p.id}
+                          class="imaging-search-result"
+                          onMouseDown=${(e) => { e.preventDefault(); handleProviderSelect(p); }}
+                        >${p.label}</div>
+                      `)}
+                    </div>
+                  `}
+                  ${!providerSearching && providerSearched && providerResults.length === 0 && providerQuery.length >= 2 && html`
+                    <div class="imaging-search-dropdown">
+                      <div class="imaging-search-result search-no-results">No providers found</div>
+                    </div>
+                  `}
+                </div>
+                <div class="imaging-search-wrapper">
+                  <div class="labeled-field" style="width:100%">
+                    <span class="labeled-field-label">Imaging Center</span>
+                    <input
+                      ref=${centerInputRef}
+                      type="text"
+                      class="labeled-field-input"
+                      value=${centerQuery || selectedCenterName}
+                      onInput=${handleCenterInput}
+                      placeholder="Search imaging centers..."
+                    />
+                  </div>
+                  ${centerSearching && html`<span class="imaging-search-spinner">Searching...</span>`}
+                  ${centerResults.length > 0 && html`
+                    <div class="imaging-search-dropdown">
+                      ${centerResults.map((r, i) => html`
+                        <div
+                          key=${i}
+                          class="imaging-search-result"
+                          onMouseDown=${(e) => { e.preventDefault(); handleCenterSelect(r); }}
+                        >
+                          <div class="imaging-center-name">${r.name}</div>
+                          ${r.description && html`<div class="imaging-center-desc">${r.description}</div>`}
+                        </div>
+                      `)}
+                    </div>
+                  `}
+                  ${!centerSearching && centerSearched && centerResults.length === 0 && centerQuery.length >= 2 && html`
+                    <div class="imaging-search-dropdown">
+                      <div class="imaging-search-result search-no-results">No imaging centers found</div>
+                    </div>
+                  `}
                 </div>
               </div>
             `}

--- a/hyperscribe/scribe/static/order-row.js
+++ b/hyperscribe/scribe/static/order-row.js
@@ -37,7 +37,14 @@ function buildDisplay(type, data) {
     if (data.refills) parts.push(`${data.refills} refill${data.refills > 1 ? 's' : ''}`);
     return parts.join(' | ') || '';
   }
-  if (type === 'lab_order') return data.comment || '';
+  if (type === 'lab_order') {
+    const parts = [];
+    if (data.lab_partner_name) parts.push(data.lab_partner_name);
+    if (data.test_names && data.test_names.length) parts.push(data.test_names.join(', '));
+    if (data.comment) parts.push(data.comment);
+    if (data.fasting_required) parts.push('Fasting');
+    return parts.join(' | ') || '';
+  }
   if (type === 'imaging_order') {
     const parts = [];
     if (data.comment) parts.push(data.comment);
@@ -47,7 +54,7 @@ function buildDisplay(type, data) {
   return '';
 }
 
-export function OrderRow({ command, commandIndex, onEdit, onDelete, readOnly }) {
+export function OrderRow({ command, commandIndex, onEdit, onDelete, readOnly, patientId }) {
   const isNew = !command.display;
   const [editing, setEditing] = useState(isNew);
   const [activeTab, setActiveTab] = useState(command.command_type || 'prescribe');
@@ -56,6 +63,7 @@ export function OrderRow({ command, commandIndex, onEdit, onDelete, readOnly }) 
   const [medQuery, setMedQuery] = useState(command.data.medication_text || '');
   const [medResults, setMedResults] = useState([]);
   const [medSearching, setMedSearching] = useState(false);
+  const [medSearched, setMedSearched] = useState(false);
   const [selectedFdb, setSelectedFdb] = useState(command.data.fdb_code || null);
   const [selectedMedDisplay, setSelectedMedDisplay] = useState(command.data.medication_text || '');
   const [sig, setSig] = useState(command.data.sig || '');
@@ -66,7 +74,35 @@ export function OrderRow({ command, commandIndex, onEdit, onDelete, readOnly }) 
   const [noteToPharmacist, setNoteToPharmacist] = useState(command.data.note_to_pharmacist || '');
 
   // Lab state
+  const [labPartners, setLabPartners] = useState([]);
+  const [labPartnerId, setLabPartnerId] = useState(command.data.lab_partner || '');
+  const [labPartnerName, setLabPartnerName] = useState(command.data.lab_partner_name || '');
+  const [labTestQuery, setLabTestQuery] = useState('');
+  const [labTestResults, setLabTestResults] = useState([]);
+  const [labTestSearching, setLabTestSearching] = useState(false);
+  const [labTestSearched, setLabTestSearched] = useState(false);
+  const [selectedTests, setSelectedTests] = useState(
+    (command.data.tests_order_codes || []).map((code, i) => ({
+      order_code: code,
+      order_name: (command.data.test_names || [])[i] || code,
+    }))
+  );
+  const [selectedDiagnoses, setSelectedDiagnoses] = useState(
+    (command.data.diagnosis_codes || []).map((code, i) => ({
+      code,
+      display: (command.data.diagnosis_displays || [])[i] || code,
+    }))
+  );
+  const [diagQuery, setDiagQuery] = useState('');
+  const [diagResults, setDiagResults] = useState([]);
+  const [diagSearching, setDiagSearching] = useState(false);
+  const [diagSearched, setDiagSearched] = useState(false);
+  const [diagFocused, setDiagFocused] = useState(false);
+  const [patientConditions, setPatientConditions] = useState([]);
+  const [labFasting, setLabFasting] = useState(command.data.fasting_required || false);
   const [labComment, setLabComment] = useState(command.data.comment || '');
+  const labTestInputRef = useRef(null);
+  const diagInputRef = useRef(null);
 
   // Imaging state
   const [imagingComment, setImagingComment] = useState(command.data.comment || '');
@@ -81,12 +117,126 @@ export function OrderRow({ command, commandIndex, onEdit, onDelete, readOnly }) 
     }
   }, [editing, activeTab]);
 
+  // Load lab partners and patient conditions when lab tab is active.
+  useEffect(() => {
+    if (activeTab !== 'lab_order') return;
+    if (labPartners.length === 0) {
+      fetch(`${API_BASE}/lab-partners`)
+        .then(r => r.json())
+        .then(d => setLabPartners(d.lab_partners || []))
+        .catch(() => {});
+    }
+    if (patientId && patientConditions.length === 0) {
+      fetch(`${API_BASE}/patient-conditions?patient_id=${encodeURIComponent(patientId)}`)
+        .then(r => r.json())
+        .then(d => setPatientConditions(d.conditions || []))
+        .catch(() => {});
+    }
+  }, [activeTab]);
+
+  const doLabTestSearch = useCallback(async (q) => {
+    if (!labPartnerId || !q || q.length < 2) { setLabTestResults([]); setLabTestSearched(false); return; }
+    setLabTestSearching(true);
+    try {
+      const res = await fetch(
+        `${API_BASE}/lab-partner-tests?partner_id=${encodeURIComponent(labPartnerId)}&query=${encodeURIComponent(q)}`
+      );
+      const data = await res.json();
+      const alreadySelected = new Set(selectedTests.map(t => t.order_code));
+      setLabTestResults((data.tests || []).filter(t => !alreadySelected.has(t.order_code)));
+    } catch (err) {
+      setLabTestResults([]);
+    } finally {
+      setLabTestSearching(false);
+      setLabTestSearched(true);
+    }
+  }, [labPartnerId, selectedTests]);
+
+  const debouncedLabTestSearch = useDebounce(doLabTestSearch, DEBOUNCE_MS);
+
+  const handleLabTestInput = (e) => {
+    const val = e.target.value;
+    setLabTestQuery(val);
+    debouncedLabTestSearch(val);
+  };
+
+  const handleLabTestSelect = (test) => {
+    setSelectedTests([...selectedTests, test]);
+    setLabTestQuery('');
+    setLabTestResults([]);
+    if (labTestInputRef.current) labTestInputRef.current.focus();
+  };
+
+  const handleLabTestRemove = (orderCode) => {
+    setSelectedTests(selectedTests.filter(t => t.order_code !== orderCode));
+  };
+
+  const handleLabPartnerChange = (e) => {
+    const id = e.target.value;
+    setLabPartnerId(id);
+    const partner = labPartners.find(p => p.id === id);
+    setLabPartnerName(partner ? partner.name : '');
+    setSelectedTests([]);
+    setLabTestQuery('');
+    setLabTestResults([]);
+    setLabTestSearched(false);
+  };
+
+  const doDiagSearch = useCallback(async (q) => {
+    if (!q || q.length < 2) { setDiagResults([]); setDiagSearched(false); return; }
+    setDiagSearching(true);
+    try {
+      const res = await fetch(
+        `${API_BASE}/search-diagnoses?query=${encodeURIComponent(q)}`
+      );
+      const data = await res.json();
+      const alreadySelected = new Set(selectedDiagnoses.map(d => d.code));
+      setDiagResults((data.results || []).filter(d => !alreadySelected.has(d.code)));
+    } catch (err) {
+      setDiagResults([]);
+    } finally {
+      setDiagSearching(false);
+      setDiagSearched(true);
+    }
+  }, [selectedDiagnoses]);
+
+  const debouncedDiagSearch = useDebounce(doDiagSearch, DEBOUNCE_MS);
+
+  const handleDiagInput = (e) => {
+    const val = e.target.value;
+    setDiagQuery(val);
+    debouncedDiagSearch(val);
+  };
+
+  const handleDiagSelect = (diag) => {
+    setSelectedDiagnoses([...selectedDiagnoses, diag]);
+    setDiagQuery('');
+    setDiagResults([]);
+    setDiagSearched(false);
+    if (diagInputRef.current) diagInputRef.current.focus();
+  };
+
+  const handleDiagRemove = (code) => {
+    setSelectedDiagnoses(selectedDiagnoses.filter(d => d.code !== code));
+  };
+
+  const diagSuggestions = (() => {
+    if (!diagQuery && patientConditions.length > 0) {
+      const alreadySelected = new Set(selectedDiagnoses.map(d => d.code));
+      return patientConditions.filter(c => !alreadySelected.has(c.code));
+    }
+    return [];
+  })();
+
   // Close dropdown on outside click.
   useEffect(() => {
     if (!editing) return;
     const handler = (e) => {
       if (containerRef.current && !containerRef.current.contains(e.target)) {
         setMedResults([]);
+        setLabTestResults([]);
+        setDiagResults([]);
+        setDiagFocused(false);
       }
     };
     document.addEventListener('mousedown', handler);
@@ -94,7 +244,7 @@ export function OrderRow({ command, commandIndex, onEdit, onDelete, readOnly }) 
   }, [editing]);
 
   const doMedSearch = useCallback(async (q) => {
-    if (!q || q.length < 2) { setMedResults([]); return; }
+    if (!q || q.length < 2) { setMedResults([]); setMedSearched(false); return; }
     setMedSearching(true);
     try {
       const res = await fetch(`${API_BASE}/search-medications?query=${encodeURIComponent(q)}`);
@@ -104,6 +254,7 @@ export function OrderRow({ command, commandIndex, onEdit, onDelete, readOnly }) 
       setMedResults([]);
     } finally {
       setMedSearching(false);
+      setMedSearched(true);
     }
   }, []);
 
@@ -122,6 +273,7 @@ export function OrderRow({ command, commandIndex, onEdit, onDelete, readOnly }) 
     setSelectedMedDisplay(result.description);
     setMedQuery(result.description);
     setMedResults([]);
+    setMedSearched(false);
   };
 
   const handleSave = () => {
@@ -139,7 +291,16 @@ export function OrderRow({ command, commandIndex, onEdit, onDelete, readOnly }) 
         note_to_pharmacist: noteToPharmacist || null,
       };
     } else if (activeTab === 'lab_order') {
-      data = { comment: labComment };
+      data = {
+        lab_partner: labPartnerId || null,
+        lab_partner_name: labPartnerName || null,
+        tests_order_codes: selectedTests.map(t => t.order_code),
+        test_names: selectedTests.map(t => t.order_name),
+        diagnosis_codes: selectedDiagnoses.map(d => d.code),
+        diagnosis_displays: selectedDiagnoses.map(d => d.display),
+        fasting_required: labFasting,
+        comment: labComment || null,
+      };
     } else if (activeTab === 'imaging_order') {
       data = { comment: imagingComment, priority: imagingPriority };
     }
@@ -197,6 +358,11 @@ export function OrderRow({ command, commandIndex, onEdit, onDelete, readOnly }) 
                       `)}
                     </div>
                   `}
+                  ${!medSearching && medSearched && medResults.length === 0 && medQuery.length >= 2 && html`
+                    <div class="medication-search-dropdown">
+                      <div class="medication-search-result search-no-results">No medications found</div>
+                    </div>
+                  `}
                 </div>
                 ${selectedFdb && html`<span class="medication-structured-badge">FDB: ${selectedFdb}</span>`}
                 <div class="order-rx-row">
@@ -230,12 +396,134 @@ export function OrderRow({ command, commandIndex, onEdit, onDelete, readOnly }) 
               </div>
             `}
             ${activeTab === 'lab_order' && html`
-              <textarea
-                class="order-textarea"
-                value=${labComment}
-                onInput=${(e) => setLabComment(e.target.value)}
-                placeholder="Lab order details..."
-              />
+              <div class="order-lab-form">
+                <div class="order-rx-row">
+                  <div class="labeled-field" style="flex:1">
+                    <span class="labeled-field-label">Lab Partner</span>
+                    <select class="labeled-field-input" value=${labPartnerId} onChange=${handleLabPartnerChange}>
+                      <option value="">Select a lab partner...</option>
+                      ${labPartners.map(p => html`
+                        <option key=${p.id} value=${p.id}>${p.name}</option>
+                      `)}
+                    </select>
+                  </div>
+                </div>
+                ${labPartnerId && html`
+                  <div class="order-rx-row">
+                    <div class="lab-test-search-wrapper" style="flex:1">
+                      <div class="labeled-field" style="width:100%">
+                        <span class="labeled-field-label">Tests</span>
+                        <input
+                          ref=${labTestInputRef}
+                          type="text"
+                          class="labeled-field-input"
+                          value=${labTestQuery}
+                          onInput=${handleLabTestInput}
+                          placeholder="Search tests..."
+                        />
+                      </div>
+                      ${labTestSearching && html`<span class="lab-test-search-spinner">Searching...</span>`}
+                      ${labTestResults.length > 0 && html`
+                        <div class="lab-test-search-dropdown">
+                          ${labTestResults.map(t => html`
+                            <div
+                              key=${t.order_code}
+                              class="lab-test-search-result"
+                              onMouseDown=${(e) => { e.preventDefault(); handleLabTestSelect(t); }}
+                            >${t.order_name}${t.order_code ? ` (${t.order_code})` : ''}</div>
+                          `)}
+                        </div>
+                      `}
+                      ${!labTestSearching && labTestSearched && labTestResults.length === 0 && labTestQuery.length >= 2 && html`
+                        <div class="lab-test-search-dropdown">
+                          <div class="lab-test-search-result search-no-results">No tests found</div>
+                        </div>
+                      `}
+                    </div>
+                  </div>
+                  ${selectedTests.length > 0 && html`
+                    <div class="lab-selected-tests">
+                      ${selectedTests.map(t => html`
+                        <span class="lab-test-chip" key=${t.order_code}>
+                          ${t.order_name}
+                          <button type="button" class="lab-test-chip-remove" onClick=${() => handleLabTestRemove(t.order_code)}>×</button>
+                        </span>
+                      `)}
+                    </div>
+                  `}
+                `}
+                <div class="order-rx-row">
+                  <div class="diag-search-wrapper" style="flex:1">
+                    <div class="labeled-field" style="width:100%">
+                      <span class="labeled-field-label">Dx</span>
+                      <input
+                        ref=${diagInputRef}
+                        class="labeled-field-input"
+                        type="text"
+                        value=${diagQuery}
+                        onInput=${handleDiagInput}
+                        onFocus=${() => setDiagFocused(true)}
+                        onBlur=${() => setTimeout(() => setDiagFocused(false), 150)}
+                        placeholder="Search diagnoses..."
+                      />
+                    </div>
+                    ${diagSearching && html`<span class="diag-search-spinner">Searching...</span>`}
+                    ${diagResults.length > 0 && html`
+                      <div class="diag-search-dropdown">
+                        ${diagResults.map(d => html`
+                          <div
+                            key=${d.code}
+                            class="diag-search-result"
+                            onMouseDown=${(e) => { e.preventDefault(); handleDiagSelect(d); }}
+                          >${d.formatted_code || d.code} — ${d.display}</div>
+                        `)}
+                      </div>
+                    `}
+                    ${!diagSearching && diagSearched && diagResults.length === 0 && diagQuery.length >= 2 && html`
+                      <div class="diag-search-dropdown">
+                        <div class="diag-search-result search-no-results">No diagnoses found</div>
+                      </div>
+                    `}
+                    ${diagFocused && !diagQuery && diagSuggestions.length > 0 && html`
+                      <div class="diag-search-dropdown">
+                        <div class="diag-suggestion-header">Patient conditions</div>
+                        ${diagSuggestions.map(d => html`
+                          <div
+                            key=${d.code}
+                            class="diag-search-result"
+                            onMouseDown=${(e) => { e.preventDefault(); handleDiagSelect(d); }}
+                          >${d.formatted_code || d.code} — ${d.display}</div>
+                        `)}
+                      </div>
+                    `}
+                  </div>
+                </div>
+                ${selectedDiagnoses.length > 0 && html`
+                  <div class="lab-selected-tests">
+                    ${selectedDiagnoses.map(d => html`
+                      <span class="lab-test-chip" key=${d.code}>
+                        ${d.formatted_code || d.code}
+                        <button type="button" class="lab-test-chip-remove" onClick=${() => handleDiagRemove(d.code)}>×</button>
+                      </span>
+                    `)}
+                  </div>
+                `}
+                <div class="order-rx-row">
+                  <button type="button" class="task-quick-btn${!labFasting ? ' active' : ''}" onClick=${() => setLabFasting(false)}>Fasting Not Required</button>
+                  <button type="button" class="task-quick-btn${labFasting ? ' active' : ''}" onClick=${() => setLabFasting(true)}>Fasting Required</button>
+                </div>
+                <div class="order-rx-row">
+                  <div class="labeled-field" style="flex:1">
+                    <span class="labeled-field-label">Comment</span>
+                    <input
+                      class="labeled-field-input"
+                      type="text"
+                      value=${labComment}
+                      onInput=${(e) => setLabComment(e.target.value)}
+                    />
+                  </div>
+                </div>
+              </div>
             `}
             ${activeTab === 'imaging_order' && html`
               <div class="order-imaging-form">

--- a/hyperscribe/scribe/static/order-row.js
+++ b/hyperscribe/scribe/static/order-row.js
@@ -338,14 +338,17 @@ export function OrderRow({ command, commandIndex, onEdit, onDelete, readOnly, pa
             ${activeTab === 'prescribe' && html`
               <div class="order-rx-form">
                 <div class="medication-search-wrapper">
-                  <input
-                    ref=${medInputRef}
-                    type="text"
-                    class="order-input"
-                    value=${medQuery}
-                    onInput=${handleMedInput}
-                    placeholder="Search medications..."
-                  />
+                  <div class="labeled-field" style="width:100%">
+                    <span class="labeled-field-label">Medication</span>
+                    <input
+                      ref=${medInputRef}
+                      type="text"
+                      class="labeled-field-input"
+                      value=${medQuery}
+                      onInput=${handleMedInput}
+                      placeholder="Search medications..."
+                    />
+                  </div>
                   ${medSearching && html`<span class="medication-search-spinner">Searching...</span>`}
                   ${medResults.length > 0 && html`
                     <div class="medication-search-dropdown">
@@ -366,32 +369,34 @@ export function OrderRow({ command, commandIndex, onEdit, onDelete, readOnly, pa
                 </div>
                 ${selectedFdb && html`<span class="medication-structured-badge">FDB: ${selectedFdb}</span>`}
                 <div class="order-rx-row">
-                  <div class="labeled-field">
+                  <div class="labeled-field" style="flex:1">
                     <span class="labeled-field-label">Qty</span>
-                    <input class="labeled-field-input labeled-field-narrow" type="number" value=${quantity} onInput=${(e) => setQuantity(e.target.value)} min="0" />
+                    <input class="labeled-field-input" type="number" value=${quantity} onInput=${(e) => setQuantity(e.target.value)} min="0" />
                   </div>
-                  <div class="labeled-field">
+                  <div class="labeled-field" style="flex:1">
                     <span class="labeled-field-label">Days</span>
-                    <input class="labeled-field-input labeled-field-narrow" type="number" value=${daysSupply} onInput=${(e) => setDaysSupply(e.target.value)} min="0" />
+                    <input class="labeled-field-input" type="number" value=${daysSupply} onInput=${(e) => setDaysSupply(e.target.value)} min="0" />
                   </div>
-                  <div class="labeled-field">
+                  <div class="labeled-field" style="flex:1">
                     <span class="labeled-field-label">Refills</span>
-                    <input class="labeled-field-input labeled-field-narrow" type="number" value=${refills} onInput=${(e) => setRefills(e.target.value)} min="0" />
+                    <input class="labeled-field-input" type="number" value=${refills} onInput=${(e) => setRefills(e.target.value)} min="0" />
                   </div>
-                  <label class="order-checkbox-label">
-                    <input type="checkbox" checked=${substitutions} onChange=${(e) => setSubstitutions(e.target.checked)} />
-                    Sub
-                  </label>
                 </div>
                 <div class="order-rx-row">
                   <div class="labeled-field" style="flex:1">
                     <span class="labeled-field-label">Sig</span>
                     <input class="labeled-field-input" type="text" value=${sig} onInput=${(e) => setSig(e.target.value)} />
                   </div>
+                </div>
+                <div class="order-rx-row">
                   <div class="labeled-field" style="flex:1">
                     <span class="labeled-field-label">Note to Pharmacist</span>
                     <input class="labeled-field-input" type="text" value=${noteToPharmacist} onInput=${(e) => setNoteToPharmacist(e.target.value)} />
                   </div>
+                </div>
+                <div class="order-rx-row">
+                  <button type="button" class="task-quick-btn${substitutions ? ' active' : ''}" onClick=${() => setSubstitutions(true)}>Substitutions Allowed</button>
+                  <button type="button" class="task-quick-btn${!substitutions ? ' active' : ''}" onClick=${() => setSubstitutions(false)}>Substitutions Not Allowed</button>
                 </div>
               </div>
             `}

--- a/hyperscribe/scribe/static/soap-group.js
+++ b/hyperscribe/scribe/static/soap-group.js
@@ -66,7 +66,7 @@ function renderConditionCodes(conditions) {
   `;
 }
 
-export function SoapGroup({ title, groupColor, sections, commandBySectionKey, onEditCommand, onDeleteCommand, adHocCommands, assignees, onAddTask, onAddOrder, onAddMedication, onAddAllergy, readOnly, sectionConditions }) {
+export function SoapGroup({ title, groupColor, sections, commandBySectionKey, onEditCommand, onDeleteCommand, adHocCommands, assignees, onAddTask, onAddOrder, onAddMedication, onAddAllergy, readOnly, sectionConditions, patientId }) {
   const coveredKeys = getCoveredKeys(commandBySectionKey);
 
   return html`
@@ -233,6 +233,7 @@ export function SoapGroup({ title, groupColor, sections, commandBySectionKey, on
                   onEdit=${onEditCommand}
                   onDelete=${onDeleteCommand}
                   readOnly=${readOnly}
+                  patientId=${patientId}
                 />
               </div>
             `;

--- a/hyperscribe/scribe/static/soap-group.js
+++ b/hyperscribe/scribe/static/soap-group.js
@@ -66,7 +66,7 @@ function renderConditionCodes(conditions) {
   `;
 }
 
-export function SoapGroup({ title, groupColor, sections, commandBySectionKey, onEditCommand, onDeleteCommand, adHocCommands, assignees, onAddTask, onAddOrder, onAddMedication, onAddAllergy, readOnly, sectionConditions, patientId }) {
+export function SoapGroup({ title, groupColor, sections, commandBySectionKey, onEditCommand, onDeleteCommand, adHocCommands, assignees, onAddTask, onAddOrder, onAddMedication, onAddAllergy, readOnly, sectionConditions, patientId, noteId, staffId, staffName }) {
   const coveredKeys = getCoveredKeys(commandBySectionKey);
 
   return html`
@@ -234,6 +234,9 @@ export function SoapGroup({ title, groupColor, sections, commandBySectionKey, on
                   onDelete=${onDeleteCommand}
                   readOnly=${readOnly}
                   patientId=${patientId}
+                  noteId=${noteId}
+                  staffId=${staffId}
+                  staffName=${staffName}
                 />
               </div>
             `;

--- a/hyperscribe/scribe/static/styles.css
+++ b/hyperscribe/scribe/static/styles.css
@@ -638,6 +638,14 @@ h2 { margin-bottom: 4px; }
 .ad-hoc-buttons { display: flex; gap: 8px; padding: 8px 0 0; margin-top: 4px; border-top: 1px dashed #e8e8ec; }
 .ad-hoc-btn { padding: 6px 14px; font-size: 13px; font-weight: 600; color: #052B49; background: #fff; border: 1px dashed #052B49; border-radius: 6px; cursor: pointer; transition: all 0.15s; }
 .ad-hoc-btn:hover { background: #f5f5ff; border-style: solid; }
+.imaging-search-wrapper { position: relative; flex: 1; min-width: 0; max-width: 500px; }
+.imaging-search-spinner { font-size: 12px; color: #888; font-style: italic; margin-top: 2px; display: block; }
+.imaging-search-dropdown { position: absolute; top: 100%; left: 0; right: 0; z-index: 10; background: #fff; border: 1px solid #ddd; border-radius: 4px; box-shadow: 0 4px 12px rgba(0,0,0,0.1); max-height: 200px; overflow-y: auto; margin-top: 2px; }
+.imaging-search-result { padding: 8px 10px; font-size: 13px; cursor: pointer; border-bottom: 1px solid #f0f0f0; }
+.imaging-search-result:last-child { border-bottom: none; }
+.imaging-search-result:hover { background: #f5f5ff; }
+.imaging-center-name { font-weight: 500; }
+.imaging-center-desc { font-size: 11px; color: #666; margin-top: 2px; }
 
 .insert-btn {
   display: inline-block;

--- a/hyperscribe/scribe/static/styles.css
+++ b/hyperscribe/scribe/static/styles.css
@@ -527,7 +527,7 @@ h2 { margin-bottom: 4px; }
 .medication-documented-badge { font-size: 11px; font-weight: 600; padding: 2px 8px; border-radius: 10px; background: #e8e8ec; color: #888; white-space: nowrap; }
 .medication-unstructured-badge { font-size: 11px; font-weight: 600; padding: 2px 8px; border-radius: 10px; background: #fff3e0; color: #e65100; white-space: nowrap; }
 .medication-structured-badge { font-size: 11px; font-weight: 600; padding: 2px 8px; border-radius: 10px; background: #e8f5e9; color: #2e7d32; white-space: nowrap; }
-.medication-search-wrapper { position: relative; flex: 1; min-width: 0; }
+.medication-search-wrapper { position: relative; flex: 1; min-width: 0; max-width: 500px; }
 .medication-search-spinner { font-size: 12px; color: #888; font-style: italic; margin-top: 2px; display: block; }
 .medication-search-dropdown { position: absolute; top: 100%; left: 0; right: 0; z-index: 10; background: #fff; border: 1px solid #ddd; border-radius: 4px; box-shadow: 0 4px 12px rgba(0,0,0,0.1); max-height: 200px; overflow-y: auto; margin-top: 2px; }
 .medication-search-result { padding: 8px 10px; font-size: 13px; cursor: pointer; border-bottom: 1px solid #f0f0f0; }
@@ -603,9 +603,9 @@ h2 { margin-bottom: 4px; }
 .order-textarea { width: 100%; min-height: 60px; padding: 6px 8px; font-family: inherit; font-size: 13px; border: 1px solid #ddd; border-radius: 4px; resize: vertical; }
 .order-textarea:focus { outline: none; border-color: #052B49; }
 .order-rx-form { display: flex; flex-direction: column; gap: 6px; }
-.order-rx-row { display: flex; gap: 6px; align-items: center; }
+.order-rx-row { display: flex; gap: 6px; align-items: center; max-width: 500px; }
 /* Labeled field: [Label|Input] */
-.labeled-field { display: flex; border: 1px solid #ddd; border-radius: 4px; overflow: hidden; }
+.labeled-field { display: flex; border: 1px solid #ddd; border-radius: 4px; overflow: hidden; max-width: 500px; }
 .labeled-field:focus-within { border-color: #052B49; }
 .labeled-field-label { padding: 5px 8px; font-size: 12px; font-weight: 600; color: #888; background: #f5f5f8; border-right: 1px solid #ddd; white-space: nowrap; display: flex; align-items: center; }
 .labeled-field-input { flex: 1; padding: 5px 8px; font-family: inherit; font-size: 13px; border: none; outline: none; min-width: 0; }

--- a/hyperscribe/scribe/static/styles.css
+++ b/hyperscribe/scribe/static/styles.css
@@ -109,7 +109,7 @@ h2 { margin-bottom: 4px; }
   padding: 10px 24px;
   border: none;
   border-radius: 24px;
-  background: #5856d6;
+  background: #052B49;
   color: #fff;
   font-size: 15px;
   font-weight: 600;
@@ -198,7 +198,7 @@ h2 { margin-bottom: 4px; }
 }
 
 .entry-avatar.patient {
-  background: #5856d6;
+  background: #052B49;
 }
 
 .entry-avatar.unspecified {
@@ -311,7 +311,7 @@ h2 { margin-bottom: 4px; }
   font-size: 13px;
   font-weight: 700;
   letter-spacing: 0.5px;
-  color: #5856d6;
+  color: #052B49;
 }
 
 /* Content blocks with colored border per command type */
@@ -347,7 +347,7 @@ h2 { margin-bottom: 4px; }
 }
 
 .content-block--rfv { border-color: #f5a623; }
-.content-block--hpi { border-color: #5856d6; }
+.content-block--hpi { border-color: #052B49; }
 .content-block--plan_cmd { border-color: #34a853; }
 .content-block--vitals { border-color: #e8563a; }
 .content-block--medication { border-color: #007aff; }
@@ -365,7 +365,7 @@ h2 { margin-bottom: 4px; }
 .icd-codes { display: flex; flex-direction: column; gap: 2px; margin-top: 8px; padding-top: 8px; border-top: 1px solid #e8e8ec; }
 .icd-condition { font-size: 13px; line-height: 1.4; color: #333; }
 .icd-condition-name { color: #555; }
-.icd-code-badge { font-weight: 600; color: #4338ca; margin-left: 2px; }
+.icd-code-badge { font-weight: 600; color: #052B49; margin-left: 2px; }
 
 .edit-btn {
   padding: 4px 12px;
@@ -444,7 +444,7 @@ h2 { margin-bottom: 4px; }
 
 .section-textarea:focus {
   outline: none;
-  border-color: #5856d6;
+  border-color: #052B49;
 }
 
 /* Summary loading */
@@ -480,7 +480,7 @@ h2 { margin-bottom: 4px; }
 }
 
 .badge-rfv { background: #f5a623; }
-.badge-hpi { background: #5856d6; }
+.badge-hpi { background: #052B49; }
 .badge-plan { background: #34a853; }
 .badge-vitals { background: #e8563a; }
 .badge-history_review { background: #059669; }
@@ -493,7 +493,7 @@ h2 { margin-bottom: 4px; }
 .command-row.deselected { opacity: 0.45; }
 .command-row.editing { flex-direction: column; cursor: default; padding: 8px; background: #fafaff; border: 1px solid #e8e8ec; border-radius: 6px; }
 .command-row-textarea { width: 100%; min-height: 80px; padding: 8px; font-family: inherit; font-size: 14px; line-height: 1.6; border: 1px solid #ddd; border-radius: 4px; resize: vertical; margin-top: 6px; }
-.command-row-textarea:focus { outline: none; border-color: #5856d6; }
+.command-row-textarea:focus { outline: none; border-color: #052B49; }
 .command-row-actions { display: flex; gap: 8px; margin-top: 6px; }
 
 /* Inline vitals rows */
@@ -510,7 +510,7 @@ h2 { margin-bottom: 4px; }
 .vitals-bp-slash { font-weight: 600; color: #888; }
 .vitals-label { font-size: 12px; font-weight: 600; color: #888; min-width: 42px; }
 .vitals-input { width: 64px; padding: 4px 6px; font-size: 14px; border: 1px solid #ddd; border-radius: 4px; text-align: right; }
-.vitals-input:focus { outline: none; border-color: #5856d6; }
+.vitals-input:focus { outline: none; border-color: #052B49; }
 .vitals-unit { font-size: 12px; color: #999; }
 
 /* Medication rows */
@@ -523,7 +523,7 @@ h2 { margin-bottom: 4px; }
 .medication-row-text { font-size: 14px; line-height: 1.6; color: #333; }
 .medication-checkbox { cursor: pointer; flex-shrink: 0; }
 .medication-row-input { width: 100%; padding: 4px 8px; font-family: inherit; font-size: 14px; border: 1px solid #ddd; border-radius: 4px; }
-.medication-row-input:focus { outline: none; border-color: #5856d6; }
+.medication-row-input:focus { outline: none; border-color: #052B49; }
 .medication-documented-badge { font-size: 11px; font-weight: 600; padding: 2px 8px; border-radius: 10px; background: #e8e8ec; color: #888; white-space: nowrap; }
 .medication-unstructured-badge { font-size: 11px; font-weight: 600; padding: 2px 8px; border-radius: 10px; background: #fff3e0; color: #e65100; white-space: nowrap; }
 .medication-structured-badge { font-size: 11px; font-weight: 600; padding: 2px 8px; border-radius: 10px; background: #e8f5e9; color: #2e7d32; white-space: nowrap; }
@@ -546,7 +546,7 @@ h2 { margin-bottom: 4px; }
 .allergy-row-text { font-size: 14px; line-height: 1.6; color: #333; }
 .allergy-checkbox { cursor: pointer; flex-shrink: 0; }
 .allergy-row-input { width: 100%; padding: 4px 8px; font-family: inherit; font-size: 14px; border: 1px solid #ddd; border-radius: 4px; }
-.allergy-row-input:focus { outline: none; border-color: #5856d6; }
+.allergy-row-input:focus { outline: none; border-color: #052B49; }
 .allergy-documented-badge { font-size: 11px; font-weight: 600; padding: 2px 8px; border-radius: 10px; background: #e8e8ec; color: #888; white-space: nowrap; }
 .allergy-unstructured-badge { font-size: 11px; font-weight: 600; padding: 2px 8px; border-radius: 10px; background: #fff3e0; color: #e65100; white-space: nowrap; }
 .allergy-structured-badge { font-size: 11px; font-weight: 600; padding: 2px 8px; border-radius: 10px; background: #e8f5e9; color: #2e7d32; white-space: nowrap; }
@@ -572,17 +572,17 @@ h2 { margin-bottom: 4px; }
 .task-form { display: flex; align-items: center; gap: 6px; width: 100%; flex-wrap: wrap; }
 .task-title-input { width: 100%; }
 .task-input { padding: 6px 8px; font-family: inherit; font-size: 14px; border: 1px solid #ddd; border-radius: 4px; }
-.task-input:focus { outline: none; border-color: #5856d6; }
+.task-input:focus { outline: none; border-color: #052B49; }
 .task-date-picker { padding: 5px 6px; font-family: inherit; font-size: 13px; border: 1px solid #ddd; border-radius: 4px; width: 130px; }
-.task-date-picker:focus { outline: none; border-color: #5856d6; }
+.task-date-picker:focus { outline: none; border-color: #052B49; }
 .task-due-date { display: flex; align-items: center; gap: 4px; }
 .task-form .command-row-actions { width: 100%; margin-top: 2px; }
-.task-quick-btn { padding: 4px 10px; font-size: 12px; font-weight: 600; color: #5856d6; background: #f0f0ff; border: 1px solid #e0e0f0; border-radius: 14px; cursor: pointer; transition: all 0.15s; }
-.task-quick-btn:hover { background: #e8e8ff; border-color: #5856d6; }
-.task-quick-btn.active { background: #5856d6; color: #fff; border-color: #5856d6; }
+.task-quick-btn { padding: 4px 10px; font-size: 12px; font-weight: 600; color: #052B49; background: #f0f0ff; border: 1px solid #e0e0f0; border-radius: 14px; cursor: pointer; transition: all 0.15s; }
+.task-quick-btn:hover { background: #e8e8ff; border-color: #052B49; }
+.task-quick-btn.active { background: #052B49; color: #fff; border-color: #052B49; }
 .task-select { padding: 5px 6px; font-family: inherit; font-size: 13px; border: 1px solid #ddd; border-radius: 4px; background: #fff; }
-.task-select:focus { outline: none; border-color: #5856d6; }
-.task-meta-badge { font-size: 11px; font-weight: 600; padding: 2px 8px; border-radius: 10px; background: #f0f0ff; color: #5856d6; white-space: nowrap; }
+.task-select:focus { outline: none; border-color: #052B49; }
+.task-meta-badge { font-size: 11px; font-weight: 600; padding: 2px 8px; border-radius: 10px; background: #f0f0ff; color: #052B49; white-space: nowrap; }
 
 /* Order rows */
 .badge-prescribe { background: #e8563a; }
@@ -595,29 +595,48 @@ h2 { margin-bottom: 4px; }
 .order-layout { display: flex; gap: 10px; width: 100%; }
 .order-tabs { display: flex; flex-direction: column; gap: 4px; flex-shrink: 0; }
 .order-tab { padding: 8px 12px; font-size: 12px; font-weight: 700; text-align: center; border: 1px solid #e0e0f0; border-radius: 6px; background: #fff; color: #888; cursor: pointer; transition: all 0.15s; min-width: 64px; }
-.order-tab:hover { background: #f5f5ff; color: #5856d6; border-color: #5856d6; }
-.order-tab.active { background: #5856d6; color: #fff; border-color: #5856d6; }
+.order-tab:hover { background: #f5f5ff; color: #052B49; border-color: #052B49; }
+.order-tab.active { background: #052B49; color: #fff; border-color: #052B49; }
 .order-form { flex: 1; display: flex; flex-direction: column; gap: 6px; min-width: 0; }
 .order-input { width: 100%; padding: 6px 8px; font-family: inherit; font-size: 13px; border: 1px solid #ddd; border-radius: 4px; }
-.order-input:focus { outline: none; border-color: #5856d6; }
+.order-input:focus { outline: none; border-color: #052B49; }
 .order-textarea { width: 100%; min-height: 60px; padding: 6px 8px; font-family: inherit; font-size: 13px; border: 1px solid #ddd; border-radius: 4px; resize: vertical; }
-.order-textarea:focus { outline: none; border-color: #5856d6; }
+.order-textarea:focus { outline: none; border-color: #052B49; }
 .order-rx-form { display: flex; flex-direction: column; gap: 6px; }
 .order-rx-row { display: flex; gap: 6px; align-items: center; }
 /* Labeled field: [Label|Input] */
 .labeled-field { display: flex; border: 1px solid #ddd; border-radius: 4px; overflow: hidden; }
-.labeled-field:focus-within { border-color: #5856d6; }
+.labeled-field:focus-within { border-color: #052B49; }
 .labeled-field-label { padding: 5px 8px; font-size: 12px; font-weight: 600; color: #888; background: #f5f5f8; border-right: 1px solid #ddd; white-space: nowrap; display: flex; align-items: center; }
 .labeled-field-input { flex: 1; padding: 5px 8px; font-family: inherit; font-size: 13px; border: none; outline: none; min-width: 0; }
 .labeled-field-narrow { width: 48px; flex: none; }
 
 .order-checkbox-label { display: flex; align-items: center; gap: 6px; font-size: 13px; color: #555; cursor: pointer; padding: 4px 0; }
+.order-lab-form { display: flex; flex-direction: column; gap: 6px; }
+.lab-test-search-wrapper { position: relative; flex: 1; min-width: 0; }
+.lab-test-search-spinner { font-size: 12px; color: #888; font-style: italic; margin-top: 2px; display: block; }
+.lab-test-search-dropdown { position: absolute; top: 100%; left: 0; right: 0; z-index: 10; background: #fff; border: 1px solid #ddd; border-radius: 4px; box-shadow: 0 4px 12px rgba(0,0,0,0.1); max-height: 200px; overflow-y: auto; margin-top: 2px; }
+.lab-test-search-result { padding: 8px 10px; font-size: 13px; cursor: pointer; border-bottom: 1px solid #f0f0f0; }
+.lab-test-search-result:last-child { border-bottom: none; }
+.lab-test-search-result:hover { background: #f5f5ff; }
+.lab-selected-tests { display: flex; flex-wrap: wrap; gap: 4px; padding: 2px 0; }
+.lab-test-chip { display: inline-flex; align-items: center; gap: 4px; background: #e8e7f8; color: #3b3a8e; font-size: 12px; padding: 2px 8px; border-radius: 12px; }
+.lab-test-chip-remove { background: none; border: none; color: #3b3a8e; font-size: 14px; cursor: pointer; padding: 0 2px; line-height: 1; }
+.lab-test-chip-remove:hover { color: #d32f2f; }
+.diag-search-wrapper { position: relative; flex: 1; min-width: 0; }
+.diag-search-spinner { font-size: 12px; color: #888; font-style: italic; margin-top: 2px; display: block; }
+.diag-search-dropdown { position: absolute; top: 100%; left: 0; right: 0; z-index: 10; background: #fff; border: 1px solid #ddd; border-radius: 4px; box-shadow: 0 4px 12px rgba(0,0,0,0.1); max-height: 200px; overflow-y: auto; margin-top: 2px; }
+.diag-search-result { padding: 8px 10px; font-size: 13px; cursor: pointer; border-bottom: 1px solid #f0f0f0; }
+.diag-search-result:last-child { border-bottom: none; }
+.diag-search-result:hover { background: #f5f5ff; }
+.diag-suggestion-header { padding: 6px 10px; font-size: 11px; font-weight: 600; color: #888; background: #f9f9fc; border-bottom: 1px solid #f0f0f0; text-transform: uppercase; letter-spacing: 0.5px; }
+.search-no-results { color: #999; font-style: italic; cursor: default; }
 .order-imaging-form { display: flex; flex-direction: column; gap: 6px; }
 .order-priority { display: flex; gap: 6px; }
 
 /* Ad-hoc command buttons */
 .ad-hoc-buttons { display: flex; gap: 8px; padding: 8px 0 0; margin-top: 4px; border-top: 1px dashed #e8e8ec; }
-.ad-hoc-btn { padding: 6px 14px; font-size: 13px; font-weight: 600; color: #5856d6; background: #fff; border: 1px dashed #5856d6; border-radius: 6px; cursor: pointer; transition: all 0.15s; }
+.ad-hoc-btn { padding: 6px 14px; font-size: 13px; font-weight: 600; color: #052B49; background: #fff; border: 1px dashed #052B49; border-radius: 6px; cursor: pointer; transition: all 0.15s; }
 .ad-hoc-btn:hover { background: #f5f5ff; border-style: solid; }
 
 .insert-btn {
@@ -673,7 +692,7 @@ h2 { margin-bottom: 4px; }
   border-radius: 6px;
   resize: vertical;
 }
-.dev-seed-textarea:focus { outline: none; border-color: #5856d6; }
+.dev-seed-textarea:focus { outline: none; border-color: #052B49; }
 .dev-seed-actions { display: flex; gap: 8px; margin-top: 12px; }
 
 /* ── Summary empty state ── */

--- a/hyperscribe/scribe/static/summary.js
+++ b/hyperscribe/scribe/static/summary.js
@@ -52,7 +52,7 @@ function buildCommandBySectionKey(commands) {
   return map;
 }
 
-function renderSoapGroups(sections, commandBySectionKey, onEditCommand, onDeleteCommand, { adHocCommands, objectiveAdHocCommands, assignees, onAddTask, onAddOrder, onAddMedication, onAddAllergy, readOnly, sectionConditions } = {}) {
+function renderSoapGroups(sections, commandBySectionKey, onEditCommand, onDeleteCommand, { adHocCommands, objectiveAdHocCommands, assignees, onAddTask, onAddOrder, onAddMedication, onAddAllergy, readOnly, sectionConditions, patientId } = {}) {
   return SOAP_GROUPS
     .map(group => {
       const matching = sections.filter(s => group.keys.has(s.key.toLowerCase()));
@@ -75,12 +75,13 @@ function renderSoapGroups(sections, commandBySectionKey, onEditCommand, onDelete
         onAddAllergy=${isObjective ? onAddAllergy : null}
         readOnly=${readOnly}
         sectionConditions=${sectionConditions}
+        patientId=${patientId}
       />`;
     })
     .filter(Boolean);
 }
 
-export function Summary({ noteId }) {
+export function Summary({ noteId, patientId }) {
   const [noteData, setNoteData] = useState(null);
   const [generating, setGenerating] = useState(true);
   const [error, setError] = useState(null);
@@ -355,7 +356,12 @@ export function Summary({ noteId }) {
           return { ...cmd, command_type: type, data: newData, display: newData.medication_text || '' };
         }
         if (type === 'lab_order') {
-          return { ...cmd, command_type: type, data: newData, display: newData.comment || '' };
+          const parts = [];
+          if (newData.lab_partner_name) parts.push(newData.lab_partner_name);
+          if (newData.test_names && newData.test_names.length) parts.push(newData.test_names.join(', '));
+          if (newData.comment) parts.push(newData.comment);
+          if (newData.fasting_required) parts.push('Fasting');
+          return { ...cmd, command_type: type, data: newData, display: parts.join(' | ') || '' };
         }
         if (type === 'imaging_order') {
           const parts = [newData.comment, newData.priority].filter(Boolean);
@@ -556,6 +562,7 @@ export function Summary({ noteId }) {
           onAddAllergy: approved ? null : handleAddAllergy,
           readOnly: approved,
           sectionConditions,
+          patientId,
         })}
         ${extracting && html`<p class="generating-message">Extracting commands...</p>`}
         ${recommending && html`<p class="generating-message">Finding recommendations...</p>`}

--- a/hyperscribe/scribe/static/summary.js
+++ b/hyperscribe/scribe/static/summary.js
@@ -52,7 +52,7 @@ function buildCommandBySectionKey(commands) {
   return map;
 }
 
-function renderSoapGroups(sections, commandBySectionKey, onEditCommand, onDeleteCommand, { adHocCommands, objectiveAdHocCommands, assignees, onAddTask, onAddOrder, onAddMedication, onAddAllergy, readOnly, sectionConditions, patientId } = {}) {
+function renderSoapGroups(sections, commandBySectionKey, onEditCommand, onDeleteCommand, { adHocCommands, objectiveAdHocCommands, assignees, onAddTask, onAddOrder, onAddMedication, onAddAllergy, readOnly, sectionConditions, patientId, noteId, staffId, staffName } = {}) {
   return SOAP_GROUPS
     .map(group => {
       const matching = sections.filter(s => group.keys.has(s.key.toLowerCase()));
@@ -76,12 +76,15 @@ function renderSoapGroups(sections, commandBySectionKey, onEditCommand, onDelete
         readOnly=${readOnly}
         sectionConditions=${sectionConditions}
         patientId=${patientId}
+        noteId=${noteId}
+        staffId=${staffId}
+        staffName=${staffName}
       />`;
     })
     .filter(Boolean);
 }
 
-export function Summary({ noteId, patientId }) {
+export function Summary({ noteId, patientId, staffId, staffName }) {
   const [noteData, setNoteData] = useState(null);
   const [generating, setGenerating] = useState(true);
   const [error, setError] = useState(null);
@@ -364,7 +367,7 @@ export function Summary({ noteId, patientId }) {
           return { ...cmd, command_type: type, data: newData, display: parts.join(' | ') || '' };
         }
         if (type === 'imaging_order') {
-          const parts = [newData.comment, newData.priority].filter(Boolean);
+          const parts = [newData.image_display, newData.additional_details, newData.comment, newData.priority].filter(Boolean);
           return { ...cmd, command_type: type, data: newData, display: parts.join(' | ') };
         }
         const field = cmd.command_type === 'rfv' ? 'comment' : 'narrative';
@@ -563,6 +566,9 @@ export function Summary({ noteId, patientId }) {
           readOnly: approved,
           sectionConditions,
           patientId,
+          noteId,
+          staffId,
+          staffName,
         })}
         ${extracting && html`<p class="generating-message">Extracting commands...</p>`}
         ${recommending && html`<p class="generating-message">Finding recommendations...</p>`}

--- a/tests/hyperscribe/scribe/commands/test_lab_order.py
+++ b/tests/hyperscribe/scribe/commands/test_lab_order.py
@@ -23,15 +23,41 @@ def test_build() -> None:
     parser = LabOrderParser()
     with patch("hyperscribe.scribe.commands.lab_order.LabOrderCommand") as mock_cmd:
         mock_cmd.return_value = MagicMock()
-        parser.build({"comment": "CBC with differential"}, "note-uuid", "cmd-uuid")
+        parser.build(
+            {
+                "lab_partner": "partner-uuid",
+                "tests_order_codes": ["CBC", "BMP"],
+                "diagnosis_codes": ["E11.9"],
+                "fasting_required": True,
+                "comment": "CBC with differential",
+            },
+            "note-uuid",
+            "cmd-uuid",
+        )
 
-    mock_cmd.assert_called_once_with(comment="CBC with differential", note_uuid="note-uuid", command_uuid="cmd-uuid")
+    mock_cmd.assert_called_once_with(
+        lab_partner="partner-uuid",
+        tests_order_codes=["CBC", "BMP"],
+        diagnosis_codes=["E11.9"],
+        fasting_required=True,
+        comment="CBC with differential",
+        note_uuid="note-uuid",
+        command_uuid="cmd-uuid",
+    )
 
 
-def test_build_empty_comment() -> None:
+def test_build_empty() -> None:
     parser = LabOrderParser()
     with patch("hyperscribe.scribe.commands.lab_order.LabOrderCommand") as mock_cmd:
         mock_cmd.return_value = MagicMock()
         parser.build({}, "note-uuid", "cmd-uuid")
 
-    mock_cmd.assert_called_once_with(comment=None, note_uuid="note-uuid", command_uuid="cmd-uuid")
+    mock_cmd.assert_called_once_with(
+        lab_partner=None,
+        tests_order_codes=[],
+        diagnosis_codes=[],
+        fasting_required=False,
+        comment=None,
+        note_uuid="note-uuid",
+        command_uuid="cmd-uuid",
+    )


### PR DESCRIPTION
## Summary
- Lab order form expanded with structured fields: lab partner selection, searchable test multi-select with chips, ICD-10 diagnosis search with patient condition suggestions, fasting toggle buttons, and comment
- Rx form layout improved: medication search as labeled field, qty/days/refills fill row width, sig and note to pharmacist on separate rows, substitutions as toggle buttons
- Imaging order form with full field support: image code search via science service, diagnosis chip-select with patient condition suggestions, order details, comment, priority toggle (Routine/Urgent), ordering provider autocomplete (defaults to logged-in user), and imaging center search (zip-code-based radiology contact lookup)
- Backend endpoints added for lab partners, lab partner tests, patient conditions, diagnosis search, imaging code search, ordering providers, and imaging center search
- staffId/staffName/noteId threaded through component tree for provider defaults and center lookups
- No-results feedback added to all search fields across the UI
- Input fields capped at 500px max width for consistency
- Purple accent colors replaced with #052B49

## Status
- Labs: looking good
- Rx form: looking good
- Imaging orders: looking good