### PR TITLE
feat: task recommendations

### DIFF
--- a/hyperscribe/scribe/api/session_view.py
+++ b/hyperscribe/scribe/api/session_view.py
@@ -758,7 +758,7 @@ class ScribeSessionView(StaffSessionAuthMixin, SimpleAPI):
 
                 patient_id = str(data.get("patient_id", ""))
                 zip_codes = resolve_zip_codes(patient_id, note_id) or None
-                rec_proposals = recommend_commands(note, api_key, zip_codes=zip_codes)
+                rec_proposals = recommend_commands(note, api_key, zip_codes=zip_codes, transcript=transcript)
                 annotate_duplicates(rec_proposals, note_uuid)
                 recommendations_list = [
                     {

--- a/hyperscribe/scribe/clients/nabla/backend.py
+++ b/hyperscribe/scribe/clients/nabla/backend.py
@@ -279,9 +279,8 @@ class NablaBackend(ScribeBackend):
             }
             if patient_context.birth_date:
                 structured_context["patient_demographics"]["birth_date"] = patient_context.birth_date
-            if patient_context.gender:
-                structured_context["patient_demographics"]["gender"] = NablaBackend._GENDER_API_MAP.get(
-                    patient_context.gender, patient_context.gender.upper()
-                )
+            mapped_gender = NablaBackend._GENDER_API_MAP.get(patient_context.gender, "")
+            if mapped_gender:
+                structured_context["patient_demographics"]["gender"] = mapped_gender
             payload["structured_context"] = structured_context
         return payload

--- a/hyperscribe/scribe/recommendations/__init__.py
+++ b/hyperscribe/scribe/recommendations/__init__.py
@@ -5,12 +5,13 @@ from logger import log
 from canvas_sdk.clients.llms.libraries import LlmAnthropic
 from canvas_sdk.clients.llms.structures.settings import LlmSettingsAnthropic
 
-from hyperscribe.scribe.backend.models import ClinicalNote, CommandProposal
+from hyperscribe.scribe.backend.models import ClinicalNote, CommandProposal, Transcript
 from hyperscribe.scribe.recommendations.allergy import AllergyRecommender
 from hyperscribe.scribe.recommendations.base import BaseRecommender
 from hyperscribe.scribe.recommendations.medication_statement import MedicationRecommender
 from hyperscribe.scribe.recommendations.prescription import PrescriptionRecommender
 from hyperscribe.scribe.recommendations.refer import ReferRecommender
+from hyperscribe.scribe.recommendations.task import TaskRecommender
 
 _MODEL = "claude-sonnet-4-5-20250929"
 
@@ -30,16 +31,22 @@ def _build_recommenders(zip_codes: list[str] | None = None) -> list[BaseRecommen
         AllergyRecommender(),
         PrescriptionRecommender(),
         ReferRecommender(zip_codes=zip_codes),
+        TaskRecommender(),
     ]
 
 
-def recommend_commands(note: ClinicalNote, api_key: str, zip_codes: list[str] | None = None) -> list[CommandProposal]:
+def recommend_commands(
+    note: ClinicalNote,
+    api_key: str,
+    zip_codes: list[str] | None = None,
+    transcript: Transcript | None = None,
+) -> list[CommandProposal]:
     """Run all recommenders against the clinical note and return proposals."""
     proposals: list[CommandProposal] = []
     for recommender in _build_recommenders(zip_codes):
         try:
             client = LlmAnthropic(_make_settings(api_key))
-            proposals.extend(recommender.recommend(note, client))
+            proposals.extend(recommender.recommend(note, client, transcript=transcript))
         except Exception:
             log.exception(f"Recommender {type(recommender).__name__} failed")
     return proposals

--- a/hyperscribe/scribe/recommendations/allergy.py
+++ b/hyperscribe/scribe/recommendations/allergy.py
@@ -9,7 +9,7 @@ from canvas_sdk.clients.llms.libraries import LlmAnthropic
 from canvas_sdk.commands.commands.allergy import AllergenType
 
 from hyperscribe.libraries.canvas_science import CanvasScience
-from hyperscribe.scribe.backend.models import ClinicalNote, CommandProposal, NoteSection
+from hyperscribe.scribe.backend.models import ClinicalNote, CommandProposal, NoteSection, Transcript
 from hyperscribe.scribe.recommendations.base import BaseRecommender
 from hyperscribe.scribe.recommendations.schemas import AllergyRecommendationList
 
@@ -56,7 +56,9 @@ def _resolve_allergy(keywords: str, cache: dict[str, dict[str, int] | None] | No
 
 
 class AllergyRecommender(BaseRecommender):
-    def recommend(self, note: ClinicalNote, client: LlmAnthropic) -> list[CommandProposal]:
+    def recommend(
+        self, note: ClinicalNote, client: LlmAnthropic, transcript: Transcript | None = None
+    ) -> list[CommandProposal]:
         all_keys = [s.key for s in note.sections]
         log.info(f"AllergyRecommender: note section keys={all_keys}, filtering by {_RELEVANT_KEYS}")
         sections = [s for s in note.sections if s.key.lower() in _RELEVANT_KEYS and s.text.strip()]

--- a/hyperscribe/scribe/recommendations/base.py
+++ b/hyperscribe/scribe/recommendations/base.py
@@ -4,13 +4,15 @@ from abc import ABC, abstractmethod
 
 from canvas_sdk.clients.llms.libraries import LlmAnthropic
 
-from hyperscribe.scribe.backend.models import ClinicalNote, CommandProposal
+from hyperscribe.scribe.backend.models import ClinicalNote, CommandProposal, Transcript
 
 
 class BaseRecommender(ABC):
     """One file per command type. Subclasses define their schema, prompt, and code resolution."""
 
     @abstractmethod
-    def recommend(self, note: ClinicalNote, client: LlmAnthropic) -> list[CommandProposal]:
+    def recommend(
+        self, note: ClinicalNote, client: LlmAnthropic, transcript: Transcript | None = None
+    ) -> list[CommandProposal]:
         """Extract structured recommendations for this command type from the note."""
         ...

--- a/hyperscribe/scribe/recommendations/medication_statement.py
+++ b/hyperscribe/scribe/recommendations/medication_statement.py
@@ -9,7 +9,7 @@ from canvas_sdk.clients.llms.libraries import LlmAnthropic
 from canvas_sdk.commands.constants import CodeSystems
 
 from hyperscribe.libraries.canvas_science import CanvasScience
-from hyperscribe.scribe.backend.models import ClinicalNote, CommandProposal, NoteSection
+from hyperscribe.scribe.backend.models import ClinicalNote, CommandProposal, NoteSection, Transcript
 from hyperscribe.scribe.recommendations.base import BaseRecommender
 from hyperscribe.scribe.recommendations.schemas import MedicationRecommendationList
 
@@ -50,7 +50,9 @@ def _resolve_medication(keywords: str, cache: dict[str, dict[str, str] | None] |
 
 
 class MedicationRecommender(BaseRecommender):
-    def recommend(self, note: ClinicalNote, client: LlmAnthropic) -> list[CommandProposal]:
+    def recommend(
+        self, note: ClinicalNote, client: LlmAnthropic, transcript: Transcript | None = None
+    ) -> list[CommandProposal]:
         all_keys = [s.key for s in note.sections]
         log.info(f"MedicationRecommender: note section keys={all_keys}, filtering by {_RELEVANT_KEYS}")
         sections = [s for s in note.sections if s.key.lower() in _RELEVANT_KEYS and s.text.strip()]

--- a/hyperscribe/scribe/recommendations/prescription.py
+++ b/hyperscribe/scribe/recommendations/prescription.py
@@ -8,7 +8,7 @@ from logger import log
 from canvas_sdk.clients.llms.libraries import LlmAnthropic
 
 from hyperscribe.libraries.canvas_science import CanvasScience
-from hyperscribe.scribe.backend.models import ClinicalNote, CommandProposal, NoteSection
+from hyperscribe.scribe.backend.models import ClinicalNote, CommandProposal, NoteSection, Transcript
 from hyperscribe.scribe.recommendations.base import BaseRecommender
 from hyperscribe.scribe.recommendations.schemas import PrescriptionRecommendationList
 from hyperscribe.structures.medication_detail import MedicationDetail
@@ -55,7 +55,9 @@ def _resolve_prescription(
 
 
 class PrescriptionRecommender(BaseRecommender):
-    def recommend(self, note: ClinicalNote, client: LlmAnthropic) -> list[CommandProposal]:
+    def recommend(
+        self, note: ClinicalNote, client: LlmAnthropic, transcript: Transcript | None = None
+    ) -> list[CommandProposal]:
         all_keys = [s.key for s in note.sections]
         log.info(f"PrescriptionRecommender: note section keys={all_keys}, filtering by {_RELEVANT_KEYS}")
         sections = [s for s in note.sections if s.key.lower() in _RELEVANT_KEYS and s.text.strip()]

--- a/hyperscribe/scribe/recommendations/refer.py
+++ b/hyperscribe/scribe/recommendations/refer.py
@@ -7,7 +7,7 @@ from logger import log
 
 from canvas_sdk.clients.llms.libraries import LlmAnthropic
 
-from hyperscribe.scribe.backend.models import ClinicalNote, CommandProposal, NoteSection
+from hyperscribe.scribe.backend.models import ClinicalNote, CommandProposal, NoteSection, Transcript
 from hyperscribe.scribe.contacts import search_refer_providers
 from hyperscribe.scribe.recommendations.base import BaseRecommender
 from hyperscribe.scribe.recommendations.schemas import ReferRecommendationList
@@ -38,7 +38,9 @@ class ReferRecommender(BaseRecommender):
     def __init__(self, zip_codes: list[str] | None = None) -> None:
         self.zip_codes = zip_codes
 
-    def recommend(self, note: ClinicalNote, client: LlmAnthropic) -> list[CommandProposal]:
+    def recommend(
+        self, note: ClinicalNote, client: LlmAnthropic, transcript: Transcript | None = None
+    ) -> list[CommandProposal]:
         sections = [s for s in note.sections if s.key.lower() in _RELEVANT_KEYS and s.text.strip()]
         if not sections:
             return []

--- a/hyperscribe/scribe/recommendations/schemas.py
+++ b/hyperscribe/scribe/recommendations/schemas.py
@@ -87,6 +87,29 @@ class ReconciliationResult(BaseModelLlmJson):
     )
 
 
+class TaskRecommendation(BaseModelLlmJson):
+    title: str = Field(description="Concise task title (e.g. 'Schedule follow-up in 2 weeks')")
+    due_date_hint: str | None = Field(
+        default=None,
+        description="Relative or absolute due date if mentioned (e.g. '2 weeks', 'next Monday')",
+    )
+    assignee_hint: str | None = Field(
+        default=None,
+        description="Who should handle this task if mentioned (e.g. 'front desk', 'nurse')",
+    )
+    comment: str | None = Field(default=None, description="Additional details or context for the task")
+    reason: str = Field(
+        description="The transcript excerpt or context that prompted this task recommendation",
+    )
+
+
+class TaskRecommendationList(BaseModelLlmJson):
+    tasks: list[TaskRecommendation] = Field(
+        default_factory=list,
+        description="List of tasks extracted from the transcript and clinical note",
+    )
+
+
 class DiagnosisSuggestion(BaseModelLlmJson):
     condition_text: str = Field(description="The original condition text")
     icd10_codes: list[str] = Field(description="2-3 ICD-10 codes (e.g. R519, G43009)")

--- a/hyperscribe/scribe/recommendations/task.py
+++ b/hyperscribe/scribe/recommendations/task.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+import json
+import re
+from http import HTTPStatus
+
+from logger import log
+
+from canvas_sdk.clients.llms.libraries import LlmAnthropic
+
+from hyperscribe.scribe.backend.models import (
+    ClinicalNote,
+    CommandProposal,
+    Transcript,
+    TranscriptItem,
+)
+from hyperscribe.scribe.recommendations.base import BaseRecommender
+from hyperscribe.scribe.recommendations.schemas import TaskRecommendationList
+
+_TASK_KEYWORDS = [
+    r"\btasks?\b",
+    r"\bfollow[\s-]?ups?\b",
+    r"\bto[\s-]?dos?\b",
+    r"\breminds?\b",
+    r"\breminders?\b",
+    r"\bschedul(?:e|ing)\b",
+    r"\bbook(?:ing)?\b",
+    r"\bcall\s+back\b",
+    r"\bcheck\s+back\b",
+    r"\breturn\s+(?:in|visit)\b",
+    r"\bcome\s+back\b",
+]
+_KEYWORD_PATTERN = re.compile("|".join(_TASK_KEYWORDS), re.IGNORECASE)
+_WINDOW_MS = 120_000  # 2 minutes
+
+_SYSTEM_PROMPT = (
+    "You are a clinical task extraction assistant.\n\n"
+    "You are given:\n"
+    "1. Transcript windows from a patient-provider encounter where task-related language was detected.\n"
+    "2. The full structured clinical note for context.\n\n"
+    "Extract actionable post-visit tasks for the care team. Examples:\n"
+    "- Follow-up appointments (e.g. 'schedule follow-up in 2 weeks')\n"
+    "- Calls to make (e.g. 'call patient with results')\n"
+    "- Patient education or instructions to send\n"
+    "- Prior authorizations to submit\n\n"
+    "For each task, provide:\n"
+    "- A clear, concise title a staff member can act on\n"
+    "- due_date_hint if the provider mentioned timing (relative or absolute)\n"
+    "- assignee_hint if the provider mentioned who should handle it\n"
+    "- comment with any additional relevant details\n"
+    "- reason: quote or closely paraphrase the specific transcript excerpt that prompted this task\n\n"
+    "Do NOT extract:\n"
+    "- Actions being done during the visit itself (e.g. 'let me check your blood pressure now')\n"
+    "- Diagnoses or assessments (handled separately)\n"
+    "- Medication changes (handled by the prescription system)\n\n"
+    "If no actionable post-visit tasks are found, return an empty list."
+)
+
+
+def find_task_matches(transcript: Transcript) -> list[int]:
+    """Return midpoint timestamps (ms) of transcript items containing task keywords."""
+    matches: list[int] = []
+    for item in transcript.items:
+        if _KEYWORD_PATTERN.search(item.text):
+            midpoint = (item.start_offset_ms + item.end_offset_ms) // 2
+            matches.append(midpoint)
+    return matches
+
+
+def merge_windows(timestamps: list[int], window_ms: int = _WINDOW_MS) -> list[tuple[int, int]]:
+    """Merge overlapping [t - window, t + window] intervals."""
+    if not timestamps:
+        return []
+    intervals = sorted((max(0, t - window_ms), t + window_ms) for t in timestamps)
+    merged = [intervals[0]]
+    for start, end in intervals[1:]:
+        if start <= merged[-1][1]:
+            merged[-1] = (merged[-1][0], max(merged[-1][1], end))
+        else:
+            merged.append((start, end))
+    return merged
+
+
+def extract_window_items(transcript: Transcript, windows: list[tuple[int, int]]) -> list[list[TranscriptItem]]:
+    """For each window, collect overlapping transcript items."""
+    result: list[list[TranscriptItem]] = []
+    for w_start, w_end in windows:
+        items = [item for item in transcript.items if item.end_offset_ms >= w_start and item.start_offset_ms <= w_end]
+        result.append(items)
+    return result
+
+
+def format_transcript_windows(window_items: list[list[TranscriptItem]]) -> str:
+    """Format window items into a human-readable string for the LLM prompt."""
+    parts: list[str] = []
+    for i, items in enumerate(window_items, 1):
+        if not items:
+            continue
+        start_ms = items[0].start_offset_ms
+        end_ms = items[-1].end_offset_ms
+        start_fmt = f"{start_ms // 60000}:{(start_ms % 60000) // 1000:02d}"
+        end_fmt = f"{end_ms // 60000}:{(end_ms % 60000) // 1000:02d}"
+        lines: list[str] = []
+        for item in items:
+            speaker = item.speaker.capitalize() if item.speaker else "Unknown"
+            lines.append(f"{speaker}: {item.text}")
+        parts.append(f"[Window {i}: {start_fmt} - {end_fmt}]\n" + "\n".join(lines))
+    return "\n\n".join(parts)
+
+
+def _build_user_prompt(windows_text: str, note: ClinicalNote) -> str:
+    note_parts: list[str] = []
+    for section in note.sections:
+        if section.text.strip():
+            note_parts.append(f"## {section.title}\n{section.text}")
+
+    return (
+        "## Transcript Windows (task-related language detected)\n\n"
+        f"{windows_text}\n\n"
+        "## Full Clinical Note\n\n" + "\n\n".join(note_parts)
+    )
+
+
+class TaskRecommender(BaseRecommender):
+    def recommend(
+        self, note: ClinicalNote, client: LlmAnthropic, transcript: Transcript | None = None
+    ) -> list[CommandProposal]:
+        if not transcript or not transcript.items:
+            return []
+
+        timestamps = find_task_matches(transcript)
+        if not timestamps:
+            return []
+
+        windows = merge_windows(timestamps)
+        window_items = extract_window_items(transcript, windows)
+        windows_text = format_transcript_windows(window_items)
+        if not windows_text:
+            return []
+
+        client.reset_prompts()
+        client.set_system_prompt([_SYSTEM_PROMPT])
+        client.set_user_prompt([_build_user_prompt(windows_text, note)])
+        client.set_schema(TaskRecommendationList)
+
+        try:
+            response = client.request()
+        except Exception:
+            log.exception("LLM request failed for task recommendations")
+            return []
+
+        if response.code != HTTPStatus.OK:
+            log.info(f"LLM returned {response.code} for task recommendations: {response.response}")
+            return []
+
+        try:
+            parsed = TaskRecommendationList.model_validate(json.loads(response.response))
+        except Exception:
+            log.exception(f"Failed to parse task LLM response: {response.response}")
+            return []
+
+        proposals: list[CommandProposal] = []
+        for task in parsed.tasks:
+            if not task.title.strip():
+                continue
+            proposals.append(
+                CommandProposal(
+                    command_type="task",
+                    display=task.title.strip(),
+                    data={
+                        "title": task.title.strip(),
+                        "due_date": None,
+                        "assign_to": None,
+                        "labels": None,
+                        "comment": task.comment or None,
+                        "due_date_hint": task.due_date_hint or None,
+                        "assignee_hint": task.assignee_hint or None,
+                        "reason": task.reason,
+                    },
+                    section_key="_recommended",
+                )
+            )
+        return proposals

--- a/hyperscribe/scribe/recommendations/task.py
+++ b/hyperscribe/scribe/recommendations/task.py
@@ -19,16 +19,6 @@ from hyperscribe.scribe.recommendations.schemas import TaskRecommendationList
 
 _TASK_KEYWORDS = [
     r"\btasks?\b",
-    r"\bfollow[\s-]?ups?\b",
-    r"\bto[\s-]?dos?\b",
-    r"\breminds?\b",
-    r"\breminders?\b",
-    r"\bschedul(?:e|ing)\b",
-    r"\bbook(?:ing)?\b",
-    r"\bcall\s+back\b",
-    r"\bcheck\s+back\b",
-    r"\breturn\s+(?:in|visit)\b",
-    r"\bcome\s+back\b",
 ]
 _KEYWORD_PATTERN = re.compile("|".join(_TASK_KEYWORDS), re.IGNORECASE)
 _WINDOW_MS = 120_000  # 2 minutes
@@ -39,10 +29,9 @@ _SYSTEM_PROMPT = (
     "1. Transcript windows from a patient-provider encounter where task-related language was detected.\n"
     "2. The full structured clinical note for context.\n\n"
     "Extract actionable post-visit tasks for the care team. Examples:\n"
-    "- Follow-up appointments (e.g. 'schedule follow-up in 2 weeks')\n"
-    "- Calls to make (e.g. 'call patient with results')\n"
-    "- Patient education or instructions to send\n"
-    "- Prior authorizations to submit\n\n"
+    "- Add a task to make calls (e.g. 'call patient with results')\n"
+    "- Add a task to call patient with instructions\n"
+    "- Add a task to check if patient is being followed by a specialty\n\n"
     "For each task, provide:\n"
     "- A clear, concise title a staff member can act on\n"
     "- due_date_hint if the provider mentioned timing (relative or absolute)\n"

--- a/hyperscribe/scribe/static/soap-group.js
+++ b/hyperscribe/scribe/static/soap-group.js
@@ -1546,7 +1546,6 @@ export function SoapGroup({ title, groupColor, sections, commandBySectionKey, on
                       readOnly=${readOnly || entry.command.already_documented || isRejected}
                       onEditingChange=${onEditingChange}
                     />
-                    ${entry.command.data.reason && html`<div class="rec-reason">${entry.command.data.reason}</div>`}
                     ${entry.command.data.due_date_hint && html`<div class="rec-hint">Suggested timing: ${entry.command.data.due_date_hint}</div>`}
                     ${entry.command.data.assignee_hint && html`<div class="rec-hint">Suggested assignee: ${entry.command.data.assignee_hint}</div>`}
                   </div>

--- a/hyperscribe/scribe/static/soap-group.js
+++ b/hyperscribe/scribe/static/soap-group.js
@@ -1522,6 +1522,54 @@ export function SoapGroup({ title, groupColor, sections, commandBySectionKey, on
             </div>
           `;
         })()}
+        ${(() => {
+          if (title !== 'ASSESSMENT & PLAN') return null;
+          const taskRecs = visibleRecs
+            .map(cmd => ({ command: cmd, index: cmd._origIndex }))
+            .filter(e => e.command.command_type === 'task');
+          if (taskRecs.length === 0) return null;
+          return html`
+            <div class="subsection">
+              <div class="subsection-title">Recommended Tasks</div>
+              ${taskRecs.map(entry => {
+                const isAccepted = entry.command.accepted && !entry.command.rejected;
+                const isRejected = entry.command.rejected;
+                return html`
+                <div class="content-block recommendation-block rec-task${isRejected ? ' rec-rejected' : ''}" key=${'rec-task-' + entry.index}>
+                  <div class="recommendation-content">
+                    <${TaskRow}
+                      command=${entry.command}
+                      commandIndex=${entry.index}
+                      onEdit=${onEditRecommendation}
+                      onDelete=${onDeleteRecommendation}
+                      assignees=${assignees}
+                      readOnly=${readOnly || entry.command.already_documented || isRejected}
+                      onEditingChange=${onEditingChange}
+                    />
+                    ${entry.command.data.reason && html`<div class="rec-reason">${entry.command.data.reason}</div>`}
+                    ${entry.command.data.due_date_hint && html`<div class="rec-hint">Suggested timing: ${entry.command.data.due_date_hint}</div>`}
+                    ${entry.command.data.assignee_hint && html`<div class="rec-hint">Suggested assignee: ${entry.command.data.assignee_hint}</div>`}
+                  </div>
+                  <div class="recommendation-actions">
+                    ${entry.command.already_documented
+                      ? html`<span class="rec-documented-badge">${entry.command._added_now ? 'Added' : 'Already in chart'}</span>`
+                      : !readOnly && html`
+                          ${isRejected && html`<span class="rec-rejected-badge">Rejected</span>`}
+                          ${isAccepted && html`<span class="rec-accepted-badge">Accepted</span>`}
+                          ${onAddNow && isAccepted && html`<button type="button" class="rec-btn-add-now" disabled=${entry.command._adding} onClick=${() => !entry.command._adding && onAddNow(entry.command, true, entry.index)}>${entry.command._adding ? 'Adding...' : 'Add Now'}</button>`}
+                          ${!entry.command._adding && html`
+                            <button type="button" class="rec-btn ${isRejected ? 'rec-btn-reject' : 'rec-btn-muted'}" onClick=${() => onRejectRecommendation(entry.index)} title="Reject">${ICON_X}</button>
+                            <button type="button" class="rec-btn ${isAccepted ? 'rec-btn-accept' : 'rec-btn-muted'}" onClick=${() => onAcceptRecommendation(entry.index)} title="Accept">${ICON_CHECK}</button>
+                          `}
+                        `
+                    }
+                  </div>
+                </div>
+                `;
+              })}
+            </div>
+          `;
+        })()}
         ${onAddTask && html`
           <div class="ad-hoc-buttons">
             <button type="button" class="ad-hoc-btn" onClick=${onAddTask}>+ Task</button>

--- a/hyperscribe/scribe/static/styles.css
+++ b/hyperscribe/scribe/static/styles.css
@@ -1469,3 +1469,10 @@ h2 { margin-bottom: 4px; }
 .signed-note-icon { font-size: 48px; margin-bottom: 16px; }
 .signed-note-title { font-size: 20px; font-weight: 700; color: #111; margin-bottom: 8px; }
 .signed-note-message { font-size: 15px; color: #6b7280; max-width: 480px; line-height: 1.5; }
+
+/* Task recommendation extras */
+.rec-reason {
+    font-size: 12px; color: #6b7280; font-style: italic;
+    margin-top: 4px; padding-left: 12px; border-left: 2px solid #e5e7eb;
+}
+.rec-hint { font-size: 11px; color: #9ca3af; margin-top: 2px; }

--- a/tests/hyperscribe/scribe/clients/nabla/test_backend.py
+++ b/tests/hyperscribe/scribe/clients/nabla/test_backend.py
@@ -96,6 +96,18 @@ def test_generate_note_with_patient_context() -> None:
     assert "Jane Doe" in payload["note_sections_customization"][1]["custom_instruction"]
 
 
+def test_generate_note_with_unknown_gender_omits_field() -> None:
+    backend, mock_rest_client = _make_backend()
+    mock_rest_client.generate_note.return_value = {"title": "Note", "sections": []}
+
+    ctx = PatientContext(name="Pat Smith", birth_date="1985-01-01", gender="UNK")
+    backend.generate_note(Transcript(), patient_context=ctx)
+
+    payload = mock_rest_client.generate_note.call_args.args[0]
+    demographics = payload["structured_context"]["patient_demographics"]
+    assert "gender" not in demographics
+
+
 def test_generate_note_without_patient_context() -> None:
     backend, mock_rest_client = _make_backend()
     mock_rest_client.generate_note.return_value = {"title": "Note", "sections": []}

--- a/tests/hyperscribe/scribe/recommendations/test_init.py
+++ b/tests/hyperscribe/scribe/recommendations/test_init.py
@@ -55,6 +55,7 @@ def test_recommend_commands_calls_all_recommenders(mock_llm_cls: MagicMock) -> N
             return_value=[rx_proposal],
         ) as mock_rx,
         patch("hyperscribe.scribe.recommendations.ReferRecommender.recommend", return_value=[]),
+        patch("hyperscribe.scribe.recommendations.TaskRecommender.recommend", return_value=[]),
     ):
         note = _make_note()
         proposals = recommend_commands(note, "test-api-key")
@@ -63,9 +64,9 @@ def test_recommend_commands_calls_all_recommenders(mock_llm_cls: MagicMock) -> N
     assert proposals[0].command_type == "medication_statement"
     assert proposals[1].command_type == "allergy"
     assert proposals[2].command_type == "prescribe"
-    mock_med.assert_called_once_with(note, mock_client)
-    mock_allergy.assert_called_once_with(note, mock_client)
-    mock_rx.assert_called_once_with(note, mock_client)
+    mock_med.assert_called_once_with(note, mock_client, transcript=None)
+    mock_allergy.assert_called_once_with(note, mock_client, transcript=None)
+    mock_rx.assert_called_once_with(note, mock_client, transcript=None)
 
 
 @patch("hyperscribe.scribe.recommendations.LlmAnthropic")
@@ -77,11 +78,12 @@ def test_recommend_commands_creates_client_with_settings(mock_llm_cls: MagicMock
         patch("hyperscribe.scribe.recommendations.AllergyRecommender.recommend", return_value=[]),
         patch("hyperscribe.scribe.recommendations.PrescriptionRecommender.recommend", return_value=[]),
         patch("hyperscribe.scribe.recommendations.ReferRecommender.recommend", return_value=[]),
+        patch("hyperscribe.scribe.recommendations.TaskRecommender.recommend", return_value=[]),
     ):
         recommend_commands(_make_note(), "my-api-key")
 
     # Each recommender gets its own client instance
-    assert mock_llm_cls.call_count == 4
+    assert mock_llm_cls.call_count == 5
     for call in mock_llm_cls.call_args_list:
         settings = call.args[0]
         assert settings.api_key == "my-api-key"
@@ -114,6 +116,7 @@ def test_recommend_commands_handles_recommender_exception(mock_llm_cls: MagicMoc
             return_value=[],
         ),
         patch("hyperscribe.scribe.recommendations.ReferRecommender.recommend", return_value=[]),
+        patch("hyperscribe.scribe.recommendations.TaskRecommender.recommend", return_value=[]),
     ):
         proposals = recommend_commands(_make_note(), "test-api-key")
 
@@ -131,6 +134,7 @@ def test_recommend_commands_empty_note(mock_llm_cls: MagicMock) -> None:
         patch("hyperscribe.scribe.recommendations.AllergyRecommender.recommend", return_value=[]),
         patch("hyperscribe.scribe.recommendations.PrescriptionRecommender.recommend", return_value=[]),
         patch("hyperscribe.scribe.recommendations.ReferRecommender.recommend", return_value=[]),
+        patch("hyperscribe.scribe.recommendations.TaskRecommender.recommend", return_value=[]),
     ):
         note = ClinicalNote(title="Empty", sections=[])
         proposals = recommend_commands(note, "test-api-key")

--- a/tests/hyperscribe/scribe/recommendations/test_task.py
+++ b/tests/hyperscribe/scribe/recommendations/test_task.py
@@ -1,0 +1,381 @@
+from __future__ import annotations
+
+import json
+from http import HTTPStatus
+from unittest.mock import MagicMock
+
+from canvas_sdk.clients.llms.structures import LlmResponse, LlmTokens
+
+from hyperscribe.scribe.backend.models import (
+    ClinicalNote,
+    NoteSection,
+    Transcript,
+    TranscriptItem,
+)
+from hyperscribe.scribe.recommendations.task import (
+    TaskRecommender,
+    _build_user_prompt,
+    extract_window_items,
+    find_task_matches,
+    format_transcript_windows,
+    merge_windows,
+)
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────
+
+
+def _item(text: str, speaker: str, start_ms: int, end_ms: int) -> TranscriptItem:
+    return TranscriptItem(text=text, speaker=speaker, start_offset_ms=start_ms, end_offset_ms=end_ms)
+
+
+def _transcript(items: list[TranscriptItem]) -> Transcript:
+    return Transcript(items=items)
+
+
+def _make_note(sections: list[NoteSection] | None = None) -> ClinicalNote:
+    return ClinicalNote(title="Test Note", sections=sections or [])
+
+
+def _make_client(response_data: dict | None = None, code: HTTPStatus = HTTPStatus.OK) -> MagicMock:
+    client = MagicMock()
+    if response_data is not None:
+        client.request.return_value = LlmResponse(
+            code=code,
+            response=json.dumps(response_data),
+            tokens=LlmTokens(prompt=100, generated=50),
+        )
+    return client
+
+
+# ── find_task_matches ────────────────────────────────────────────────────
+
+
+def test_find_task_matches_basic() -> None:
+    t = _transcript(
+        [
+            _item("I have a headache", "patient", 0, 2000),
+            _item("Let's schedule a follow up", "provider", 3000, 5000),
+            _item("Sounds good", "patient", 6000, 7000),
+            _item("We also need to add a task for labs", "provider", 8000, 10000),
+        ]
+    )
+    matches = find_task_matches(t)
+    assert matches == [4000, 9000]
+
+
+def test_find_task_matches_no_matches() -> None:
+    t = _transcript(
+        [
+            _item("Hello", "provider", 0, 1000),
+            _item("Hi doctor", "patient", 1500, 2500),
+        ]
+    )
+    assert find_task_matches(t) == []
+
+
+def test_find_task_matches_case_insensitive() -> None:
+    t = _transcript(
+        [
+            _item("FOLLOW UP in two weeks", "provider", 0, 2000),
+            _item("Schedule that please", "provider", 3000, 4000),
+        ]
+    )
+    matches = find_task_matches(t)
+    assert len(matches) == 2
+
+
+def test_find_task_matches_hyphenated() -> None:
+    t = _transcript(
+        [
+            _item("We need a follow-up", "provider", 0, 2000),
+        ]
+    )
+    assert len(find_task_matches(t)) == 1
+
+
+def test_find_task_matches_todo_variant() -> None:
+    t = _transcript(
+        [
+            _item("Add that to the to-do list", "provider", 0, 2000),
+        ]
+    )
+    assert len(find_task_matches(t)) == 1
+
+
+# ── merge_windows ────────────────────────────────────────────────────────
+
+
+def test_merge_windows_no_overlap() -> None:
+    result = merge_windows([60_000, 360_000])
+    assert result == [(0, 180_000), (240_000, 480_000)]
+
+
+def test_merge_windows_overlap() -> None:
+    result = merge_windows([100_000, 150_000])
+    assert len(result) == 1
+    assert result[0] == (0, 270_000)
+
+
+def test_merge_windows_all_overlap() -> None:
+    result = merge_windows([60_000, 90_000, 120_000])
+    assert len(result) == 1
+
+
+def test_merge_windows_empty() -> None:
+    assert merge_windows([]) == []
+
+
+def test_merge_windows_clamps_to_zero() -> None:
+    result = merge_windows([30_000])
+    assert result[0][0] == 0
+
+
+# ── extract_window_items ─────────────────────────────────────────────────
+
+
+def test_extract_window_items_basic() -> None:
+    t = _transcript(
+        [
+            _item("a", "p", 0, 1000),
+            _item("b", "p", 50_000, 51_000),
+            _item("c", "p", 200_000, 201_000),
+        ]
+    )
+    windows = [(0, 60_000), (190_000, 210_000)]
+    result = extract_window_items(t, windows)
+    assert len(result) == 2
+    assert len(result[0]) == 2  # a and b overlap with first window
+    assert len(result[1]) == 1  # c overlaps with second window
+
+
+def test_extract_window_items_boundary() -> None:
+    t = _transcript(
+        [
+            _item("edge", "p", 60_000, 60_001),
+        ]
+    )
+    windows = [(0, 60_000)]
+    result = extract_window_items(t, windows)
+    assert len(result[0]) == 1  # item starts at window end boundary
+
+
+# ── format_transcript_windows ────────────────────────────────────────────
+
+
+def test_format_transcript_windows_basic() -> None:
+    items = [
+        [
+            _item("Let's follow up", "provider", 180_000, 182_000),
+            _item("OK doctor", "patient", 183_000, 184_000),
+        ],
+    ]
+    result = format_transcript_windows(items)
+    assert "[Window 1: 3:00 - 3:04]" in result
+    assert "Provider: Let's follow up" in result
+    assert "Patient: OK doctor" in result
+
+
+def test_format_transcript_windows_empty_items() -> None:
+    assert format_transcript_windows([[]]) == ""
+
+
+def test_format_transcript_windows_multiple_windows() -> None:
+    items = [
+        [_item("first window", "provider", 0, 1000)],
+        [_item("second window", "provider", 300_000, 301_000)],
+    ]
+    result = format_transcript_windows(items)
+    assert "[Window 1:" in result
+    assert "[Window 2:" in result
+
+
+# ── _build_user_prompt ───────────────────────────────────────────────────
+
+
+def test_build_user_prompt_includes_windows_and_note() -> None:
+    note = _make_note(
+        [
+            NoteSection(key="hpi", title="HPI", text="Patient complains of headache."),
+            NoteSection(key="plan", title="Plan", text="Follow up in 2 weeks."),
+        ]
+    )
+    result = _build_user_prompt("Provider: follow up in 2 weeks", note)
+    assert "Transcript Windows" in result
+    assert "follow up in 2 weeks" in result
+    assert "## HPI" in result
+    assert "## Plan" in result
+
+
+def test_build_user_prompt_skips_empty_sections() -> None:
+    note = _make_note(
+        [
+            NoteSection(key="hpi", title="HPI", text="Content here."),
+            NoteSection(key="ros", title="ROS", text="  "),
+        ]
+    )
+    result = _build_user_prompt("window text", note)
+    assert "## HPI" in result
+    assert "## ROS" not in result
+
+
+# ── TaskRecommender.recommend ────────────────────────────────────────────
+
+
+def test_recommend_extracts_tasks() -> None:
+    t = _transcript(
+        [
+            _item("Let's schedule a follow-up in two weeks", "provider", 60_000, 62_000),
+        ]
+    )
+    note = _make_note([NoteSection(key="plan", title="Plan", text="Follow up in 2 weeks.")])
+    client = _make_client(
+        {
+            "tasks": [
+                {
+                    "title": "Schedule follow-up in 2 weeks",
+                    "dueDateHint": "2 weeks",
+                    "assigneeHint": None,
+                    "comment": None,
+                    "reason": "Provider said: 'Let's schedule a follow-up in two weeks'",
+                }
+            ]
+        }
+    )
+
+    proposals = TaskRecommender().recommend(note, client, transcript=t)
+
+    assert len(proposals) == 1
+    assert proposals[0].command_type == "task"
+    assert proposals[0].display == "Schedule follow-up in 2 weeks"
+    assert proposals[0].data["title"] == "Schedule follow-up in 2 weeks"
+    assert proposals[0].data["due_date_hint"] == "2 weeks"
+    assert proposals[0].data["reason"] == "Provider said: 'Let's schedule a follow-up in two weeks'"
+    assert proposals[0].data["due_date"] is None
+    assert proposals[0].data["assign_to"] is None
+    assert proposals[0].section_key == "_recommended"
+
+
+def test_recommend_multiple_tasks() -> None:
+    t = _transcript(
+        [
+            _item("Schedule follow-up", "provider", 60_000, 62_000),
+            _item("Also remind me to call the patient", "provider", 300_000, 302_000),
+        ]
+    )
+    note = _make_note([NoteSection(key="plan", title="Plan", text="Follow up.")])
+    client = _make_client(
+        {
+            "tasks": [
+                {"title": "Schedule follow-up", "reason": "transcript excerpt 1"},
+                {"title": "Call patient with results", "reason": "transcript excerpt 2"},
+            ]
+        }
+    )
+
+    proposals = TaskRecommender().recommend(note, client, transcript=t)
+    assert len(proposals) == 2
+    assert proposals[0].display == "Schedule follow-up"
+    assert proposals[1].display == "Call patient with results"
+
+
+def test_recommend_no_transcript() -> None:
+    note = _make_note()
+    client = _make_client()
+    assert TaskRecommender().recommend(note, client, transcript=None) == []
+    client.request.assert_not_called()
+
+
+def test_recommend_empty_transcript() -> None:
+    note = _make_note()
+    client = _make_client()
+    assert TaskRecommender().recommend(note, client, transcript=_transcript([])) == []
+    client.request.assert_not_called()
+
+
+def test_recommend_no_keywords() -> None:
+    t = _transcript(
+        [
+            _item("Hello how are you", "provider", 0, 2000),
+            _item("Fine thanks", "patient", 3000, 4000),
+        ]
+    )
+    note = _make_note()
+    client = _make_client()
+    assert TaskRecommender().recommend(note, client, transcript=t) == []
+    client.request.assert_not_called()
+
+
+def test_recommend_llm_error() -> None:
+    t = _transcript([_item("Schedule a follow-up", "provider", 0, 2000)])
+    note = _make_note([NoteSection(key="plan", title="Plan", text="Follow up.")])
+    client = MagicMock()
+    client.request.return_value = LlmResponse(
+        code=HTTPStatus.INTERNAL_SERVER_ERROR,
+        response="Server error",
+        tokens=LlmTokens(prompt=0, generated=0),
+    )
+    assert TaskRecommender().recommend(note, client, transcript=t) == []
+
+
+def test_recommend_llm_exception() -> None:
+    t = _transcript([_item("Schedule a follow-up", "provider", 0, 2000)])
+    note = _make_note([NoteSection(key="plan", title="Plan", text="Follow up.")])
+    client = MagicMock()
+    client.request.side_effect = Exception("Network error")
+    assert TaskRecommender().recommend(note, client, transcript=t) == []
+
+
+def test_recommend_malformed_response() -> None:
+    t = _transcript([_item("Schedule a follow-up", "provider", 0, 2000)])
+    note = _make_note([NoteSection(key="plan", title="Plan", text="Follow up.")])
+    client = MagicMock()
+    client.request.return_value = LlmResponse(
+        code=HTTPStatus.OK,
+        response="not valid json",
+        tokens=LlmTokens(prompt=100, generated=50),
+    )
+    assert TaskRecommender().recommend(note, client, transcript=t) == []
+
+
+def test_recommend_empty_tasks() -> None:
+    t = _transcript([_item("Schedule a follow-up", "provider", 0, 2000)])
+    note = _make_note([NoteSection(key="plan", title="Plan", text="Follow up.")])
+    client = _make_client({"tasks": []})
+    assert TaskRecommender().recommend(note, client, transcript=t) == []
+
+
+def test_recommend_skips_blank_titles() -> None:
+    t = _transcript([_item("Schedule a follow-up", "provider", 0, 2000)])
+    note = _make_note([NoteSection(key="plan", title="Plan", text="Follow up.")])
+    client = _make_client(
+        {
+            "tasks": [
+                {"title": "  ", "reason": "some context"},
+                {"title": "Real task", "reason": "some context"},
+            ]
+        }
+    )
+    proposals = TaskRecommender().recommend(note, client, transcript=t)
+    assert len(proposals) == 1
+    assert proposals[0].display == "Real task"
+
+
+def test_recommend_with_assignee_and_comment() -> None:
+    t = _transcript([_item("Have the front desk schedule a follow-up", "provider", 0, 2000)])
+    note = _make_note([NoteSection(key="plan", title="Plan", text="Follow up.")])
+    client = _make_client(
+        {
+            "tasks": [
+                {
+                    "title": "Schedule follow-up",
+                    "assigneeHint": "front desk",
+                    "comment": "Patient prefers mornings",
+                    "reason": "Provider mentioned front desk",
+                }
+            ]
+        }
+    )
+    proposals = TaskRecommender().recommend(note, client, transcript=t)
+    assert proposals[0].data["assignee_hint"] == "front desk"
+    assert proposals[0].data["comment"] == "Patient prefers mornings"

--- a/tests/hyperscribe/scribe/recommendations/test_task.py
+++ b/tests/hyperscribe/scribe/recommendations/test_task.py
@@ -55,9 +55,9 @@ def test_find_task_matches_basic() -> None:
     t = _transcript(
         [
             _item("I have a headache", "patient", 0, 2000),
-            _item("Let's schedule a follow up", "provider", 3000, 5000),
+            _item("Add a task for the follow up", "provider", 3000, 5000),
             _item("Sounds good", "patient", 6000, 7000),
-            _item("We also need to add a task for labs", "provider", 8000, 10000),
+            _item("We also need a task for labs", "provider", 8000, 10000),
         ]
     )
     matches = find_task_matches(t)
@@ -77,27 +77,18 @@ def test_find_task_matches_no_matches() -> None:
 def test_find_task_matches_case_insensitive() -> None:
     t = _transcript(
         [
-            _item("FOLLOW UP in two weeks", "provider", 0, 2000),
-            _item("Schedule that please", "provider", 3000, 4000),
+            _item("Add a TASK for the labs", "provider", 0, 2000),
+            _item("Another Task here", "provider", 3000, 4000),
         ]
     )
     matches = find_task_matches(t)
     assert len(matches) == 2
 
 
-def test_find_task_matches_hyphenated() -> None:
+def test_find_task_matches_plural() -> None:
     t = _transcript(
         [
-            _item("We need a follow-up", "provider", 0, 2000),
-        ]
-    )
-    assert len(find_task_matches(t)) == 1
-
-
-def test_find_task_matches_todo_variant() -> None:
-    t = _transcript(
-        [
-            _item("Add that to the to-do list", "provider", 0, 2000),
+            _item("We have some tasks to do", "provider", 0, 2000),
         ]
     )
     assert len(find_task_matches(t)) == 1
@@ -225,7 +216,7 @@ def test_build_user_prompt_skips_empty_sections() -> None:
 def test_recommend_extracts_tasks() -> None:
     t = _transcript(
         [
-            _item("Let's schedule a follow-up in two weeks", "provider", 60_000, 62_000),
+            _item("Add a task to schedule a follow-up in two weeks", "provider", 60_000, 62_000),
         ]
     )
     note = _make_note([NoteSection(key="plan", title="Plan", text="Follow up in 2 weeks.")])
@@ -259,8 +250,8 @@ def test_recommend_extracts_tasks() -> None:
 def test_recommend_multiple_tasks() -> None:
     t = _transcript(
         [
-            _item("Schedule follow-up", "provider", 60_000, 62_000),
-            _item("Also remind me to call the patient", "provider", 300_000, 302_000),
+            _item("Add a task for the follow-up", "provider", 60_000, 62_000),
+            _item("Another task to call the patient", "provider", 300_000, 302_000),
         ]
     )
     note = _make_note([NoteSection(key="plan", title="Plan", text="Follow up.")])
@@ -307,7 +298,7 @@ def test_recommend_no_keywords() -> None:
 
 
 def test_recommend_llm_error() -> None:
-    t = _transcript([_item("Schedule a follow-up", "provider", 0, 2000)])
+    t = _transcript([_item("Add a task for the follow-up", "provider", 0, 2000)])
     note = _make_note([NoteSection(key="plan", title="Plan", text="Follow up.")])
     client = MagicMock()
     client.request.return_value = LlmResponse(
@@ -319,7 +310,7 @@ def test_recommend_llm_error() -> None:
 
 
 def test_recommend_llm_exception() -> None:
-    t = _transcript([_item("Schedule a follow-up", "provider", 0, 2000)])
+    t = _transcript([_item("Add a task for the follow-up", "provider", 0, 2000)])
     note = _make_note([NoteSection(key="plan", title="Plan", text="Follow up.")])
     client = MagicMock()
     client.request.side_effect = Exception("Network error")
@@ -327,7 +318,7 @@ def test_recommend_llm_exception() -> None:
 
 
 def test_recommend_malformed_response() -> None:
-    t = _transcript([_item("Schedule a follow-up", "provider", 0, 2000)])
+    t = _transcript([_item("Add a task for the follow-up", "provider", 0, 2000)])
     note = _make_note([NoteSection(key="plan", title="Plan", text="Follow up.")])
     client = MagicMock()
     client.request.return_value = LlmResponse(
@@ -339,14 +330,14 @@ def test_recommend_malformed_response() -> None:
 
 
 def test_recommend_empty_tasks() -> None:
-    t = _transcript([_item("Schedule a follow-up", "provider", 0, 2000)])
+    t = _transcript([_item("Add a task for the follow-up", "provider", 0, 2000)])
     note = _make_note([NoteSection(key="plan", title="Plan", text="Follow up.")])
     client = _make_client({"tasks": []})
     assert TaskRecommender().recommend(note, client, transcript=t) == []
 
 
 def test_recommend_skips_blank_titles() -> None:
-    t = _transcript([_item("Schedule a follow-up", "provider", 0, 2000)])
+    t = _transcript([_item("Add a task for the follow-up", "provider", 0, 2000)])
     note = _make_note([NoteSection(key="plan", title="Plan", text="Follow up.")])
     client = _make_client(
         {
@@ -362,7 +353,7 @@ def test_recommend_skips_blank_titles() -> None:
 
 
 def test_recommend_with_assignee_and_comment() -> None:
-    t = _transcript([_item("Have the front desk schedule a follow-up", "provider", 0, 2000)])
+    t = _transcript([_item("Add a task for the front desk to handle", "provider", 0, 2000)])
     note = _make_note([NoteSection(key="plan", title="Plan", text="Follow up.")])
     client = _make_client(
         {


### PR DESCRIPTION
This pull request introduces a new system for extracting and recommending actionable post-visit clinical tasks based on transcript and note content. It adds a `TaskRecommender` that leverages LLMs to identify, structure, and display task recommendations, and updates the core recommendation infrastructure to support passing transcript data. The UI is also enhanced to surface these recommendations to users in the appropriate section. Additionally, there are minor improvements to gender mapping in backend payloads.

**Task Recommendation System:**

- Added a new `TaskRecommender` class that analyzes transcripts and clinical notes to extract actionable post-visit tasks using LLMs, including logic for keyword detection, transcript windowing, LLM prompting, and schema validation. (`hyperscribe/scribe/recommendations/task.py`)
- Defined new Pydantic models `TaskRecommendation` and `TaskRecommendationList` for structured LLM output, including fields for title, due date hint, assignee hint, comment, and reason. (`hyperscribe/scribe/recommendations/schemas.py`)

**Frontend Enhancements:**

- Updated the SOAP group UI to display recommended tasks under "ASSESSMENT & PLAN", including task details, hints, and action buttons for accepting or rejecting recommendations. (`hyperscribe/scribe/static/soap-group.js`)
- Added new CSS styles for task recommendation details and hints for improved readability and visual distinction. (`hyperscribe/scribe/static/styles.css`)

**Backend Data Improvements:**

- Improved gender mapping in the Nabla backend payload builder to only include gender if it maps to a known value, preventing accidental uppercasing of unknown values. (`hyperscribe/scribe/clients/nabla/backend.py`)