### PR TITLE
Add custom instructions for Social History and Family History sections

### DIFF
--- a/hyperscribe/scribe/clients/nabla/backend.py
+++ b/hyperscribe/scribe/clients/nabla/backend.py
@@ -264,8 +264,8 @@ class NablaBackend(ScribeBackend):
                     "section_key": "FAMILY_HISTORY",
                     "custom_instruction": (
                         "Be thorough. Document all family members mentioned, their relationship "
-                        "to the patient, and any medical conditions, causes of death, or congenital "
-                        "conditions discussed. Distinguish between the patient's own history and "
+                        "to the patient, and any medical conditions or causes of death "
+                        "discussed. Distinguish between the patient's own history and "
                         "family members' history."
                     ),
                 },

--- a/hyperscribe/scribe/clients/nabla/backend.py
+++ b/hyperscribe/scribe/clients/nabla/backend.py
@@ -252,6 +252,23 @@ class NablaBackend(ScribeBackend):
                     "level_of_detail": "DEFAULT",
                     "custom_instruction": hpi_custom_instructions,
                 },
+                {
+                    "section_key": "SOCIAL_HISTORY",
+                    "custom_instruction": (
+                        "Be thorough. Include all relevant details discussed for: "
+                        "Living Situation, Social Support, Caregiving Resources, "
+                        "Occupation, Alcohol, Tobacco, Recreational Drugs, and Exposures."
+                    ),
+                },
+                {
+                    "section_key": "FAMILY_HISTORY",
+                    "custom_instruction": (
+                        "Be thorough. Document all family members mentioned, their relationship "
+                        "to the patient, and any medical conditions, causes of death, or congenital "
+                        "conditions discussed. Distinguish between the patient's own history and "
+                        "family members' history."
+                    ),
+                },
             ],
         }
         if patient_context is not None:


### PR DESCRIPTION
## Summary

- Add targeted custom instructions for `SOCIAL_HISTORY` and `FAMILY_HISTORY` sections to improve Nabla output detail
- Social History instructions align with the Social History questionnaire fields
- Family History instructions guide capture of family members, conditions, and distinguish patient vs family member history

Cherry-picked from #249 (`75b7d0b`) to isolate this change for independent review.

## Test plan

- [ ] Verify Social History section output includes detail aligned with questionnaire fields
- [ ] Verify Family History section captures family members and conditions
- [ ] Confirm no regression in other sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)