### PR TITLE
Improve HPI clinical output: demographics, writing style, and structured context

### DIFF
--- a/hyperscribe/scribe/api/scribe_view.py
+++ b/hyperscribe/scribe/api/scribe_view.py
@@ -38,7 +38,10 @@ class ScribeView(StaffSessionAuthMixin, SimpleAPI):
         logged_in_staff = Staff.objects.get(id=staff_id)
 
         note = Note.objects.select_related("patient", "provider").get(id=note_id)
-        patient_name = note.patient.full_name
+        patient = note.patient
+        patient_name = patient.full_name
+        patient_birth_date = patient.birth_date.isoformat() if patient.birth_date else ""
+        patient_gender = str(patient.sex_at_birth) if patient.sex_at_birth else ""
         note_editable = Helper.editable_note(note.dbid)
 
         # Use the provider stored with the transcript (the user who recorded it).
@@ -63,7 +66,9 @@ class ScribeView(StaffSessionAuthMixin, SimpleAPI):
                 "provider_name": provider_name,
                 "provider_photo_url": provider_photo_url,
                 "patient_name": patient_name,
-                "patient_id": str(note.patient.id),
+                "patient_birth_date": patient_birth_date,
+                "patient_gender": patient_gender,
+                "patient_id": str(patient.id),
                 "staff_id": str(staff_id),
                 "staff_name": logged_in_staff.credentialed_name,
                 "debug_mode": "true" if self.secrets.get("ScribeDebugStaffers") else "",

--- a/hyperscribe/scribe/clients/nabla/backend.py
+++ b/hyperscribe/scribe/clients/nabla/backend.py
@@ -217,10 +217,9 @@ class NablaBackend(ScribeBackend):
 
         hpi_custom_instructions = (
             f"Begin this section with a single opening sentence in this exact format: {opening}\n"
-            "Write in complete sentences using the patient's name or appropriate pronouns as the subject. "
+            "Write in complete sentences with clear subjects. "
             "Do not use sentence fragments or omit the subject of a sentence. "
-            "Use formal medical terminology and a professional clinical narrative tone throughout. "
-            "Provide a thorough and comprehensive narrative.\n"
+            "Use formal medical terminology and a professional clinical narrative tone throughout.\n"
             "Include ROS at the end of this section and add positive and negative symptoms as mentioned.\n"
             "ROS\n"
             "General:\n"
@@ -250,31 +249,22 @@ class NablaBackend(ScribeBackend):
                 {
                     "section_key": "HISTORY_OF_PRESENT_ILLNESS",
                     "style": "PARAGRAPH",
-                    "level_of_detail": "DETAILED",
+                    "level_of_detail": "DEFAULT",
                     "custom_instruction": hpi_custom_instructions,
                 },
             ],
         }
-        # NOTE: structured_context with patient_demographics is supported by the
-        # Nabla API (see nabla-integration-improvements.md) and the frontend now
-        # sends patient_context. However, testing showed that when structured_context
-        # is included in the payload, Nabla produces significantly shorter and less
-        # detailed HPI output — omitting relevant medical history, medications, and
-        # social context that it otherwise extracts from the transcript. Until this
-        # is resolved (possibly via Nabla API version or additional parameters),
-        # demographics are baked into the custom_instruction above instead.
-        #
-        # if patient_context is not None:
-        #     structured_context: dict[str, Any] = {
-        #         "patient_demographics": {
-        #             "name": patient_context.name,
-        #         },
-        #     }
-        #     if patient_context.birth_date:
-        #         structured_context["patient_demographics"]["birth_date"] = patient_context.birth_date
-        #     if patient_context.gender:
-        #         structured_context["patient_demographics"]["gender"] = _GENDER_API_MAP.get(
-        #             patient_context.gender, patient_context.gender.upper()
-        #         )
-        #     payload["structured_context"] = structured_context
+        if patient_context is not None:
+            structured_context: dict[str, Any] = {
+                "patient_demographics": {
+                    "name": patient_context.name,
+                },
+            }
+            if patient_context.birth_date:
+                structured_context["patient_demographics"]["birth_date"] = patient_context.birth_date
+            if patient_context.gender:
+                structured_context["patient_demographics"]["gender"] = NablaBackend._GENDER_API_MAP.get(
+                    patient_context.gender, patient_context.gender.upper()
+                )
+            payload["structured_context"] = structured_context
         return payload

--- a/hyperscribe/scribe/clients/nabla/backend.py
+++ b/hyperscribe/scribe/clients/nabla/backend.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from datetime import date
 from typing import Any
 
 from hyperscribe.scribe.backend import (
@@ -182,14 +183,45 @@ class NablaBackend(ScribeBackend):
         return NormalizedData(conditions=conditions, observations=observations)
 
     @staticmethod
+    def _age_from_birth_date(birth_date: str) -> int | None:
+        """Calculate age in years from a YYYY-MM-DD birth date string."""
+        try:
+            dob = date.fromisoformat(birth_date)
+        except (ValueError, TypeError):
+            return None
+        today = date.today()
+        return today.year - dob.year - ((today.month, today.day) < (dob.month, dob.day))
+
+    @staticmethod
+    def _display_gender(gender: str) -> str | None:
+        """Map a gender value to a lowercase display string for the HPI opening line."""
+        gender_display = {"M": "male", "F": "female", "MALE": "male", "FEMALE": "female"}
+        return gender_display.get(gender) or gender.lower() or None
+
+    _GENDER_API_MAP: dict[str, str] = {"M": "MALE", "F": "FEMALE", "male": "MALE", "female": "FEMALE"}
+
+    @staticmethod
     def _build_note_payload(
         transcript: Transcript,
         patient_context: PatientContext | None,
     ) -> dict[str, Any]:
-        demographics = "Start this section with patient's name, age, gender, and [reason for visit as mentioned].\n"
+        # Build the HPI opening line with concrete demographics when available.
+        if patient_context is not None:
+            name = patient_context.name or "[PATIENT_NAME]"
+            age = NablaBackend._age_from_birth_date(patient_context.birth_date)
+            age_str = str(age) if age is not None else "[AGE]"
+            gender_str = NablaBackend._display_gender(patient_context.gender) or "[GENDER]"
+            opening = f"'{name} is a {age_str}-year-old {gender_str} who presents today for [CHIEF COMPLAINT].'"
+        else:
+            opening = "'[PATIENT_NAME] is a [AGE]-year-old [GENDER] who presents today for [CHIEF COMPLAINT].'"
+
         hpi_custom_instructions = (
-            demographics
-            + "Include ROS at the end of this section and add positive and negative symptoms as mentioned.\n"
+            f"Begin this section with a single opening sentence in this exact format: {opening}\n"
+            "Write in complete sentences using the patient's name or appropriate pronouns as the subject. "
+            "Do not use sentence fragments or omit the subject of a sentence. "
+            "Use formal medical terminology and a professional clinical narrative tone throughout. "
+            "Provide a thorough and comprehensive narrative.\n"
+            "Include ROS at the end of this section and add positive and negative symptoms as mentioned.\n"
             "ROS\n"
             "General:\n"
             "Skin:\n"
@@ -218,18 +250,31 @@ class NablaBackend(ScribeBackend):
                 {
                     "section_key": "HISTORY_OF_PRESENT_ILLNESS",
                     "style": "PARAGRAPH",
+                    "level_of_detail": "DETAILED",
                     "custom_instruction": hpi_custom_instructions,
                 },
             ],
         }
-        if patient_context is not None:
-            payload["patient_context"] = {
-                "name": patient_context.name,
-                "birth_date": patient_context.birth_date,
-                "gender": patient_context.gender,
-                "encounter_diagnoses": [
-                    {"system": c.system, "code": c.code, "display": c.display}
-                    for c in patient_context.encounter_diagnoses
-                ],
-            }
+        # NOTE: structured_context with patient_demographics is supported by the
+        # Nabla API (see nabla-integration-improvements.md) and the frontend now
+        # sends patient_context. However, testing showed that when structured_context
+        # is included in the payload, Nabla produces significantly shorter and less
+        # detailed HPI output — omitting relevant medical history, medications, and
+        # social context that it otherwise extracts from the transcript. Until this
+        # is resolved (possibly via Nabla API version or additional parameters),
+        # demographics are baked into the custom_instruction above instead.
+        #
+        # if patient_context is not None:
+        #     structured_context: dict[str, Any] = {
+        #         "patient_demographics": {
+        #             "name": patient_context.name,
+        #         },
+        #     }
+        #     if patient_context.birth_date:
+        #         structured_context["patient_demographics"]["birth_date"] = patient_context.birth_date
+        #     if patient_context.gender:
+        #         structured_context["patient_demographics"]["gender"] = _GENDER_API_MAP.get(
+        #             patient_context.gender, patient_context.gender.upper()
+        #         )
+        #     payload["structured_context"] = structured_context
         return payload

--- a/hyperscribe/scribe/static/app.js
+++ b/hyperscribe/scribe/static/app.js
@@ -6,7 +6,7 @@ import { Audit } from '/plugin-io/api/hyperscribe/scribe/static/audit.js';
 
 const html = htm.bind(h);
 
-export function App({ noteId, view, providerName, providerPhotoUrl, patientName, patientId, staffId, staffName, debugMode, noteEditable, alertFacilityEnabled }) {
+export function App({ noteId, view, providerName, providerPhotoUrl, patientName, patientBirthDate, patientGender, patientId, staffId, staffName, debugMode, noteEditable, alertFacilityEnabled }) {
   if (view === 'audit') {
     return html`<${Audit} noteId=${noteId} />`;
   }
@@ -24,6 +24,8 @@ export function App({ noteId, view, providerName, providerPhotoUrl, patientName,
       providerName=${providerName}
       providerPhotoUrl=${providerPhotoUrl}
       patientName=${patientName}
+      patientBirthDate=${patientBirthDate}
+      patientGender=${patientGender}
       debugMode=${debugMode}
       noteEditable=${noteEditable}
       alertFacilityEnabled=${alertFacilityEnabled}

--- a/hyperscribe/scribe/static/index.html
+++ b/hyperscribe/scribe/static/index.html
@@ -51,6 +51,8 @@
       providerName: '{{ provider_name }}',
       providerPhotoUrl: '{{ provider_photo_url }}',
       patientName: '{{ patient_name }}',
+      patientBirthDate: '{{ patient_birth_date }}',
+      patientGender: '{{ patient_gender }}',
       patientId: '{{ patient_id }}',
       staffId: '{{ staff_id }}',
       staffName: '{{ staff_name }}',

--- a/hyperscribe/scribe/static/summary.js
+++ b/hyperscribe/scribe/static/summary.js
@@ -162,7 +162,7 @@ function renderSoapGroups(sections, commandBySectionKey, onEditCommand, onDelete
     .filter(Boolean);
 }
 
-export function Scribe({ noteId, patientId, staffId, staffName, providerName, providerPhotoUrl, patientName, debugMode, noteEditable = true, alertFacilityEnabled = false }) {
+export function Scribe({ noteId, patientId, staffId, staffName, providerName, providerPhotoUrl, patientName, patientBirthDate, patientGender, debugMode, noteEditable = true, alertFacilityEnabled = false }) {
   const [noteData, setNoteData] = useState(null);
   const [generating, setGenerating] = useState(false);
   const [error, setError] = useState(null);
@@ -320,6 +320,11 @@ export function Scribe({ noteId, patientId, staffId, staffName, providerName, pr
           patient_id: patientId,
           template_ros_sections: selectedTemplate?.ros_sections || null,
           template_pe_sections: selectedTemplate?.pe_sections || null,
+          patient_context: {
+            name: patientName || '',
+            birth_date: patientBirthDate || '',
+            gender: patientGender || '',
+          },
         }),
       });
       const data = await res.json();

--- a/tests/hyperscribe/scribe/clients/nabla/test_backend.py
+++ b/tests/hyperscribe/scribe/clients/nabla/test_backend.py
@@ -89,8 +89,10 @@ def test_generate_note_with_patient_context() -> None:
     backend.generate_note(Transcript(), patient_context=ctx)
 
     payload = mock_rest_client.generate_note.call_args.args[0]
-    assert payload["patient_context"]["name"] == "Jane Doe"
-    assert payload["patient_context"]["encounter_diagnoses"][0]["code"] == "R51"
+    # structured_context is intentionally not sent (see comment in _build_note_payload).
+    # Demographics are baked into the custom_instruction instead.
+    assert "structured_context" not in payload
+    assert "Jane Doe" in payload["note_sections_customization"][1]["custom_instruction"]
 
 
 def test_generate_note_without_patient_context() -> None:
@@ -100,7 +102,7 @@ def test_generate_note_without_patient_context() -> None:
     backend.generate_note(Transcript())
 
     payload = mock_rest_client.generate_note.call_args.args[0]
-    assert "patient_context" not in payload
+    assert "structured_context" not in payload
 
 
 def test_generate_normalized_data() -> None:

--- a/tests/hyperscribe/scribe/clients/nabla/test_backend.py
+++ b/tests/hyperscribe/scribe/clients/nabla/test_backend.py
@@ -89,9 +89,10 @@ def test_generate_note_with_patient_context() -> None:
     backend.generate_note(Transcript(), patient_context=ctx)
 
     payload = mock_rest_client.generate_note.call_args.args[0]
-    # structured_context is intentionally not sent (see comment in _build_note_payload).
-    # Demographics are baked into the custom_instruction instead.
-    assert "structured_context" not in payload
+    demographics = payload["structured_context"]["patient_demographics"]
+    assert demographics["name"] == "Jane Doe"
+    assert demographics["birth_date"] == "1990-05-15"
+    assert demographics["gender"] == "FEMALE"
     assert "Jane Doe" in payload["note_sections_customization"][1]["custom_instruction"]
 
 


### PR DESCRIPTION
## Summary

- **HPI opening line**: Replace vague demographics instruction with precise clinical format (`[Name] is a [age]-year-old [gender] who presents today for [CHIEF COMPLAINT]`). Age is pre-computed from DOB, gender mapped from Canvas `sex_at_birth`.
- **Writing style**: Add guidance for complete sentences with clear subjects; prevent sentence fragments.
- **Level of detail**: Add `level_of_detail` parameter to HPI section customization (currently set to `DEFAULT` for testing).
- **Patient context wiring**: Patient name, birth_date, and gender now flow from Canvas DB → scribe view → frontend → `generate-summary` POST body.
- **Payload fix**: Replace unused `payload["patient_context"]` (invalid API field) with correct `structured_context.patient_demographics` per API spec.

## Files changed

- `hyperscribe/scribe/clients/nabla/backend.py` — HPI instruction, demographics helpers, structured_context payload
- `hyperscribe/scribe/api/scribe_view.py` — pass patient birth_date and gender to frontend
- `hyperscribe/scribe/static/index.html` — thread new fields to JS config
- `hyperscribe/scribe/static/app.js` — pass props to Scribe component
- `hyperscribe/scribe/static/summary.js` — include patient_context in generate-summary POST
- `tests/hyperscribe/scribe/clients/nabla/test_backend.py` — updated assertions

## Test plan

- [ ] Generate note with patient context — verify HPI opens with `[Name] is a [age]-year-old [gender] who presents today for [chief complaint]`
- [ ] Verify complete sentences with proper subjects (no fragments like "Reported experiencing...")
- [ ] Verify structured_context accepted by API (no 400 errors)
- [ ] Verify existing Scribe flow without patient context still works (placeholder fallback)
- [ ] Run `uv run pytest tests/hyperscribe/scribe/clients/nabla/test_backend.py tests/hyperscribe/scribe/api/` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)