### PR TITLE
fix: remove unauthorized module assignment

### DIFF
--- a/hyperscribe/libraries/canvas_science.py
+++ b/hyperscribe/libraries/canvas_science.py
@@ -179,11 +179,9 @@ class CanvasScience:
         for _ in range(Constants.MAX_ATTEMPTS_CANVAS_SERVICES):
             try:
                 if is_ontologies:
-                    ontologies_http._MAX_REQUEST_TIMEOUT_SECONDS = 7
                     response = ontologies_http.get_json(url, headers)
                     source = "ontologies"
                 else:
-                    science_http._MAX_REQUEST_TIMEOUT_SECONDS = 7
                     response = science_http.get_json(url, headers)
                     source = "science"
 


### PR DESCRIPTION
This pull request makes a minor update to the `get_attempts` method in `canvas_science.py`. The change removes the lines that set the `_MAX_REQUEST_TIMEOUT_SECONDS` attribute for both `ontologies_http` and `science_http` before making HTTP requests. This simplifies the method and relies on the default timeout settings for these HTTP clients.

- Removed manual setting of `_MAX_REQUEST_TIMEOUT_SECONDS` for `ontologies_http` and `science_http` in the `get_attempts` method, defaulting to the clients' existing timeout configuration.