### PR TITLE
Fix JWT token expiry and recording state regressions

### DIFF
--- a/hyperscribe/scribe/static/recording-hook.js
+++ b/hyperscribe/scribe/static/recording-hook.js
@@ -84,15 +84,25 @@ export function useRecording(noteId, initialTranscript) {
       return false;
     }
 
+    const refreshConfig = async () => {
+      const res = await fetch(`${API_BASE}/config`, { cache: 'no-store' });
+      return res.json();
+    };
+
     let client;
     try {
-      client = createScribeClient(config);
+      client = createScribeClient({ ...config, refreshConfig });
       client.onTranscriptItem = handleTranscriptItem;
       client.onError = (msg, code) => {
         if (code === 83011) {
           // Stream timeout — Nabla closes the connection if a stream receives
           // no audio for 10s. Not actionable for the user; the client will
           // reconnect and replay buffered audio automatically.
+          return;
+        }
+        if (code === 50025) {
+          // JWT expired — the client will refresh the token and reconnect
+          // automatically. Not actionable for the user.
           return;
         }
         setError(code ? `${msg} (${code})` : msg);

--- a/hyperscribe/scribe/static/recording-hook.js
+++ b/hyperscribe/scribe/static/recording-hook.js
@@ -174,7 +174,7 @@ export function useRecording(noteId, initialTranscript) {
     return true;
   }, [handleTranscriptItem]);
 
-  const disconnectAll = useCallback(async () => {
+  const disconnectAll = useCallback(async ({ force = false } = {}) => {
     cleanupAudio(audioCtxRef, streamRef, workletNodeRef);
     setAudioLevel(0);
     setSilenceWarning(false);
@@ -190,8 +190,13 @@ export function useRecording(noteId, initialTranscript) {
       client.onEnd = () => {};
       client.onDisconnect = () => {};
       client.onReconnect = () => {};
-      // end() drains any buffered audio before closing.
-      await client.end();
+      if (force) {
+        // forceEnd() closes immediately without draining the buffer.
+        client.forceEnd();
+      } else {
+        // end() drains any buffered audio before closing.
+        await client.end();
+      }
       client.onTranscriptItem = () => {};
     }
   }, []);
@@ -257,7 +262,7 @@ export function useRecording(noteId, initialTranscript) {
 
   const finishRecording = useCallback(async () => {
     setStatus('finishing');
-    await disconnectAll();
+    await disconnectAll({ force: true });
     // Save transcript with finalized flag.
     if (noteId && entriesRef.current.length > 0) {
       try {
@@ -372,10 +377,15 @@ export function useRecording(noteId, initialTranscript) {
     }
   }, []);
 
+  const finalizedRef = useRef(finalized);
+  finalizedRef.current = finalized;
+
   // Cleanup on unmount — save transcript via sendBeacon before destroying resources.
+  // Skip if the transcript is already finalized to avoid overwriting finalized=true
+  // with the default finalized=false.
   useEffect(() => {
     return () => {
-      if (noteId && (entriesRef.current.length > 0 || statusRef.current !== 'idle')) {
+      if (noteId && !finalizedRef.current && (entriesRef.current.length > 0 || statusRef.current !== 'idle')) {
         const payload = new Blob(
           [JSON.stringify({ note_id: noteId, transcript: { items: entriesRef.current } })],
           { type: 'application/json' },

--- a/hyperscribe/scribe/static/scribeClient.js
+++ b/hyperscribe/scribe/static/scribeClient.js
@@ -26,7 +26,7 @@ function int16ArrayToBase64(int16Array) {
 }
 
 const MAX_RECONNECT_ATTEMPTS = 10;
-const END_TIMEOUT_MS = 60000;
+const END_TIMEOUT_MS = 30000;
 // If we have in-flight audio and the server hasn't responded in this long,
 // consider the connection dead. Browser offline events and WebSocket close
 // detection are unreliable on macOS — this catches it at the application level.

--- a/hyperscribe/scribe/static/scribeClient.js
+++ b/hyperscribe/scribe/static/scribeClient.js
@@ -42,9 +42,13 @@ class NablaScribeClient {
    * @param {string} config.encoding
    * @param {string[]} config.speech_locales
    * @param {string} config.stream_id
+   * @param {function(): Promise<object>} [config.refreshConfig] — async callback
+   *   that returns a fresh config object (with a new access_token) when the
+   *   current token has expired. Called before each reconnect attempt.
    */
   constructor(config) {
     this._config = config;
+    this._refreshConfig = config.refreshConfig || null;
     this._ws = null;
     this._nextSeqId = 0;
 
@@ -320,8 +324,29 @@ class NablaScribeClient {
     }
     if (!this._ws) {
       this._reconnectAttempts = 0;
-      this._createWebSocket();
+      this._reconnect();
     }
+  }
+
+  /**
+   * @private
+   * Fetch fresh tokens from the backend and reconnect. Called by
+   * _scheduleReconnect and _handleOnline so that an expired JWT is
+   * replaced before the new WebSocket handshake.
+   */
+  async _reconnect() {
+    if (this._refreshConfig) {
+      try {
+        const freshConfig = await this._refreshConfig();
+        if (freshConfig && freshConfig.access_token) {
+          this._config.access_token = freshConfig.access_token;
+        }
+      } catch {
+        // Fall through with existing token — the connect attempt will fail
+        // and trigger another retry via the normal backoff path.
+      }
+    }
+    this._createWebSocket();
   }
 
   /** @private */
@@ -336,7 +361,7 @@ class NablaScribeClient {
     if (typeof navigator !== 'undefined' && !navigator.onLine) return;
     const delay = Math.min(1000 * Math.pow(2, this._reconnectAttempts), 30000);
     this._reconnectAttempts++;
-    this._reconnectTimer = setTimeout(() => this._createWebSocket(), delay);
+    this._reconnectTimer = setTimeout(() => this._reconnect(), delay);
   }
 
   /**


### PR DESCRIPTION
## Summary
- During long Nabla transcription sessions the user access token expires, causing every WebSocket reconnect to fail with error 50025 ("Invalid JWT token: The Token has expired")
- Added `_reconnect()` to `NablaScribeClient` that fetches fresh tokens via a `refreshConfig` callback before each reconnect attempt
- Suppress error 50025 from user display (same pattern as existing 83011 stream-timeout suppression) since reconnection handles it transparently
- **Fix "Paused" badge after finish** — skip `sendBeacon` on unmount when the transcript is already finalized, preventing the backend from overwriting `finalized=true` back to `false` ([KOALA-4818](https://canvasmedical.atlassian.net/browse/KOALA-4818))
- **Fix stuck "Finalizing Transcript..."** — use `forceEnd()` instead of `end()` when finishing recording so the UI doesn't block on buffer drain; reduce `END_TIMEOUT_MS` from 60s to 30s for the pause path ([KOALA-4818](https://canvasmedical.atlassian.net/browse/KOALA-4818))

## Test plan
- [ ] Start a recording session and let it run long enough for the Nabla JWT to expire (or simulate by shortening the token TTL)
- [ ] Verify the WebSocket reconnects silently with fresh tokens — no red error text should appear
- [ ] Verify normal pause/resume and network-loss reconnection still work
- [ ] Pause → Finish → Accept & Prescribe → return to note: should **not** show "Paused" badge
- [ ] Start → Finish (no pause): "Finalizing Transcript..." should resolve quickly, not hang for 60s

[KOALA-4818]: https://canvasmedical.atlassian.net/browse/KOALA-4818?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[KOALA-4818]: https://canvasmedical.atlassian.net/browse/KOALA-4818?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ