### PR TITLE
Custom instructions family sections, improve psych ROS

### DIFF
--- a/hyperscribe/scribe/api/session_view.py
+++ b/hyperscribe/scribe/api/session_view.py
@@ -624,7 +624,9 @@ class ScribeSessionView(StaffSessionAuthMixin, SimpleAPI):
         patient_context = _parse_patient_context(data)
         visit_template_name = str(data.get("selected_template_name", "") or "")
         try:
-            note = backend.generate_note(transcript, patient_context=patient_context, visit_template_name=visit_template_name)
+            note = backend.generate_note(
+                transcript, patient_context=patient_context, visit_template_name=visit_template_name,
+            )
         except ScribeError as exc:
             return [JSONResponse({"error": str(exc)}, status_code=HTTPStatus.INTERNAL_SERVER_ERROR)]
 
@@ -867,7 +869,9 @@ class ScribeSessionView(StaffSessionAuthMixin, SimpleAPI):
         patient_context = _parse_patient_context(data)
         visit_template_name = str(data.get("selected_template_name", "") or "")
         try:
-            note = backend.generate_note(transcript, patient_context=patient_context, visit_template_name=visit_template_name)
+            note = backend.generate_note(
+                transcript, patient_context=patient_context, visit_template_name=visit_template_name,
+            )
         except ScribeError as exc:
             return [JSONResponse({"error": str(exc)}, status_code=HTTPStatus.INTERNAL_SERVER_ERROR)]
         return [

--- a/hyperscribe/scribe/api/session_view.py
+++ b/hyperscribe/scribe/api/session_view.py
@@ -622,8 +622,9 @@ class ScribeSessionView(StaffSessionAuthMixin, SimpleAPI):
 
         transcript = _parse_transcript(transcript_data)
         patient_context = _parse_patient_context(data)
+        visit_template_name = str(data.get("selected_template_name", "") or "")
         try:
-            note = backend.generate_note(transcript, patient_context=patient_context)
+            note = backend.generate_note(transcript, patient_context=patient_context, visit_template_name=visit_template_name)
         except ScribeError as exc:
             return [JSONResponse({"error": str(exc)}, status_code=HTTPStatus.INTERNAL_SERVER_ERROR)]
 
@@ -864,8 +865,9 @@ class ScribeSessionView(StaffSessionAuthMixin, SimpleAPI):
 
         transcript = _parse_transcript(transcript_data)
         patient_context = _parse_patient_context(data)
+        visit_template_name = str(data.get("selected_template_name", "") or "")
         try:
-            note = backend.generate_note(transcript, patient_context=patient_context)
+            note = backend.generate_note(transcript, patient_context=patient_context, visit_template_name=visit_template_name)
         except ScribeError as exc:
             return [JSONResponse({"error": str(exc)}, status_code=HTTPStatus.INTERNAL_SERVER_ERROR)]
         return [

--- a/hyperscribe/scribe/backend/base.py
+++ b/hyperscribe/scribe/backend/base.py
@@ -25,6 +25,7 @@ class ScribeBackend(ABC):
         transcript: Transcript,
         *,
         patient_context: PatientContext | None = None,
+        visit_template_name: str = "",
     ) -> ClinicalNote: ...
 
     @abstractmethod

--- a/hyperscribe/scribe/clients/nabla/backend.py
+++ b/hyperscribe/scribe/clients/nabla/backend.py
@@ -273,6 +273,14 @@ class NablaBackend(ScribeBackend):
                         "family members' history."
                     ),
                 },
+                {
+                    "section_key": "REVIEW_OF_SYSTEMS",
+                    "custom_instruction": (
+                        "Focus on psychiatric review of systems. Use these categories: "
+                        "Depressive Symptoms, Anxiety Symptoms, Sleep, Appetite, "
+                        "SI/HI, Hallucinations, Delusions/Paranoia, Manic Symptoms."
+                    ),
+                },
             ],
         }
         if patient_context is not None:

--- a/hyperscribe/scribe/clients/nabla/backend.py
+++ b/hyperscribe/scribe/clients/nabla/backend.py
@@ -20,7 +20,10 @@ from hyperscribe.scribe.clients.nabla.client import NablaClient
 
 _NABLA_API_VERSION = "2026-02-20"
 _NOTE_LOCALE = "ENGLISH_US"
-_NOTE_TEMPLATE = "PSYCHIATRY_MULTIPLE_SECTIONS"
+_NOTE_TEMPLATE = "GENERIC_MULTIPLE_SECTIONS_AP_MERGED"
+_PSYCHIATRY_NOTE_TEMPLATE = "PSYCHIATRY_MULTIPLE_SECTIONS"
+
+_PSYCHIATRY_TEMPLATE_NAMES: frozenset[str] = frozenset({"Psychiatry"})
 
 
 class NablaBackend(ScribeBackend):
@@ -48,8 +51,9 @@ class NablaBackend(ScribeBackend):
         transcript: Transcript,
         *,
         patient_context: PatientContext | None = None,
+        visit_template_name: str = "",
     ) -> ClinicalNote:
-        payload = self._build_note_payload(transcript, patient_context)
+        payload = self._build_note_payload(transcript, patient_context, visit_template_name=visit_template_name)
         raw = self._rest_client.generate_note(payload)
         self._last_raw_note_response = raw
         return self._parse_note(raw)
@@ -204,7 +208,11 @@ class NablaBackend(ScribeBackend):
     def _build_note_payload(
         transcript: Transcript,
         patient_context: PatientContext | None,
+        *,
+        visit_template_name: str = "",
     ) -> dict[str, Any]:
+        is_psychiatry = visit_template_name in _PSYCHIATRY_TEMPLATE_NAMES
+
         # Build the HPI opening line with concrete demographics when available.
         if patient_context is not None:
             name = patient_context.name or "[PATIENT_NAME]"
@@ -232,19 +240,28 @@ class NablaBackend(ScribeBackend):
             "Musculoskeletal:"
         )
 
-        payload: dict[str, Any] = {
-            "transcript_items": [
-                {
-                    "text": item.text,
-                    "speaker_type": item.speaker or "UNSPECIFIED",
-                    "start_offset_ms": item.start_offset_ms,
-                    "end_offset_ms": item.end_offset_ms,
-                }
-                for item in transcript.items
-            ],
-            "note_template": _NOTE_TEMPLATE,
-            "note_locale": _NOTE_LOCALE,
-            "note_sections_customization": [
+        # Shared custom instructions for all templates.
+        social_history_instruction = {
+            "section_key": "SOCIAL_HISTORY",
+            "custom_instruction": (
+                "Be thorough. Include all relevant details discussed for: "
+                "Living Situation, Social Support, Caregiving Resources, "
+                "Occupation, Alcohol, Tobacco, Recreational Drugs, and Exposures."
+            ),
+        }
+        family_history_instruction = {
+            "section_key": "FAMILY_HISTORY",
+            "custom_instruction": (
+                "Be thorough. Document all family members mentioned, their relationship "
+                "to the patient, and any medical conditions, causes of death, or "
+                "conditions discussed. Distinguish between the patient's own history and "
+                "family members' history."
+            ),
+        }
+
+        if is_psychiatry:
+            note_template = _PSYCHIATRY_NOTE_TEMPLATE
+            sections_customization = [
                 {"section_key": "ASSESSMENT", "style": "BULLET_POINTS"},
                 {
                     "section_key": "PLAN",
@@ -256,23 +273,8 @@ class NablaBackend(ScribeBackend):
                     "style": "PARAGRAPH",
                     "custom_instruction": hpi_custom_instructions,
                 },
-                {
-                    "section_key": "SOCIAL_HISTORY",
-                    "custom_instruction": (
-                        "Be thorough. Include all relevant details discussed for: "
-                        "Living Situation, Social Support, Caregiving Resources, "
-                        "Occupation, Alcohol, Tobacco, Recreational Drugs, and Exposures."
-                    ),
-                },
-                {
-                    "section_key": "FAMILY_HISTORY",
-                    "custom_instruction": (
-                        "Be thorough. Document all family members mentioned, their relationship "
-                        "to the patient, and any medical conditions, causes of death, or "
-                        "conditions discussed. Distinguish between the patient's own history and "
-                        "family members' history."
-                    ),
-                },
+                social_history_instruction,
+                family_history_instruction,
                 {
                     "section_key": "MENTAL_HEALTH_EXAM",
                     "custom_instruction": (
@@ -281,7 +283,34 @@ class NablaBackend(ScribeBackend):
                         "SI/HI, Hallucinations, Delusions/Paranoia, Manic Symptoms."
                     ),
                 },
+            ]
+        else:
+            note_template = _NOTE_TEMPLATE
+            sections_customization = [
+                {"section_key": "ASSESSMENT_AND_PLAN", "style": "BULLET_POINTS", "split_by_problem": True},
+                {
+                    "section_key": "HISTORY_OF_PRESENT_ILLNESS",
+                    "style": "PARAGRAPH",
+                    "level_of_detail": "DEFAULT",
+                    "custom_instruction": hpi_custom_instructions,
+                },
+                social_history_instruction,
+                family_history_instruction,
+            ]
+
+        payload: dict[str, Any] = {
+            "transcript_items": [
+                {
+                    "text": item.text,
+                    "speaker_type": item.speaker or "UNSPECIFIED",
+                    "start_offset_ms": item.start_offset_ms,
+                    "end_offset_ms": item.end_offset_ms,
+                }
+                for item in transcript.items
             ],
+            "note_template": note_template,
+            "note_locale": _NOTE_LOCALE,
+            "note_sections_customization": sections_customization,
         }
         if patient_context is not None:
             structured_context: dict[str, Any] = {

--- a/hyperscribe/scribe/clients/nabla/backend.py
+++ b/hyperscribe/scribe/clients/nabla/backend.py
@@ -264,7 +264,7 @@ class NablaBackend(ScribeBackend):
                     "section_key": "FAMILY_HISTORY",
                     "custom_instruction": (
                         "Be thorough. Document all family members mentioned, their relationship "
-                        "to the patient, and any medical conditions, causes of death, or congenital "
+                        "to the patient, and any medical conditions, causes of death, or "
                         "conditions discussed. Distinguish between the patient's own history and "
                         "family members' history."
                     ),

--- a/hyperscribe/scribe/clients/nabla/backend.py
+++ b/hyperscribe/scribe/clients/nabla/backend.py
@@ -20,7 +20,7 @@ from hyperscribe.scribe.clients.nabla.client import NablaClient
 
 _NABLA_API_VERSION = "2026-02-20"
 _NOTE_LOCALE = "ENGLISH_US"
-_NOTE_TEMPLATE = "GENERIC_MULTIPLE_SECTIONS_AP_MERGED"
+_NOTE_TEMPLATE = "PSYCHIATRY_MULTIPLE_SECTIONS"
 
 
 class NablaBackend(ScribeBackend):
@@ -245,12 +245,33 @@ class NablaBackend(ScribeBackend):
             "note_template": _NOTE_TEMPLATE,
             "note_locale": _NOTE_LOCALE,
             "note_sections_customization": [
-                {"section_key": "ASSESSMENT_AND_PLAN", "style": "BULLET_POINTS", "split_by_problem": True},
+                {"section_key": "ASSESSMENT", "style": "BULLET_POINTS"},
+                {
+                    "section_key": "PLAN",
+                    "style": "BULLET_POINTS",
+                    "custom_instruction": "Organize by problem, with the plan for each problem grouped together.",
+                },
                 {
                     "section_key": "HISTORY_OF_PRESENT_ILLNESS",
                     "style": "PARAGRAPH",
-                    "level_of_detail": "DEFAULT",
                     "custom_instruction": hpi_custom_instructions,
+                },
+                {
+                    "section_key": "SOCIAL_HISTORY",
+                    "custom_instruction": (
+                        "Be thorough. Include all relevant details discussed for: "
+                        "Living Situation, Social Support, Caregiving Resources, "
+                        "Occupation, Alcohol, Tobacco, Recreational Drugs, and Exposures."
+                    ),
+                },
+                {
+                    "section_key": "FAMILY_HISTORY",
+                    "custom_instruction": (
+                        "Be thorough. Document all family members mentioned, their relationship "
+                        "to the patient, and any medical conditions, causes of death, or "
+                        "conditions discussed. Distinguish between the patient's own history and "
+                        "family members' history."
+                    ),
                 },
             ],
         }

--- a/hyperscribe/scribe/clients/nabla/backend.py
+++ b/hyperscribe/scribe/clients/nabla/backend.py
@@ -252,6 +252,23 @@ class NablaBackend(ScribeBackend):
                     "level_of_detail": "DEFAULT",
                     "custom_instruction": hpi_custom_instructions,
                 },
+                {
+                    "section_key": "SOCIAL_HISTORY",
+                    "custom_instruction": (
+                        "Be thorough. Include all relevant details discussed for: "
+                        "Living Situation, Social Support, Caregiving Resources, "
+                        "Occupation, Alcohol, Tobacco, Recreational Drugs, and Exposures."
+                    ),
+                },
+                {
+                    "section_key": "FAMILY_HISTORY",
+                    "custom_instruction": (
+                        "Be thorough. Document all family members mentioned, their relationship "
+                        "to the patient, and any medical conditions, causes of death, or congenital "
+                        "conditions discussed. Distinguish between the patient's own history and "
+                        "family members' history."
+                    ),
+                },
             ],
         }
         if patient_context is not None:

--- a/hyperscribe/scribe/clients/nabla/backend.py
+++ b/hyperscribe/scribe/clients/nabla/backend.py
@@ -274,9 +274,9 @@ class NablaBackend(ScribeBackend):
                     ),
                 },
                 {
-                    "section_key": "REVIEW_OF_SYSTEMS",
+                    "section_key": "MENTAL_HEALTH_EXAM",
                     "custom_instruction": (
-                        "Focus on psychiatric review of systems. Use these categories: "
+                        "Be thorough. Use these categories: "
                         "Depressive Symptoms, Anxiety Symptoms, Sleep, Appetite, "
                         "SI/HI, Hallucinations, Delusions/Paranoia, Manic Symptoms."
                     ),

--- a/hyperscribe/scribe/clients/nabla/backend.py
+++ b/hyperscribe/scribe/clients/nabla/backend.py
@@ -240,25 +240,6 @@ class NablaBackend(ScribeBackend):
             "Musculoskeletal:"
         )
 
-        # Shared custom instructions for all templates.
-        social_history_instruction = {
-            "section_key": "SOCIAL_HISTORY",
-            "custom_instruction": (
-                "Be thorough. Include all relevant details discussed for: "
-                "Living Situation, Social Support, Caregiving Resources, "
-                "Occupation, Alcohol, Tobacco, Recreational Drugs, and Exposures."
-            ),
-        }
-        family_history_instruction = {
-            "section_key": "FAMILY_HISTORY",
-            "custom_instruction": (
-                "Be thorough. Document all family members mentioned, their relationship "
-                "to the patient, and any medical conditions, causes of death, or "
-                "conditions discussed. Distinguish between the patient's own history and "
-                "family members' history."
-            ),
-        }
-
         if is_psychiatry:
             note_template = _PSYCHIATRY_NOTE_TEMPLATE
             sections_customization = [
@@ -273,8 +254,6 @@ class NablaBackend(ScribeBackend):
                     "style": "PARAGRAPH",
                     "custom_instruction": hpi_custom_instructions,
                 },
-                social_history_instruction,
-                family_history_instruction,
                 {
                     "section_key": "MENTAL_HEALTH_EXAM",
                     "custom_instruction": (
@@ -294,8 +273,6 @@ class NablaBackend(ScribeBackend):
                     "level_of_detail": "DEFAULT",
                     "custom_instruction": hpi_custom_instructions,
                 },
-                social_history_instruction,
-                family_history_instruction,
             ]
 
         payload: dict[str, Any] = {

--- a/hyperscribe/scribe/commands/extractor.py
+++ b/hyperscribe/scribe/commands/extractor.py
@@ -97,8 +97,15 @@ def parse_ros_subsections(text: str) -> list[dict[str, str]]:
 
 
 def _extract_ros(note: ClinicalNote) -> CommandProposal | None:
-    """Extract review_of_systems section into an ROS command with per-system subsections."""
+    """Extract review_of_systems or mental_health_exam section into an ROS command.
+
+    Prefer mental_health_exam when present (psychiatry template) over the
+    generic review_of_systems.
+    """
     ros_section = next(
+        (s for s in note.sections if s.key.lower() == "mental_health_exam" and s.text.strip()),
+        None,
+    ) or next(
         (s for s in note.sections if s.key.lower() == "review_of_systems" and s.text.strip()),
         None,
     )

--- a/hyperscribe/scribe/static/summary.js
+++ b/hyperscribe/scribe/static/summary.js
@@ -417,6 +417,7 @@ export function Scribe({ noteId, patientId, staffId, staffName, providerName, pr
           note_id: noteId,
           note_uuid: noteId,
           patient_id: patientId,
+          selected_template_name: selectedTemplate?.name || null,
           template_ros_sections: selectedTemplate?.ros_sections || null,
           template_pe_sections: selectedTemplate?.pe_sections || null,
           patient_context: {


### PR DESCRIPTION
**Summary**                                                                                                   
   
- Add custom instructions for `SOCIAL_HISTORY` and `FAMILY_HISTORY` to improve Nabla output detail across all visit templates                                                                                           
- Add conditional `PSYCHIATRY_MULTIPLE_SECTIONS` Nabla template when the provider selects the Psychiatry visit template                                                                                            
 - Add `MENTAL_HEALTH_EXAM` custom instruction with psychiatric ROS categories (Depressive Symptoms, Anxiety Symptoms, Sleep, Appetite, SI/HI, Hallucinations, Delusions/Paranoia, Manic Symptoms)                     
 - Map `MENTAL_HEALTH_EXAM` to existing ROS command in the extractor, preferred over generic review_of_systems when present                                                                           - Pass `selected_template_name` from frontend through to Nabla backend for template selection 