### PR TITLE
Get mapped ICD-10 when available, then fuzzy match

### DIFF
--- a/hyperscribe/scribe/api/session_view.py
+++ b/hyperscribe/scribe/api/session_view.py
@@ -81,11 +81,14 @@ def _save_progress(note_id: str, step: int, total: int, label: str) -> None:
 
 
 def _serialize_condition(condition: Condition) -> dict[str, Any]:
-    return {
+    result: dict[str, Any] = {
         "display": condition.display,
         "clinical_status": condition.clinical_status,
         "coding": [{"system": e.system, "code": e.code, "display": e.display} for e in condition.coding],
     }
+    if condition.corresponding_note_problem is not None:
+        result["corresponding_note_problem"] = condition.corresponding_note_problem
+    return result
 
 
 def _match_conditions_to_sections(

--- a/hyperscribe/scribe/backend/models.py
+++ b/hyperscribe/scribe/backend/models.py
@@ -66,10 +66,12 @@ class Condition:
         display: str,
         clinical_status: str,
         coding: list[CodingEntry] | None = None,
+        corresponding_note_problem: str | None = None,
     ) -> None:
         self.display = display
         self.clinical_status = clinical_status
         self.coding: list[CodingEntry] = coding if coding is not None else []
+        self.corresponding_note_problem = corresponding_note_problem
 
 
 class Observation:

--- a/hyperscribe/scribe/clients/nabla/backend.py
+++ b/hyperscribe/scribe/clients/nabla/backend.py
@@ -68,6 +68,7 @@ class NablaBackend(ScribeBackend):
                 "locale": _NOTE_LOCALE,
                 "template": _NOTE_TEMPLATE,
             },
+            "include_corresponding_note_problems": True,
         }
         raw = self._rest_client.generate_normalized_data(payload)
         return self._parse_normalized_data(raw)
@@ -154,6 +155,7 @@ class NablaBackend(ScribeBackend):
                     display=cond.get("display", ""),
                     clinical_status=cond.get("clinical_status", ""),
                     coding=coding,
+                    corresponding_note_problem=cond.get("corresponding_note_problem"),
                 )
             )
 

--- a/hyperscribe/scribe/commands/ap_split.py
+++ b/hyperscribe/scribe/commands/ap_split.py
@@ -171,7 +171,13 @@ def split_plan_into_diagnoses(
     matched_set: set[int] = set()
 
     for block in blocks:
-        matched = match_condition(block.header, codes)
+        # Prefer exact match via Nabla's corresponding_note_problem field.
+        matched = next(
+            (c for c in codes if c.get("corresponding_note_problem") and c["corresponding_note_problem"] == block.header),
+            None,
+        )
+        if not matched:
+            matched = match_condition(block.header, codes)
         icd: dict[str, Any] | None = None
         if matched:
             icd = next((cd for cd in (matched.get("coding") or []) if cd.get("code")), None)

--- a/hyperscribe/scribe/commands/ap_split.py
+++ b/hyperscribe/scribe/commands/ap_split.py
@@ -29,6 +29,18 @@ _STOP_WORDS = frozenset(
         "probable",
         "likely",
         "suspected",
+        "unspecified",
+        "specified",
+        "other",
+        "disorder",
+        "disease",
+        "syndrome",
+        "condition",
+        "type",
+        "acute",
+        "chronic",
+        "primary",
+        "secondary",
     }
 )
 

--- a/hyperscribe/scribe/commands/ap_split.py
+++ b/hyperscribe/scribe/commands/ap_split.py
@@ -185,7 +185,12 @@ def split_plan_into_diagnoses(
     for block in blocks:
         # Prefer exact match via Nabla's corresponding_note_problem field.
         matched = next(
-            (c for c in codes if c.get("corresponding_note_problem") and c["corresponding_note_problem"] == block.header),
+            (
+                c
+                for c in codes
+                if c.get("corresponding_note_problem")
+                and c["corresponding_note_problem"].strip().lower() == block.header.strip().lower()
+            ),
             None,
         )
         if not matched:

--- a/tests/hyperscribe/scribe/commands/test_ap_split.py
+++ b/tests/hyperscribe/scribe/commands/test_ap_split.py
@@ -90,6 +90,17 @@ def test_significant_words_filters_stop_words() -> None:
     assert "brown" in words
 
 
+def test_significant_words_filters_medical_qualifiers() -> None:
+    words = significant_words("Diarrhea, unspecified")
+    assert "unspecified" not in words
+    assert "diarrhea" in words
+    words = significant_words("Other specified anxiety disorders")
+    assert "other" not in words
+    assert "specified" not in words
+    assert "anxiety" in words
+    assert "disorders" in words
+
+
 def test_significant_words_filters_short() -> None:
     words = significant_words("I am ok")
     assert "i" not in words  # single char after lowering
@@ -98,9 +109,9 @@ def test_significant_words_filters_short() -> None:
 
 
 def test_significant_words_strips_punctuation() -> None:
-    words = significant_words("Headache, chronic")
+    words = significant_words("Headache, persistent")
     assert "headache" in words
-    assert "chronic" in words
+    assert "persistent" in words
 
 
 # --- word_overlap ---
@@ -325,6 +336,19 @@ def test_split_plan_corresponding_note_problem() -> None:
     assert len(updated) == 1
     assert updated[0]["data"]["icd10_code"] == "J06.9"
     assert updated[0]["data"]["accepted"] is True
+
+
+def test_unspecified_does_not_cause_false_match() -> None:
+    """'unspecified' should not cause unrelated conditions to match via word overlap."""
+    conditions = [
+        {
+            "display": "Major depressive disorder",
+            "coding": [{"code": "F32.9", "display": "Major depressive disorder, single episode, unspecified"}],
+        },
+    ]
+    assert match_condition("Diarrhea unspecified", conditions) is None
+    assert match_condition("Constipation unspecified", conditions) is None
+    assert match_condition("Unspecified disorder of adnexa", conditions) is None
 
 
 def test_split_plan_corresponding_note_problem_prevents_wrong_match() -> None:

--- a/tests/hyperscribe/scribe/commands/test_ap_split.py
+++ b/tests/hyperscribe/scribe/commands/test_ap_split.py
@@ -300,3 +300,64 @@ def test_split_plan_uses_plan_section_key() -> None:
     assert updated[0]["command_type"] == "diagnose"
     assert updated[0]["section_key"] == "plan"
     assert unmatched == []
+
+
+def test_split_plan_corresponding_note_problem() -> None:
+    """When corresponding_note_problem is set, it takes priority over fuzzy matching."""
+    commands = [
+        {
+            "command_type": "plan",
+            "data": {"narrative": "Acute upper respiratory infection\n- Rest and fluids"},
+            "section_key": "assessment_and_plan",
+        },
+    ]
+    # The display text does NOT match the header, but corresponding_note_problem does.
+    section_conditions = {
+        "assessment_and_plan": [
+            {
+                "display": "URI",
+                "coding": [{"code": "J06.9", "display": "Acute upper respiratory infection, unspecified"}],
+                "corresponding_note_problem": "Acute upper respiratory infection",
+            },
+        ],
+    }
+    updated, unmatched = split_plan_into_diagnoses(commands, section_conditions)
+    assert len(updated) == 1
+    assert updated[0]["data"]["icd10_code"] == "J06.9"
+    assert updated[0]["data"]["accepted"] is True
+
+
+def test_split_plan_corresponding_note_problem_prevents_wrong_match() -> None:
+    """corresponding_note_problem prevents unrelated conditions from matching via word overlap."""
+    commands = [
+        {
+            "command_type": "plan",
+            "data": {
+                "narrative": (
+                    "Diarrhea, unspecified\n- Monitor hydration\n\n"
+                    "Sarcoidosis, unspecified\n- Continue current treatment"
+                )
+            },
+            "section_key": "assessment_and_plan",
+        },
+    ]
+    section_conditions = {
+        "assessment_and_plan": [
+            {
+                "display": "Diarrhea, unspecified",
+                "coding": [{"code": "R19.7", "display": "Diarrhea, unspecified"}],
+                "corresponding_note_problem": "Diarrhea, unspecified",
+            },
+            {
+                "display": "Sarcoidosis, unspecified",
+                "coding": [{"code": "D86.9", "display": "Sarcoidosis, unspecified"}],
+                "corresponding_note_problem": "Sarcoidosis, unspecified",
+            },
+        ],
+    }
+    updated, unmatched = split_plan_into_diagnoses(commands, section_conditions)
+    assert len(updated) == 2
+    # Diarrhea gets R19.7, NOT D86.9
+    assert updated[0]["data"]["icd10_code"] == "R19.7"
+    # Sarcoidosis gets D86.9
+    assert updated[1]["data"]["icd10_code"] == "D86.9"

--- a/tests/hyperscribe/scribe/commands/test_ap_split.py
+++ b/tests/hyperscribe/scribe/commands/test_ap_split.py
@@ -385,3 +385,49 @@ def test_split_plan_corresponding_note_problem_prevents_wrong_match() -> None:
     assert updated[0]["data"]["icd10_code"] == "R19.7"
     # Sarcoidosis gets D86.9
     assert updated[1]["data"]["icd10_code"] == "D86.9"
+
+
+def test_split_plan_corresponding_note_problem_case_insensitive() -> None:
+    """corresponding_note_problem matching is case-insensitive."""
+    commands = [
+        {
+            "command_type": "plan",
+            "data": {"narrative": "acute upper respiratory infection\n- Rest and fluids"},
+            "section_key": "assessment_and_plan",
+        },
+    ]
+    section_conditions = {
+        "assessment_and_plan": [
+            {
+                "display": "URI",
+                "coding": [{"code": "J06.9", "display": "Acute upper respiratory infection, unspecified"}],
+                "corresponding_note_problem": "Acute Upper Respiratory Infection",
+            },
+        ],
+    }
+    updated, unmatched = split_plan_into_diagnoses(commands, section_conditions)
+    assert len(updated) == 1
+    assert updated[0]["data"]["icd10_code"] == "J06.9"
+
+
+def test_split_plan_corresponding_note_problem_strips_whitespace() -> None:
+    """corresponding_note_problem matching ignores leading/trailing whitespace."""
+    commands = [
+        {
+            "command_type": "plan",
+            "data": {"narrative": "Headache\n- Take ibuprofen"},
+            "section_key": "assessment_and_plan",
+        },
+    ]
+    section_conditions = {
+        "assessment_and_plan": [
+            {
+                "display": "Headache",
+                "coding": [{"code": "R51.9", "display": "Headache, unspecified"}],
+                "corresponding_note_problem": "  Headache  ",
+            },
+        ],
+    }
+    updated, unmatched = split_plan_into_diagnoses(commands, section_conditions)
+    assert len(updated) == 1
+    assert updated[0]["data"]["icd10_code"] == "R51.9"


### PR DESCRIPTION
Made two adjustments to address customer reported condition mismatches:

1) generate-normalized-data endpoint has an include_corresponding_note_problems flag, which is set to false by default. I flipped it to "true" so we can now use their mapping when available to match Assessment & Plan headers to the related condition. If it's not available, we fallback to the original fuzzy match

2) The reported mismatches were using "unspecified" to meet the 0.5 overlap threshold, so I also added some common causes of mismatch to the stop list