### PR TITLE
Running Hyperscribe on a provided transcript through API

### DIFF
--- a/hyperscribe/CANVAS_MANIFEST.json
+++ b/hyperscribe/CANVAS_MANIFEST.json
@@ -1,6 +1,6 @@
 {
   "sdk_version": "0.85.0",
-  "plugin_version": "2026-01-26 v0.2.156 (main)",
+  "plugin_version": "2026-04-17 v0.2.157 (db-20260417-automated-transcript)",
   "name": "hyperscribe",
   "description": "Create commands based on the content of an audio discussion between a patient and a provider.",
   "url_permissions": [],
@@ -160,9 +160,9 @@
     "VendorTextLLM"
   ],
   "tags": {
-    "version_date": "2026-01-26",
-    "version_branch": "main",
-    "version_semantic": "0.2.156"
+    "version_date": "2026-04-17",
+    "version_branch": "db-20260417-automated-transcript",
+    "version_semantic": "0.2.157"
   },
   "references": [],
   "license": "",

--- a/hyperscribe/commands/base.py
+++ b/hyperscribe/commands/base.py
@@ -23,7 +23,7 @@ class Base:
         cache: LimitedCache,
         identification: IdentificationParameters,
         permissions: TemplatePermissions,
-    ):
+    ) -> None:
         self.settings = settings
         self.identification = identification
         self.cache = cache

--- a/hyperscribe/handlers/capture_view.py
+++ b/hyperscribe/handlers/capture_view.py
@@ -206,6 +206,38 @@ class CaptureView(SimpleAPI):
         content_type = CycleData.content_type_text()
         return self._add_cycle(content, content_type)
 
+    @api.post("/capture/transcript-session/<patient_id>/<note_id>")
+    def transcript_session_post(self) -> list[Response | Effect]:
+        body = self.request.json()
+        transcript = body.get("transcript", "")
+        if not isinstance(transcript, str) or not transcript.strip():
+            return [Response(b"'transcript' must be a non-empty string", HTTPStatus.BAD_REQUEST)]
+
+        identification = IdentificationParameters(
+            patient_uuid=self.request.path_params["patient_id"],
+            note_uuid=self.request.path_params["note_id"],
+            provider_uuid=str(Note.objects.get(id=self.request.path_params["note_id"]).provider.id),
+            canvas_instance=self.environment[Constants.CUSTOMER_IDENTIFIER],
+        )
+
+        stop_and_go = StopAndGo(identification.note_uuid)
+        stop_and_go.add_waiting_cycle().set_ended(True).save()
+        cycle = stop_and_go.waiting_cycles()[-1]
+
+        aws_s3 = AwsS3Credentials.from_dictionary(self.secrets)
+        path_s3 = CycleData.s3_key_path(identification, cycle)
+        response = AwsS3(aws_s3).upload_binary_to_s3(path_s3, transcript.encode(), CycleData.content_type_text())
+        if response.status_code != HTTPStatus.OK:
+            log.info(f"Failed to save transcript with status {response.status_code}: {str(response.content)}")
+            if not response.status_code:
+                return [Response(b"Failed to save transcript (AWS S3 failure)", HTTPStatus.SERVICE_UNAVAILABLE)]
+            return [Response(response.content, HTTPStatus(response.status_code))]
+
+        user_id = self.request.headers.get("canvas-logged-in-user-id")
+        executor.submit(Helper.with_cleanup(self.run_commander), identification, user_id)
+
+        return [Response(f"Transcript session cycle {cycle} started".encode(), HTTPStatus.CREATED)]
+
     def _draft_key(self) -> str:
         patient_uuid = self.request.path_params["patient_id"]
         note_uuid = self.request.path_params["note_id"]

--- a/hyperscribe/handlers/capture_view.py
+++ b/hyperscribe/handlers/capture_view.py
@@ -213,14 +213,24 @@ class CaptureView(SimpleAPI):
         if not isinstance(transcript, str) or not transcript.strip():
             return [Response(b"'transcript' must be a non-empty string", HTTPStatus.BAD_REQUEST)]
 
+        patient_id = self.request.path_params["patient_id"]
+        note_id = self.request.path_params["note_id"]
+
+        note_db = Note.objects.filter(id=note_id).first()
+        if not note_db:
+            return [Response(b"The note is incorrect", HTTPStatus.BAD_REQUEST)]
+        if not Helper.editable_note(note_db.dbid):
+            return [Response(b"The note is not editable", HTTPStatus.BAD_REQUEST)]
+
         identification = IdentificationParameters(
-            patient_uuid=self.request.path_params["patient_id"],
-            note_uuid=self.request.path_params["note_id"],
-            provider_uuid=str(Note.objects.get(id=self.request.path_params["note_id"]).provider.id),
+            patient_uuid=patient_id,
+            note_uuid=note_id,
+            provider_uuid=str(note_db.provider.id),
             canvas_instance=self.environment[Constants.CUSTOMER_IDENTIFIER],
         )
-
-        stop_and_go = StopAndGo(identification.note_uuid)
+        stop_and_go = StopAndGo.get(identification.note_uuid)
+        if stop_and_go.cycle() > 0:
+            return [Response(b"Hyperscribe has already run for this note", HTTPStatus.BAD_REQUEST)]
         stop_and_go.add_waiting_cycle().set_ended(True).save()
         cycle = stop_and_go.waiting_cycles()[-1]
 

--- a/tests/hyperscribe/commands/test_base.py
+++ b/tests/hyperscribe/commands/test_base.py
@@ -95,87 +95,6 @@ def test_class_name():
     assert result == expected
 
 
-def test_command_type():
-    tested = Base
-    with pytest.raises(NotImplementedError):
-        _ = tested.command_type()
-
-
-def test_schema_key():
-    tested = helper_instance()
-    with pytest.raises(NotImplementedError):
-        _ = tested.schema_key()
-
-
-def test_note_section():
-    tested = Base
-    with pytest.raises(NotImplementedError):
-        _ = tested.note_section()
-
-
-def test_staged_command_extract():
-    tested = helper_instance()
-    with pytest.raises(NotImplementedError):
-        _ = tested.staged_command_extract({})
-
-
-@patch.object(Base, "class_name")
-def test_custom_prompt(class_name):
-    def reset_mocks():
-        class_name.reset_mock()
-
-    tested = helper_instance()
-    tests = [
-        ("Command1", "Prompt1"),
-        ("Command2", "Prompt2"),
-        ("Command3", ""),  # <-- not active
-        ("Command4", ""),
-        ("Command5", ""),  # <--- unknown
-    ]
-    for class_name_side_effect, expected in tests:
-        class_name.side_effect = [class_name_side_effect]
-        result = tested.custom_prompt()
-        assert result == expected, f"---> {class_name_side_effect}"
-
-        calls = [call()]
-        assert class_name.mock_calls == calls
-        reset_mocks()
-
-
-def test_command_from_json():
-    chatter = MagicMock()
-    tested = helper_instance()
-    with pytest.raises(NotImplementedError):
-        instruction = InstructionWithParameters(
-            uuid="theUuid",
-            index=7,
-            instruction="theInstruction",
-            information="theInformation",
-            is_new=False,
-            is_updated=True,
-            previous_information="thePreviousInformation",
-            parameters={"key": "value"},
-        )
-        _ = tested.command_from_json(instruction, chatter)
-    assert chatter.mock_calls == []
-
-
-def test_add_code2description():
-    tested = helper_instance()
-    assert tested._arguments_code2description == {}
-
-    tested.add_code2description("code1", "description1")
-    tested.add_code2description("code2", "description2")
-    tested.add_code2description("code3", "description3")
-    tested.add_code2description("code2", "description4")
-    expected = {
-        "code1": "description1",
-        "code2": "description4",
-        "code3": "description3",
-    }
-    assert tested._arguments_code2description == expected
-
-
 @pytest.mark.parametrize(
     "items, index, name, expected_label",
     [
@@ -244,37 +163,136 @@ def test_add_code2description():
     ],
 )
 def test_resolve_item_by_index(items, index, name, expected_label):
-    result = Base.resolve_item_by_index(items, index, name)
+    tested = Base
+    result = tested.resolve_item_by_index(items, index, name)
     if expected_label is None:
         assert result is None
     else:
+        expected = expected_label
         assert result is not None
-        assert result.label == expected_label
+        assert result.label == expected
 
 
 @patch("hyperscribe.commands.base.log")
 def test_resolve_item_by_index_logs_warning_on_out_of_range(mock_log):
-    items = [CodedItem(uuid="uuid1", label="Condition A", code="A01")]
-    result = Base.resolve_item_by_index(items, 5, "Condition A")
+    tested = Base
+    result = tested.resolve_item_by_index([CodedItem(uuid="uuid1", label="Condition A", code="A01")], 5, "Condition A")
+    expected = "Condition A"
     assert result is not None
-    assert result.label == "Condition A"
-    assert mock_log.mock_calls == [
-        call.warning("Index 5 out of range for 1 items, falling back to name-based lookup"),
-    ]
+    assert result.label == expected
+
+    exp_calls = [call.warning("Index 5 out of range for 1 items, falling back to name-based lookup")]
+    assert mock_log.mock_calls == exp_calls
 
 
 @patch("hyperscribe.commands.base.log")
 def test_resolve_item_by_index_logs_warning_on_name_mismatch(mock_log):
-    items = [
-        CodedItem(uuid="uuid1", label="Condition A", code="A01"),
-        CodedItem(uuid="uuid2", label="Condition B", code="B02"),
-    ]
-    result = Base.resolve_item_by_index(items, 0, "Condition B")
+    tested = Base
+    result = tested.resolve_item_by_index(
+        [
+            CodedItem(uuid="uuid1", label="Condition A", code="A01"),
+            CodedItem(uuid="uuid2", label="Condition B", code="B02"),
+        ],
+        0,
+        "Condition B",
+    )
+    expected = "Condition B"
     assert result is not None
-    assert result.label == "Condition B"
-    assert mock_log.mock_calls == [
-        call.warning("Index 0 (Condition A) does not match name (Condition B), falling back to name-based lookup"),
+    assert result.label == expected
+
+    exp_calls = [call.warning("Index 0 (Condition A) does not match name (Condition B), falling back to name-based lookup")]
+    assert mock_log.mock_calls == exp_calls
+
+
+@patch("hyperscribe.commands.base.log")
+def test_resolve_item_by_index__out_of_range_no_name(mock_log):
+    tested = Base
+    result = tested.resolve_item_by_index([CodedItem(uuid="uuid1", label="Condition A", code="A01")], 5, None)
+    assert result is None
+
+    exp_calls = [call.warning("Index 5 out of range for 1 items, falling back to name-based lookup")]
+    assert mock_log.mock_calls == exp_calls
+
+
+def test_command_type():
+    tested = Base
+    with pytest.raises(NotImplementedError):
+        _ = tested.command_type()
+
+
+def test_schema_key():
+    tested = helper_instance()
+    with pytest.raises(NotImplementedError):
+        _ = tested.schema_key()
+
+
+def test_note_section():
+    tested = Base
+    with pytest.raises(NotImplementedError):
+        _ = tested.note_section()
+
+
+def test_staged_command_extract():
+    tested = helper_instance()
+    with pytest.raises(NotImplementedError):
+        _ = tested.staged_command_extract({})
+
+
+@patch.object(Base, "class_name")
+def test_custom_prompt(class_name):
+    def reset_mocks():
+        class_name.reset_mock()
+
+    tested = helper_instance()
+    tests = [
+        ("Command1", "Prompt1"),
+        ("Command2", "Prompt2"),
+        ("Command3", ""),  # <-- not active
+        ("Command4", ""),
+        ("Command5", ""),  # <--- unknown
     ]
+    for class_name_side_effect, expected in tests:
+        class_name.side_effect = [class_name_side_effect]
+        result = tested.custom_prompt()
+        assert result == expected, f"---> {class_name_side_effect}"
+
+        exp_calls = [call()]
+        assert class_name.mock_calls == exp_calls
+        reset_mocks()
+
+
+def test_command_from_json():
+    chatter = MagicMock()
+    tested = helper_instance()
+    with pytest.raises(NotImplementedError):
+        instruction = InstructionWithParameters(
+            uuid="theUuid",
+            index=7,
+            instruction="theInstruction",
+            information="theInformation",
+            is_new=False,
+            is_updated=True,
+            previous_information="thePreviousInformation",
+            parameters={"key": "value"},
+        )
+        _ = tested.command_from_json(instruction, chatter)
+    assert chatter.mock_calls == []
+
+
+def test_add_code2description():
+    tested = helper_instance()
+    assert tested._arguments_code2description == {}
+
+    tested.add_code2description("code1", "description1")
+    tested.add_code2description("code2", "description2")
+    tested.add_code2description("code3", "description3")
+    tested.add_code2description("code2", "description4")
+    expected = {
+        "code1": "description1",
+        "code2": "description4",
+        "code3": "description3",
+    }
+    assert tested._arguments_code2description == expected
 
 
 @patch("hyperscribe.commands.base.InstructionWithSummary")
@@ -366,8 +384,8 @@ def test_command_from_json_with_summary(command_from_json, instruction_with_summ
     result = tested.command_from_json_with_summary(instruction, chatter)
     assert result is None
 
-    calls = [call(instruction, chatter)]
-    assert command_from_json.mock_calls == calls
+    exp_calls = [call(instruction, chatter)]
+    assert command_from_json.mock_calls == exp_calls
     assert instruction_with_summary.mock_calls == []
     assert chatter.mock_calls == []
     assert command.mock_calls == []
@@ -400,15 +418,15 @@ def test_command_from_json_with_summary(command_from_json, instruction_with_summ
     expected = instruction_with_summary.add_explanation.return_value
     assert result is expected
 
-    calls = [call(instruction, chatter)]
-    assert command_from_json.mock_calls == calls
-    calls = [call.add_explanation(instruction=instruction_with_command, summary="theSummary")]
-    assert instruction_with_summary.mock_calls == calls
-    calls = [
+    exp_calls = [call(instruction, chatter)]
+    assert command_from_json.mock_calls == exp_calls
+    exp_calls = [call.add_explanation(instruction=instruction_with_command, summary="theSummary")]
+    assert instruction_with_summary.mock_calls == exp_calls
+    exp_calls = [
         call.reset_prompts(),
         call.single_conversation(system_prompt, user_prompt, schemas, instruction),
     ]
-    assert chatter.mock_calls == calls
+    assert chatter.mock_calls == exp_calls
     assert command.mock_calls == []
     reset_mocks()
     # -- no chatter response
@@ -419,15 +437,15 @@ def test_command_from_json_with_summary(command_from_json, instruction_with_summ
     expected = instruction_with_summary.add_explanation.return_value
     assert result is expected
 
-    calls = [call(instruction, chatter)]
-    assert command_from_json.mock_calls == calls
-    calls = [call.add_explanation(instruction=instruction_with_command, summary="")]
-    assert instruction_with_summary.mock_calls == calls
-    calls = [
+    exp_calls = [call(instruction, chatter)]
+    assert command_from_json.mock_calls == exp_calls
+    exp_calls = [call.add_explanation(instruction=instruction_with_command, summary="")]
+    assert instruction_with_summary.mock_calls == exp_calls
+    exp_calls = [
         call.reset_prompts(),
         call.single_conversation(system_prompt, user_prompt, schemas, instruction),
     ]
-    assert chatter.mock_calls == calls
+    assert chatter.mock_calls == exp_calls
     assert command.mock_calls == []
     reset_mocks()
 
@@ -500,16 +518,16 @@ def test_command_from_json_custom_prompted(custom_prompt, json_schema, demograph
         result = tested.command_from_json_custom_prompted("theData", chatter)
         assert result == expected
 
-        calls = [call()]
-        assert custom_prompt.mock_calls == calls
-        calls = [call.get(["command_custom_prompt"])]
-        assert json_schema.mock_calls == calls
-        calls = [call(False)]
-        assert demographic.mock_calls == calls
-        calls = [call.now()]
-        assert mock_datetime.mock_calls == calls
-        calls = [call.single_conversation(system_prompt, user_prompt, [{"the": "schema"}], None)]
-        assert chatter.mock_calls == calls
+        exp_calls = [call()]
+        assert custom_prompt.mock_calls == exp_calls
+        exp_calls = [call.get(["command_custom_prompt"])]
+        assert json_schema.mock_calls == exp_calls
+        exp_calls = [call(False)]
+        assert demographic.mock_calls == exp_calls
+        exp_calls = [call.now()]
+        assert mock_datetime.mock_calls == exp_calls
+        exp_calls = [call.single_conversation(system_prompt, user_prompt, [{"the": "schema"}], None)]
+        assert chatter.mock_calls == exp_calls
         reset_mocks()
 
     # there is NO custom prompt
@@ -523,8 +541,8 @@ def test_command_from_json_custom_prompted(custom_prompt, json_schema, demograph
     expected = "theData"
     assert result == expected
 
-    calls = [call()]
-    assert custom_prompt.mock_calls == calls
+    exp_calls = [call()]
+    assert custom_prompt.mock_calls == exp_calls
     assert json_schema.mock_calls == []
     assert demographic.mock_calls == []
     assert mock_datetime.mock_calls == []
@@ -609,18 +627,20 @@ def _setup_llm_mocks(mock_json_schema, mock_demographic, mock_datetime):
 )
 def test_can_edit_command(permissions, expected):
     tested = helper_instance()
-    command_type = MagicMock(return_value=BASE_CMD)
+    command_type = MagicMock()
+    command_type.side_effect = [BASE_CMD]
     tested.command_type = command_type
-    load_permissions = MagicMock(return_value=permissions)
+    load_permissions = MagicMock()
+    load_permissions.side_effect = [permissions]
     tested.permissions.load_permissions = load_permissions
 
     result = tested.can_edit_command()
     assert result is expected
 
-    calls = [call()]
-    assert command_type.mock_calls == calls
-    calls = [call()]
-    assert load_permissions.mock_calls == calls
+    exp_calls = [call()]
+    assert command_type.mock_calls == exp_calls
+    exp_calls = [call()]
+    assert load_permissions.mock_calls == exp_calls
 
 
 # -- can_edit_field --------------------------------------------------------
@@ -690,18 +710,20 @@ def test_can_edit_command(permissions, expected):
 )
 def test_can_edit_field(permissions, field_name, expected):
     tested = helper_instance()
-    command_type = MagicMock(return_value=BASE_CMD)
+    command_type = MagicMock()
+    command_type.side_effect = [BASE_CMD]
     tested.command_type = command_type
-    load_permissions = MagicMock(return_value=permissions)
+    load_permissions = MagicMock()
+    load_permissions.side_effect = [permissions]
     tested.permissions.load_permissions = load_permissions
 
     result = tested.can_edit_field(field_name)
     assert result is expected
 
-    calls = [call()]
-    assert command_type.mock_calls == calls
-    calls = [call()]
-    assert load_permissions.mock_calls == calls
+    exp_calls = [call()]
+    assert command_type.mock_calls == exp_calls
+    exp_calls = [call()]
+    assert load_permissions.mock_calls == exp_calls
 
 
 # -- get_template_instructions ---------------------------------------------
@@ -709,27 +731,31 @@ def test_can_edit_field(permissions, field_name, expected):
 
 def test_get_template_instructions__no_template():
     tested = helper_instance()
-    command_type = MagicMock(return_value=BASE_CMD)
+    command_type = MagicMock()
+    command_type.side_effect = [BASE_CMD]
     tested.command_type = command_type
-    load_permissions = MagicMock(return_value={})
+    load_permissions = MagicMock()
+    load_permissions.side_effect = [{}]
     tested.permissions.load_permissions = load_permissions
 
     result = tested.get_template_instructions("narrative")
     expected = []
     assert result == expected
 
-    calls = [call()]
-    assert command_type.mock_calls == calls
-    calls = [call()]
-    assert load_permissions.mock_calls == calls
+    exp_calls = [call()]
+    assert command_type.mock_calls == exp_calls
+    exp_calls = [call()]
+    assert load_permissions.mock_calls == exp_calls
 
 
 def test_get_template_instructions__with_instructions():
     tested = helper_instance()
-    command_type = MagicMock(return_value=BASE_CMD)
+    command_type = MagicMock()
+    command_type.side_effect = [BASE_CMD]
     tested.command_type = command_type
-    load_permissions = MagicMock(
-        return_value={
+    load_permissions = MagicMock()
+    load_permissions.side_effect = [
+        {
             BASE_CMD: {
                 "plugin_can_edit": True,
                 "field_permissions": [
@@ -741,65 +767,69 @@ def test_get_template_instructions__with_instructions():
                 ],
             }
         }
-    )
+    ]
     tested.permissions.load_permissions = load_permissions
 
     result = tested.get_template_instructions("narrative")
     expected = ["symptoms", "duration", "severity"]
     assert result == expected
 
-    calls = [call()]
-    assert command_type.mock_calls == calls
-    calls = [call()]
-    assert load_permissions.mock_calls == calls
+    exp_calls = [call()]
+    assert command_type.mock_calls == exp_calls
+    exp_calls = [call()]
+    assert load_permissions.mock_calls == exp_calls
 
 
 def test_get_template_instructions__field_not_found():
     tested = helper_instance()
-    command_type = MagicMock(return_value=BASE_CMD)
+    command_type = MagicMock()
+    command_type.side_effect = [BASE_CMD]
     tested.command_type = command_type
-    load_permissions = MagicMock(
-        return_value={
+    load_permissions = MagicMock()
+    load_permissions.side_effect = [
+        {
             BASE_CMD: {
                 "plugin_can_edit": True,
                 "field_permissions": [{"field_name": "other_field", "add_instructions": ["foo"]}],
             }
         }
-    )
+    ]
     tested.permissions.load_permissions = load_permissions
 
     result = tested.get_template_instructions("narrative")
     expected = []
     assert result == expected
 
-    calls = [call()]
-    assert command_type.mock_calls == calls
-    calls = [call()]
-    assert load_permissions.mock_calls == calls
+    exp_calls = [call()]
+    assert command_type.mock_calls == exp_calls
+    exp_calls = [call()]
+    assert load_permissions.mock_calls == exp_calls
 
 
 def test_get_template_instructions__missing_key():
     tested = helper_instance()
-    command_type = MagicMock(return_value=BASE_CMD)
+    command_type = MagicMock()
+    command_type.side_effect = [BASE_CMD]
     tested.command_type = command_type
-    load_permissions = MagicMock(
-        return_value={
+    load_permissions = MagicMock()
+    load_permissions.side_effect = [
+        {
             BASE_CMD: {
                 "plugin_can_edit": True,
                 "field_permissions": [{"field_name": "narrative", "plugin_can_edit": True}],
             }
         }
-    )
+    ]
     tested.permissions.load_permissions = load_permissions
 
     result = tested.get_template_instructions("narrative")
     expected = []
     assert result == expected
 
-    calls = [call()]
-    assert command_type.mock_calls == calls
-    calls = [call()]
-    assert load_permissions.mock_calls == calls
+    exp_calls = [call()]
+    assert command_type.mock_calls == exp_calls
+    exp_calls = [call()]
+    assert load_permissions.mock_calls == exp_calls
 
 
 # -- get_template_framework ------------------------------------------------
@@ -807,27 +837,31 @@ def test_get_template_instructions__missing_key():
 
 def test_get_template_framework__no_template():
     tested = helper_instance()
-    command_type = MagicMock(return_value=BASE_CMD)
+    command_type = MagicMock()
+    command_type.side_effect = [BASE_CMD]
     tested.command_type = command_type
-    load_permissions = MagicMock(return_value={})
+    load_permissions = MagicMock()
+    load_permissions.side_effect = [{}]
     tested.permissions.load_permissions = load_permissions
 
     result = tested.get_template_framework("narrative")
     expected = None
     assert result == expected
 
-    calls = [call()]
-    assert command_type.mock_calls == calls
-    calls = [call()]
-    assert load_permissions.mock_calls == calls
+    exp_calls = [call()]
+    assert command_type.mock_calls == exp_calls
+    exp_calls = [call()]
+    assert load_permissions.mock_calls == exp_calls
 
 
 def test_get_template_framework__with_framework():
     tested = helper_instance()
-    command_type = MagicMock(return_value=BASE_CMD)
+    command_type = MagicMock()
+    command_type.side_effect = [BASE_CMD]
     tested.command_type = command_type
-    load_permissions = MagicMock(
-        return_value={
+    load_permissions = MagicMock()
+    load_permissions.side_effect = [
+        {
             BASE_CMD: {
                 "plugin_can_edit": True,
                 "field_permissions": [
@@ -839,65 +873,69 @@ def test_get_template_framework__with_framework():
                 ],
             }
         }
-    )
+    ]
     tested.permissions.load_permissions = load_permissions
 
     result = tested.get_template_framework("narrative")
     expected = "Patient is a [AGE] year old [GENDER]."
     assert result == expected
 
-    calls = [call()]
-    assert command_type.mock_calls == calls
-    calls = [call()]
-    assert load_permissions.mock_calls == calls
+    exp_calls = [call()]
+    assert command_type.mock_calls == exp_calls
+    exp_calls = [call()]
+    assert load_permissions.mock_calls == exp_calls
 
 
 def test_get_template_framework__field_not_found():
     tested = helper_instance()
-    command_type = MagicMock(return_value=BASE_CMD)
+    command_type = MagicMock()
+    command_type.side_effect = [BASE_CMD]
     tested.command_type = command_type
-    load_permissions = MagicMock(
-        return_value={
+    load_permissions = MagicMock()
+    load_permissions.side_effect = [
+        {
             BASE_CMD: {
                 "plugin_can_edit": True,
                 "field_permissions": [{"field_name": "other_field", "plugin_edit_framework": "some framework"}],
             }
         }
-    )
+    ]
     tested.permissions.load_permissions = load_permissions
 
     result = tested.get_template_framework("narrative")
     expected = None
     assert result == expected
 
-    calls = [call()]
-    assert command_type.mock_calls == calls
-    calls = [call()]
-    assert load_permissions.mock_calls == calls
+    exp_calls = [call()]
+    assert command_type.mock_calls == exp_calls
+    exp_calls = [call()]
+    assert load_permissions.mock_calls == exp_calls
 
 
 def test_get_template_framework__missing_key():
     tested = helper_instance()
-    command_type = MagicMock(return_value=BASE_CMD)
+    command_type = MagicMock()
+    command_type.side_effect = [BASE_CMD]
     tested.command_type = command_type
-    load_permissions = MagicMock(
-        return_value={
+    load_permissions = MagicMock()
+    load_permissions.side_effect = [
+        {
             BASE_CMD: {
                 "plugin_can_edit": True,
                 "field_permissions": [{"field_name": "narrative", "plugin_can_edit": True}],
             }
         }
-    )
+    ]
     tested.permissions.load_permissions = load_permissions
 
     result = tested.get_template_framework("narrative")
     expected = None
     assert result == expected
 
-    calls = [call()]
-    assert command_type.mock_calls == calls
-    calls = [call()]
-    assert load_permissions.mock_calls == calls
+    exp_calls = [call()]
+    assert command_type.mock_calls == exp_calls
+    exp_calls = [call()]
+    assert load_permissions.mock_calls == exp_calls
 
 
 # -- resolve_framework ----------------------------------------------------
@@ -909,14 +947,21 @@ def test_resolve_framework(mock_get_framework):
 
     # returns cached framework when available
     mock_get_framework.side_effect = ["Cached framework content"]
-    assert tested.resolve_framework("narrative") == "Cached framework content"
-    assert mock_get_framework.mock_calls == [call("narrative")]
+    result = tested.resolve_framework("narrative")
+    expected = "Cached framework content"
+    assert result == expected
+
+    exp_calls = [call("narrative")]
+    assert mock_get_framework.mock_calls == exp_calls
+    mock_get_framework.reset_mock()
 
     # returns None when no framework
-    mock_get_framework.reset_mock()
     mock_get_framework.side_effect = [None]
-    assert tested.resolve_framework("narrative") is None
-    assert mock_get_framework.mock_calls == [call("narrative")]
+    result = tested.resolve_framework("narrative")
+    assert result is None
+
+    exp_calls = [call("narrative")]
+    assert mock_get_framework.mock_calls == exp_calls
 
 
 # -- fill_template_content -------------------------------------------------
@@ -932,14 +977,17 @@ def test_fill_template_content__no_framework_no_instructions(
     chatter = MagicMock()
     instruction = make_instruction()
     tested = helper_instance()
-    mockresolve_framework.return_value = None
-    mock_get_instructions.return_value = []
+    mockresolve_framework.side_effect = [None]
+    mock_get_instructions.side_effect = [[]]
 
     result = tested.fill_template_content("generated", "narrative", instruction, chatter)
 
-    assert result == "generated"
-    assert mockresolve_framework.mock_calls == [call("narrative")]
-    assert mock_get_instructions.mock_calls == [call("narrative")]
+    expected = "generated"
+    assert result == expected
+    exp_calls = [call("narrative")]
+    assert mockresolve_framework.mock_calls == exp_calls
+    exp_calls = [call("narrative")]
+    assert mock_get_instructions.mock_calls == exp_calls
     assert mock_enhance.mock_calls == []
     assert chatter.mock_calls == []
 
@@ -954,16 +1002,20 @@ def test_fill_template_content__no_framework_with_instructions(
     chatter = MagicMock()
     instruction = make_instruction()
     tested = helper_instance()
-    mockresolve_framework.return_value = None
-    mock_get_instructions.return_value = ["symptoms", "duration"]
-    mock_enhance.return_value = "enhanced content"
+    mockresolve_framework.side_effect = [None]
+    mock_get_instructions.side_effect = [["symptoms", "duration"]]
+    mock_enhance.side_effect = ["enhanced content"]
 
     result = tested.fill_template_content("generated", "narrative", instruction, chatter)
 
-    assert result == "enhanced content"
-    assert mockresolve_framework.mock_calls == [call("narrative")]
-    assert mock_get_instructions.mock_calls == [call("narrative")]
-    assert mock_enhance.mock_calls == [call("generated", ["symptoms", "duration"], instruction, chatter)]
+    expected = "enhanced content"
+    assert result == expected
+    exp_calls = [call("narrative")]
+    assert mockresolve_framework.mock_calls == exp_calls
+    exp_calls = [call("narrative")]
+    assert mock_get_instructions.mock_calls == exp_calls
+    exp_calls = [call("generated", ["symptoms", "duration"], instruction, chatter)]
+    assert mock_enhance.mock_calls == exp_calls
     assert chatter.mock_calls == []
 
 
@@ -978,11 +1030,11 @@ def test_fill_template_content_with_framework(
     chatter = MagicMock()
     instruction = make_instruction(information="Patient reports headache for 3 days.")
     tested = helper_instance()
-    mockresolve_framework.return_value = "Patient is a [AGE] year old [GENDER] presenting with [SYMPTOMS]."
-    mock_get_instructions.return_value = ["symptoms", "duration"]
+    mockresolve_framework.side_effect = ["Patient is a [AGE] year old [GENDER] presenting with [SYMPTOMS]."]
+    mock_get_instructions.side_effect = [["symptoms", "duration"]]
     _setup_llm_mocks(mock_json_schema, mock_demographic, mock_datetime)
-    chatter.single_conversation.return_value = [
-        {"enhancedContent": "Patient is a 45 year old male presenting with headache x3d."}
+    chatter.single_conversation.side_effect = [
+        [{"enhancedContent": "Patient is a 45 year old male presenting with headache x3d."}]
     ]
 
     result = tested.fill_template_content("generated headache content", "narrative", instruction, chatter)
@@ -1035,11 +1087,11 @@ def test_fill_template_content_with_framework(
         "```",
         "",
     ]
-    calls = [
+    exp_calls = [
         call.reset_prompts(),
         call.single_conversation(system_prompt, user_prompt, [{"type": "array"}], instruction),
     ]
-    assert chatter.mock_calls == calls
+    assert chatter.mock_calls == exp_calls
 
 
 @patch("hyperscribe.commands.base.datetime", wraps=datetime)
@@ -1053,14 +1105,14 @@ def test_fill_template_content_strips_lit_markers(
     chatter = MagicMock()
     instruction = make_instruction(information="Patient memory concerns noted.")
     tested = helper_instance()
-    mockresolve_framework.return_value = (
+    mockresolve_framework.side_effect = [
         "Patient presenting for assessment.\n"
         "{lit:Current concerns with memory:}\n"
         "{lit:Current concerns with functioning:}"
-    )
-    mock_get_instructions.return_value = []
+    ]
+    mock_get_instructions.side_effect = [[]]
     _setup_llm_mocks(mock_json_schema, mock_demographic, mock_datetime)
-    chatter.single_conversation.return_value = [{"enhancedContent": "filled content"}]
+    chatter.single_conversation.side_effect = [[{"enhancedContent": "filled content"}]]
 
     tested.fill_template_content("generated", "narrative", instruction, chatter)
 
@@ -1111,11 +1163,11 @@ def test_fill_template_content_strips_lit_markers(
         "```",
         "",
     ]
-    calls = [
+    exp_calls = [
         call.reset_prompts(),
         call.single_conversation(system_prompt, user_prompt, [{"type": "array"}], instruction),
     ]
-    assert chatter.mock_calls == calls
+    assert chatter.mock_calls == exp_calls
 
 
 @patch("hyperscribe.commands.base.datetime", wraps=datetime)
@@ -1128,10 +1180,10 @@ def test_fill_template_content_with_framework_no_add_instructions(
 ):
     chatter = MagicMock()
     tested = helper_instance()
-    mockresolve_framework.return_value = "Patient is presenting today."
-    mock_get_instructions.return_value = []
+    mockresolve_framework.side_effect = ["Patient is presenting today."]
+    mock_get_instructions.side_effect = [[]]
     _setup_llm_mocks(mock_json_schema, mock_demographic, mock_datetime)
-    chatter.single_conversation.return_value = [{"enhancedContent": "Patient is presenting today with headache."}]
+    chatter.single_conversation.side_effect = [[{"enhancedContent": "Patient is presenting today with headache."}]]
 
     instruction = make_instruction()
     result = tested.fill_template_content("generated", "narrative", instruction, chatter)
@@ -1184,14 +1236,20 @@ def test_fill_template_content_with_framework_no_add_instructions(
         "```",
         "",
     ]
-    calls = [
+    exp_calls = [
         call.reset_prompts(),
         call.single_conversation(system_prompt, user_prompt, [{"type": "array"}], instruction),
     ]
-    assert chatter.mock_calls == calls
+    assert chatter.mock_calls == exp_calls
 
 
-@pytest.mark.parametrize("llm_response", [[], [{"enhancedContent": ""}]])
+@pytest.mark.parametrize(
+    ("llm_response",),
+    [
+        pytest.param([], id="empty_response"),
+        pytest.param([{"enhancedContent": ""}], id="empty_content"),
+    ],
+)
 @patch("hyperscribe.commands.base.datetime", wraps=datetime)
 @patch.object(LimitedCache, "demographic__str__")
 @patch("hyperscribe.commands.base.JsonSchema")
@@ -1207,10 +1265,10 @@ def test_fill_template_content_llm_empty_falls_back(
 ):
     chatter = MagicMock()
     tested = helper_instance()
-    mockresolve_framework.return_value = "Template structure here."
-    mock_get_instructions.return_value = ["symptoms"]
+    mockresolve_framework.side_effect = ["Template structure here."]
+    mock_get_instructions.side_effect = [["symptoms"]]
     _setup_llm_mocks(mock_json_schema, mock_demographic, mock_datetime)
-    chatter.single_conversation.return_value = llm_response
+    chatter.single_conversation.side_effect = [llm_response]
 
     instruction = make_instruction()
     result = tested.fill_template_content("generated content", "narrative", instruction, chatter)
@@ -1263,11 +1321,11 @@ def test_fill_template_content_llm_empty_falls_back(
         "```",
         "",
     ]
-    calls = [
+    exp_calls = [
         call.reset_prompts(),
         call.single_conversation(system_prompt, user_prompt, [{"type": "array"}], instruction),
     ]
-    assert chatter.mock_calls == calls
+    assert chatter.mock_calls == exp_calls
 
 
 @patch("hyperscribe.commands.base.datetime", wraps=datetime)
@@ -1290,10 +1348,10 @@ def test_fill_template_content_uses_existing_structure(
     )
     instruction = make_instruction(information="Some prose from transcript")
     tested = helper_instance()
-    mockresolve_framework.return_value = structured_content
-    mock_get_instructions.return_value = []
+    mockresolve_framework.side_effect = [structured_content]
+    mock_get_instructions.side_effect = [[]]
     _setup_llm_mocks(mock_json_schema, mock_demographic, mock_datetime)
-    chatter.single_conversation.return_value = [{"enhancedContent": "Updated structured content"}]
+    chatter.single_conversation.side_effect = [[{"enhancedContent": "Updated structured content"}]]
 
     tested.fill_template_content("generated prose", "narrative", instruction, chatter)
 
@@ -1344,11 +1402,11 @@ def test_fill_template_content_uses_existing_structure(
         "```",
         "",
     ]
-    calls = [
+    exp_calls = [
         call.reset_prompts(),
         call.single_conversation(system_prompt, user_prompt, [{"type": "array"}], instruction),
     ]
-    assert chatter.mock_calls == calls
+    assert chatter.mock_calls == exp_calls
 
 
 # -- enhance_with_template_instructions ------------------------------------
@@ -1363,11 +1421,12 @@ def test_enhance_with_template_instructions(mock_json_schema, mock_demographic, 
 
     instruction = make_instruction(information="Patient reports headache for 3 days.")
     _setup_llm_mocks(mock_json_schema, mock_demographic, mock_datetime)
-    chatter.single_conversation.return_value = [{"enhancedContent": "Enhanced: headache x3d"}]
+    chatter.single_conversation.side_effect = [[{"enhancedContent": "Enhanced: headache x3d"}]]
 
     result = tested.enhance_with_template_instructions("original", ["symptoms", "duration"], instruction, chatter)
 
-    assert result == "Enhanced: headache x3d"
+    expected = "Enhanced: headache x3d"
+    assert result == expected
     assert mock_json_schema.mock_calls == [call.get(["template_enhanced_content"])]
     assert mock_demographic.mock_calls == [call(False)]
     assert mock_datetime.mock_calls == [call.now()]
@@ -1410,14 +1469,20 @@ def test_enhance_with_template_instructions(mock_json_schema, mock_demographic, 
         "```",
         "",
     ]
-    calls = [
+    exp_calls = [
         call.reset_prompts(),
         call.single_conversation(system_prompt, user_prompt, [{"type": "array"}], instruction),
     ]
-    assert chatter.mock_calls == calls
+    assert chatter.mock_calls == exp_calls
 
 
-@pytest.mark.parametrize("llm_response", [[], [{"enhancedContent": ""}]])
+@pytest.mark.parametrize(
+    ("llm_response",),
+    [
+        pytest.param([], id="empty_response"),
+        pytest.param([{"enhancedContent": ""}], id="empty_content"),
+    ],
+)
 @patch("hyperscribe.commands.base.datetime", wraps=datetime)
 @patch.object(LimitedCache, "demographic__str__")
 @patch("hyperscribe.commands.base.JsonSchema")
@@ -1425,12 +1490,13 @@ def test_enhance_with_template_instructions_llm_empty(mock_json_schema, mock_dem
     chatter = MagicMock()
     tested = helper_instance()
     _setup_llm_mocks(mock_json_schema, mock_demographic, mock_datetime)
-    chatter.single_conversation.return_value = llm_response
+    chatter.single_conversation.side_effect = [llm_response]
 
     instruction = make_instruction()
     result = tested.enhance_with_template_instructions("original", ["symptoms"], instruction, chatter)
 
-    assert result == "original"
+    expected = "original"
+    assert result == expected
     assert mock_json_schema.mock_calls == [call.get(["template_enhanced_content"])]
     assert mock_demographic.mock_calls == [call(False)]
     assert mock_datetime.mock_calls == [call.now()]
@@ -1473,8 +1539,8 @@ def test_enhance_with_template_instructions_llm_empty(mock_json_schema, mock_dem
         "```",
         "",
     ]
-    calls = [
+    exp_calls = [
         call.reset_prompts(),
         call.single_conversation(system_prompt, user_prompt, [{"type": "array"}], instruction),
     ]
-    assert chatter.mock_calls == calls
+    assert chatter.mock_calls == exp_calls

--- a/tests/hyperscribe/commands/test_base.py
+++ b/tests/hyperscribe/commands/test_base.py
@@ -200,7 +200,9 @@ def test_resolve_item_by_index_logs_warning_on_name_mismatch(mock_log):
     assert result is not None
     assert result.label == expected
 
-    exp_calls = [call.warning("Index 0 (Condition A) does not match name (Condition B), falling back to name-based lookup")]
+    exp_calls = [
+        call.warning("Index 0 (Condition A) does not match name (Condition B), falling back to name-based lookup")
+    ]
     assert mock_log.mock_calls == exp_calls
 
 

--- a/tests/hyperscribe/handlers/test_capture_view.py
+++ b/tests/hyperscribe/handlers/test_capture_view.py
@@ -599,12 +599,92 @@ def test_transcript_session_post(stop_and_go, executor, helper, cycle_data, aws_
     assert note_db.mock_calls == []
     reset_mocks()
 
+    # note not found
+    note_db.filter.return_value.first.side_effect = [None]
+
+    tested.request = SimpleNamespace(
+        path_params={"patient_id": "thePatientId", "note_id": "theNoteId"},
+        json=lambda: {"transcript": "theTranscript"},
+    )
+    result = tested.transcript_session_post()
+    expected = [Response(b"The note is incorrect", HTTPStatus.BAD_REQUEST)]
+    assert result == expected
+
+    assert stop_and_go.mock_calls == []
+    assert executor.mock_calls == []
+    assert helper.mock_calls == []
+    assert cycle_data.mock_calls == []
+    assert aws_s3.mock_calls == []
+    assert log.mock_calls == []
+    exp_calls = [call.filter(id="theNoteId"), call.filter().first()]
+    assert note_db.mock_calls == exp_calls
+    reset_mocks()
+
+    # note not editable
+    note_db.filter.return_value.first.side_effect = [
+        SimpleNamespace(dbid=42, provider=SimpleNamespace(id="theProviderId")),
+    ]
+    helper.editable_note.side_effect = [False]
+
+    tested.request = SimpleNamespace(
+        path_params={"patient_id": "thePatientId", "note_id": "theNoteId"},
+        json=lambda: {"transcript": "theTranscript"},
+    )
+    result = tested.transcript_session_post()
+    expected = [Response(b"The note is not editable", HTTPStatus.BAD_REQUEST)]
+    assert result == expected
+
+    assert stop_and_go.mock_calls == []
+    assert executor.mock_calls == []
+    exp_calls = [call.editable_note(42)]
+    assert helper.mock_calls == exp_calls
+    assert cycle_data.mock_calls == []
+    assert aws_s3.mock_calls == []
+    assert log.mock_calls == []
+    exp_calls = [call.filter(id="theNoteId"), call.filter().first()]
+    assert note_db.mock_calls == exp_calls
+    reset_mocks()
+
+    # hyperscribe has already run (cycle() > 0)
+    note_db.filter.return_value.first.side_effect = [
+        SimpleNamespace(dbid=42, provider=SimpleNamespace(id="theProviderId")),
+    ]
+    helper.editable_note.side_effect = [True]
+    stop_and_go.get.return_value.cycle.side_effect = [5]
+
+    tested.request = SimpleNamespace(
+        path_params={"patient_id": "thePatientId", "note_id": "theNoteId"},
+        json=lambda: {"transcript": "theTranscript"},
+    )
+    result = tested.transcript_session_post()
+    expected = [Response(b"Hyperscribe has already run for this note", HTTPStatus.BAD_REQUEST)]
+    assert result == expected
+
+    assert executor.mock_calls == []
+    exp_calls = [call.editable_note(42)]
+    assert helper.mock_calls == exp_calls
+    assert cycle_data.mock_calls == []
+    exp_calls = [
+        call.get("theNoteId"),
+        call.get().cycle(),
+    ]
+    assert stop_and_go.mock_calls == exp_calls
+    assert aws_s3.mock_calls == []
+    assert log.mock_calls == []
+    exp_calls = [call.filter(id="theNoteId"), call.filter().first()]
+    assert note_db.mock_calls == exp_calls
+    reset_mocks()
+
     # AWS S3 upload failure with valid status code
-    stop_and_go.return_value.waiting_cycles.side_effect = [[21]]
+    stop_and_go.get.return_value.cycle.side_effect = [0]
+    stop_and_go.get.return_value.waiting_cycles.side_effect = [[21]]
+    helper.editable_note.side_effect = [True]
     cycle_data.s3_key_path.side_effect = ["theS3Path"]
     cycle_data.content_type_text.side_effect = ["text/plain"]
     aws_s3.return_value.upload_binary_to_s3.side_effect = [SimpleNamespace(content=b"theProblem", status_code=501)]
-    note_db.get.side_effect = [SimpleNamespace(provider=SimpleNamespace(id="theProviderId"))]
+    note_db.filter.return_value.first.side_effect = [
+        SimpleNamespace(dbid=42, provider=SimpleNamespace(id="theProviderId")),
+    ]
 
     tested.request = SimpleNamespace(
         path_params={"patient_id": "thePatientId", "note_id": "theNoteId"},
@@ -615,15 +695,17 @@ def test_transcript_session_post(stop_and_go, executor, helper, cycle_data, aws_
     assert result == expected
 
     assert executor.mock_calls == []
-    assert helper.mock_calls == []
+    exp_calls = [call.editable_note(42)]
+    assert helper.mock_calls == exp_calls
     exp_calls = [call.s3_key_path(identification, 21), call.content_type_text()]
     assert cycle_data.mock_calls == exp_calls
     exp_calls = [
-        call("theNoteId"),
-        call().add_waiting_cycle(),
-        call().add_waiting_cycle().set_ended(True),
-        call().add_waiting_cycle().set_ended().save(),
-        call().waiting_cycles(),
+        call.get("theNoteId"),
+        call.get().cycle(),
+        call.get().add_waiting_cycle(),
+        call.get().add_waiting_cycle().set_ended(True),
+        call.get().add_waiting_cycle().set_ended().save(),
+        call.get().waiting_cycles(),
     ]
     assert stop_and_go.mock_calls == exp_calls
     exp_calls = [
@@ -633,16 +715,20 @@ def test_transcript_session_post(stop_and_go, executor, helper, cycle_data, aws_
     assert aws_s3.mock_calls == exp_calls
     exp_calls = [call.info("Failed to save transcript with status 501: b'theProblem'")]
     assert log.mock_calls == exp_calls
-    exp_calls = [call.get(id="theNoteId")]
+    exp_calls = [call.filter(id="theNoteId"), call.filter().first()]
     assert note_db.mock_calls == exp_calls
     reset_mocks()
 
     # AWS S3 upload failure with None status code
-    stop_and_go.return_value.waiting_cycles.side_effect = [[21]]
+    stop_and_go.get.return_value.cycle.side_effect = [0]
+    stop_and_go.get.return_value.waiting_cycles.side_effect = [[21]]
+    helper.editable_note.side_effect = [True]
     cycle_data.s3_key_path.side_effect = ["theS3Path"]
     cycle_data.content_type_text.side_effect = ["text/plain"]
     aws_s3.return_value.upload_binary_to_s3.side_effect = [SimpleNamespace(content=None, status_code=None)]
-    note_db.get.side_effect = [SimpleNamespace(provider=SimpleNamespace(id="theProviderId"))]
+    note_db.filter.return_value.first.side_effect = [
+        SimpleNamespace(dbid=42, provider=SimpleNamespace(id="theProviderId")),
+    ]
 
     tested.request = SimpleNamespace(
         path_params={"patient_id": "thePatientId", "note_id": "theNoteId"},
@@ -653,15 +739,17 @@ def test_transcript_session_post(stop_and_go, executor, helper, cycle_data, aws_
     assert result == expected
 
     assert executor.mock_calls == []
-    assert helper.mock_calls == []
+    exp_calls = [call.editable_note(42)]
+    assert helper.mock_calls == exp_calls
     exp_calls = [call.s3_key_path(identification, 21), call.content_type_text()]
     assert cycle_data.mock_calls == exp_calls
     exp_calls = [
-        call("theNoteId"),
-        call().add_waiting_cycle(),
-        call().add_waiting_cycle().set_ended(True),
-        call().add_waiting_cycle().set_ended().save(),
-        call().waiting_cycles(),
+        call.get("theNoteId"),
+        call.get().cycle(),
+        call.get().add_waiting_cycle(),
+        call.get().add_waiting_cycle().set_ended(True),
+        call.get().add_waiting_cycle().set_ended().save(),
+        call.get().waiting_cycles(),
     ]
     assert stop_and_go.mock_calls == exp_calls
     exp_calls = [
@@ -671,16 +759,20 @@ def test_transcript_session_post(stop_and_go, executor, helper, cycle_data, aws_
     assert aws_s3.mock_calls == exp_calls
     exp_calls = [call.info("Failed to save transcript with status None: None")]
     assert log.mock_calls == exp_calls
-    exp_calls = [call.get(id="theNoteId")]
+    exp_calls = [call.filter(id="theNoteId"), call.filter().first()]
     assert note_db.mock_calls == exp_calls
     reset_mocks()
 
     # successful upload
-    stop_and_go.return_value.waiting_cycles.side_effect = [[21]]
+    stop_and_go.get.return_value.cycle.side_effect = [0]
+    stop_and_go.get.return_value.waiting_cycles.side_effect = [[21]]
+    helper.editable_note.side_effect = [True]
     cycle_data.s3_key_path.side_effect = ["theS3Path"]
     cycle_data.content_type_text.side_effect = ["text/plain"]
     aws_s3.return_value.upload_binary_to_s3.side_effect = [SimpleNamespace(content=b"Good", status_code=200)]
-    note_db.get.side_effect = [SimpleNamespace(provider=SimpleNamespace(id="theProviderId"))]
+    note_db.filter.return_value.first.side_effect = [
+        SimpleNamespace(dbid=42, provider=SimpleNamespace(id="theProviderId")),
+    ]
 
     tested.request = SimpleNamespace(
         path_params={"patient_id": "thePatientId", "note_id": "theNoteId"},
@@ -693,16 +785,17 @@ def test_transcript_session_post(stop_and_go, executor, helper, cycle_data, aws_
 
     exp_calls = [call.submit(helper.with_cleanup.return_value, identification, "theUserId")]
     assert executor.mock_calls == exp_calls
-    exp_calls = [call.with_cleanup(tested.run_commander)]
+    exp_calls = [call.editable_note(42), call.with_cleanup(tested.run_commander)]
     assert helper.mock_calls == exp_calls
     exp_calls = [call.s3_key_path(identification, 21), call.content_type_text()]
     assert cycle_data.mock_calls == exp_calls
     exp_calls = [
-        call("theNoteId"),
-        call().add_waiting_cycle(),
-        call().add_waiting_cycle().set_ended(True),
-        call().add_waiting_cycle().set_ended().save(),
-        call().waiting_cycles(),
+        call.get("theNoteId"),
+        call.get().cycle(),
+        call.get().add_waiting_cycle(),
+        call.get().add_waiting_cycle().set_ended(True),
+        call.get().add_waiting_cycle().set_ended().save(),
+        call.get().waiting_cycles(),
     ]
     assert stop_and_go.mock_calls == exp_calls
     exp_calls = [
@@ -711,7 +804,7 @@ def test_transcript_session_post(stop_and_go, executor, helper, cycle_data, aws_
     ]
     assert aws_s3.mock_calls == exp_calls
     assert log.mock_calls == []
-    exp_calls = [call.get(id="theNoteId")]
+    exp_calls = [call.filter(id="theNoteId"), call.filter().first()]
     assert note_db.mock_calls == exp_calls
     reset_mocks()
 

--- a/tests/hyperscribe/handlers/test_capture_view.py
+++ b/tests/hyperscribe/handlers/test_capture_view.py
@@ -70,20 +70,28 @@ def test_constants():
 
 @patch.object(Authenticator, "check")
 def test_authenticate(check):
-    view = helper_instance()
-    view.request = SimpleNamespace(query_params={"ts": "123", "sig": "abc"})
-    creds = Credentials(view.request)
+    tested = helper_instance()
+    tested.request = SimpleNamespace(query_params={"ts": "123", "sig": "abc"})
+    creds = Credentials(tested.request)
 
     # False case
-    check.return_value = False
-    assert view.authenticate(creds) is False
-    check.assert_called_once_with("signingKey", Constants.API_SIGNED_EXPIRATION_SECONDS, {"ts": "123", "sig": "abc"})
+    check.side_effect = [False]
+    result = tested.authenticate(creds)
+    expected = False
+    assert result is expected
+
+    exp_calls = [call("signingKey", Constants.API_SIGNED_EXPIRATION_SECONDS, {"ts": "123", "sig": "abc"})]
+    assert check.mock_calls == exp_calls
     check.reset_mock()
 
     # True case
-    check.return_value = True
-    assert view.authenticate(creds) is True
-    check.assert_called_once()
+    check.side_effect = [True]
+    result = tested.authenticate(creds)
+    expected = True
+    assert result is expected
+
+    exp_calls = [call("signingKey", Constants.API_SIGNED_EXPIRATION_SECONDS, {"ts": "123", "sig": "abc"})]
+    assert check.mock_calls == exp_calls
 
 
 @patch("hyperscribe.handlers.capture_view.requests_post")
@@ -104,17 +112,17 @@ def test_trigger_render(authenticator, helper, requests_post):
     expected = "theResponse"
     assert result == expected
 
-    calls = [
+    exp_calls = [
         call.presigned_url_no_params(
             "signingKey",
             "theHost/plugin-io/api/hyperscribe/capture/render/thePatientId/theNoteId/theUserId",
         )
     ]
-    assert authenticator.mock_calls == calls
-    calls = [call.canvas_host("customerIdentifier")]
-    assert helper.mock_calls == calls
-    calls = [call("theUrl", headers={"Content-Type": "application/json"}, verify=True, timeout=None)]
-    assert requests_post.mock_calls == calls
+    assert authenticator.mock_calls == exp_calls
+    exp_calls = [call.canvas_host("customerIdentifier")]
+    assert helper.mock_calls == exp_calls
+    exp_calls = [call("theUrl", headers={"Content-Type": "application/json"}, verify=True, timeout=None)]
+    assert requests_post.mock_calls == exp_calls
     reset_mocks()
 
 
@@ -148,14 +156,14 @@ def test_session_progress_log(progress):
     )
     tested = helper_instance()
     tested.session_progress_log("thePatientId", "theNoteId", "theProgress")
-    calls = [
+    exp_calls = [
         call.send_to_user(
             identification,
             settings,
             [ProgressMessage(message="theProgress", section="events:7")],
         )
     ]
-    assert progress.mock_calls == calls
+    assert progress.mock_calls == exp_calls
     reset_mocks()
 
 
@@ -192,7 +200,7 @@ def test_capture_get(authenticator, render_to_string, stop_and_go, helper, custo
     expected = [HTMLResponse(content="<html/>", status_code=HTTPStatus(200))]
     assert result == expected
 
-    calls = [
+    exp_calls = [
         call.presigned_url("signingKey", "/plugin-io/api/hyperscribe/progress", {"note_id": "the-00-note"}),
         call.presigned_url_no_params(
             "signingKey",
@@ -227,8 +235,8 @@ def test_capture_get(authenticator, render_to_string, stop_and_go, helper, custo
             "/plugin-io/api/hyperscribe/draft/the-00-patient/the-00-note",
         ),
     ]
-    assert authenticator.mock_calls == calls
-    calls = [
+    assert authenticator.mock_calls == exp_calls
+    exp_calls = [
         call(
             "templates/hyperscribe.html",
             {
@@ -255,25 +263,25 @@ def test_capture_get(authenticator, render_to_string, stop_and_go, helper, custo
             },
         ),
     ]
-    assert render_to_string.mock_calls == calls
-    calls = [
+    assert render_to_string.mock_calls == exp_calls
+    exp_calls = [
         call.get("the-00-note"),
         call.get().is_ended(),
         call.get().is_paused(),
         call.get().cycle(),
         call.get().is_paused(),
     ]
-    assert stop_and_go.mock_calls == calls
-    calls = [call.canvas_ws_host("customerIdentifier")]
-    assert helper.mock_calls == calls
-    calls = [
+    assert stop_and_go.mock_calls == exp_calls
+    exp_calls = [call.canvas_ws_host("customerIdentifier")]
+    assert helper.mock_calls == exp_calls
+    exp_calls = [
         call.customizations(
             AwsS3Credentials(aws_key="theKey", aws_secret="theSecret", region="theRegion", bucket="theBucketLogs"),
             "customerIdentifier",
             "the-00-user",
         )
     ]
-    assert customization.mock_calls == calls
+    assert customization.mock_calls == exp_calls
     reset_mocks()
 
 
@@ -290,8 +298,8 @@ def test_new_session_post(session_progress_log):
     result = tested.new_session_post()
     assert result == []
 
-    calls = [call("thePatientId", "theNoteId", "started")]
-    assert session_progress_log.mock_calls == calls
+    exp_calls = [call("thePatientId", "theNoteId", "started")]
+    assert session_progress_log.mock_calls == exp_calls
     reset_mocks()
 
 
@@ -459,16 +467,16 @@ def test_audio_chunk_post(add_cycle, webm_prefix, log):
     expected = [Response(b"Good", HTTPStatus(200))]
     assert result == expected
 
-    calls = [call(b"theAudio", "audio/test")]
-    assert add_cycle.mock_calls == calls
+    exp_calls = [call(b"theAudio", "audio/test")]
+    assert add_cycle.mock_calls == exp_calls
     assert webm_prefix.mock_calls == []
-    calls = [
+    exp_calls = [
         call.info("audio_form_part.name: audio"),
         call.info("audio_form_part.filename: chunk_000_other"),
         call.info("len(audio_form_part.content): 8"),
         call.info("audio_form_part.content_type: audio/test"),
     ]
-    assert log.mock_calls == calls
+    assert log.mock_calls == exp_calls
     reset_mocks()
     # -- later chunk
     add_cycle.side_effect = [[Response(b"Good", HTTPStatus(200))]]
@@ -489,17 +497,17 @@ def test_audio_chunk_post(add_cycle, webm_prefix, log):
     expected = [Response(b"Good", HTTPStatus(200))]
     assert result == expected
 
-    calls = [call(b"thePrefixedAudio", "audio/test")]
-    assert add_cycle.mock_calls == calls
-    calls = [call.add_prefix(b"theAudio")]
-    assert webm_prefix.mock_calls == calls
-    calls = [
+    exp_calls = [call(b"thePrefixedAudio", "audio/test")]
+    assert add_cycle.mock_calls == exp_calls
+    exp_calls = [call.add_prefix(b"theAudio")]
+    assert webm_prefix.mock_calls == exp_calls
+    exp_calls = [
         call.info("audio_form_part.name: audio"),
         call.info("audio_form_part.filename: chunk_123_other"),
         call.info("len(audio_form_part.content): 8"),
         call.info("audio_form_part.content_type: audio/test"),
     ]
-    assert log.mock_calls == calls
+    assert log.mock_calls == exp_calls
     reset_mocks()
 
 
@@ -518,8 +526,193 @@ def test_transcript_chunk_post(add_cycle):
     expected = [Response(b"Good", HTTPStatus(200))]
     assert result == expected
 
-    calls = [call(b"theTranscript", "text/plain")]
-    assert add_cycle.mock_calls == calls
+    exp_calls = [call(b"theTranscript", "text/plain")]
+    assert add_cycle.mock_calls == exp_calls
+    reset_mocks()
+
+
+@patch.object(Note, "objects")
+@patch("hyperscribe.handlers.capture_view.log")
+@patch("hyperscribe.handlers.capture_view.AwsS3")
+@patch("hyperscribe.handlers.capture_view.CycleData")
+@patch("hyperscribe.handlers.capture_view.Helper")
+@patch("hyperscribe.handlers.capture_view.executor")
+@patch("hyperscribe.handlers.capture_view.StopAndGo")
+def test_transcript_session_post(stop_and_go, executor, helper, cycle_data, aws_s3, log, note_db):
+    def reset_mocks():
+        stop_and_go.reset_mock()
+        executor.reset_mock()
+        helper.reset_mock()
+        cycle_data.reset_mock()
+        aws_s3.reset_mock()
+        log.reset_mock()
+        note_db.reset_mock()
+
+    aws_s3_credentials = AwsS3Credentials(
+        aws_key="theKey",
+        aws_secret="theSecret",
+        region="theRegion",
+        bucket="theBucketLogs",
+    )
+    identification = IdentificationParameters(
+        patient_uuid="thePatientId",
+        note_uuid="theNoteId",
+        provider_uuid="theProviderId",
+        canvas_instance="customerIdentifier",
+    )
+
+    tested = helper_instance()
+
+    # invalid transcript: not a string
+    tested.request = SimpleNamespace(
+        path_params={"patient_id": "thePatientId", "note_id": "theNoteId"},
+        json=lambda: {"transcript": 123},
+    )
+    result = tested.transcript_session_post()
+    expected = [Response(b"'transcript' must be a non-empty string", HTTPStatus.BAD_REQUEST)]
+    assert result == expected
+
+    assert stop_and_go.mock_calls == []
+    assert executor.mock_calls == []
+    assert helper.mock_calls == []
+    assert cycle_data.mock_calls == []
+    assert aws_s3.mock_calls == []
+    assert log.mock_calls == []
+    assert note_db.mock_calls == []
+    reset_mocks()
+
+    # invalid transcript: whitespace only
+    tested.request = SimpleNamespace(
+        path_params={"patient_id": "thePatientId", "note_id": "theNoteId"},
+        json=lambda: {"transcript": "   "},
+    )
+    result = tested.transcript_session_post()
+    expected = [Response(b"'transcript' must be a non-empty string", HTTPStatus.BAD_REQUEST)]
+    assert result == expected
+
+    assert stop_and_go.mock_calls == []
+    assert executor.mock_calls == []
+    assert helper.mock_calls == []
+    assert cycle_data.mock_calls == []
+    assert aws_s3.mock_calls == []
+    assert log.mock_calls == []
+    assert note_db.mock_calls == []
+    reset_mocks()
+
+    # AWS S3 upload failure with valid status code
+    stop_and_go.return_value.waiting_cycles.side_effect = [[21]]
+    cycle_data.s3_key_path.side_effect = ["theS3Path"]
+    cycle_data.content_type_text.side_effect = ["text/plain"]
+    aws_s3.return_value.upload_binary_to_s3.side_effect = [SimpleNamespace(content=b"theProblem", status_code=501)]
+    note_db.get.side_effect = [SimpleNamespace(provider=SimpleNamespace(id="theProviderId"))]
+
+    tested.request = SimpleNamespace(
+        path_params={"patient_id": "thePatientId", "note_id": "theNoteId"},
+        json=lambda: {"transcript": "theTranscript"},
+    )
+    result = tested.transcript_session_post()
+    expected = [Response(b"theProblem", HTTPStatus(501))]
+    assert result == expected
+
+    assert executor.mock_calls == []
+    assert helper.mock_calls == []
+    exp_calls = [call.s3_key_path(identification, 21), call.content_type_text()]
+    assert cycle_data.mock_calls == exp_calls
+    exp_calls = [
+        call("theNoteId"),
+        call().add_waiting_cycle(),
+        call().add_waiting_cycle().set_ended(True),
+        call().add_waiting_cycle().set_ended().save(),
+        call().waiting_cycles(),
+    ]
+    assert stop_and_go.mock_calls == exp_calls
+    exp_calls = [
+        call(aws_s3_credentials),
+        call().upload_binary_to_s3("theS3Path", b"theTranscript", "text/plain"),
+    ]
+    assert aws_s3.mock_calls == exp_calls
+    exp_calls = [call.info("Failed to save transcript with status 501: b'theProblem'")]
+    assert log.mock_calls == exp_calls
+    exp_calls = [call.get(id="theNoteId")]
+    assert note_db.mock_calls == exp_calls
+    reset_mocks()
+
+    # AWS S3 upload failure with None status code
+    stop_and_go.return_value.waiting_cycles.side_effect = [[21]]
+    cycle_data.s3_key_path.side_effect = ["theS3Path"]
+    cycle_data.content_type_text.side_effect = ["text/plain"]
+    aws_s3.return_value.upload_binary_to_s3.side_effect = [SimpleNamespace(content=None, status_code=None)]
+    note_db.get.side_effect = [SimpleNamespace(provider=SimpleNamespace(id="theProviderId"))]
+
+    tested.request = SimpleNamespace(
+        path_params={"patient_id": "thePatientId", "note_id": "theNoteId"},
+        json=lambda: {"transcript": "theTranscript"},
+    )
+    result = tested.transcript_session_post()
+    expected = [Response(b"Failed to save transcript (AWS S3 failure)", HTTPStatus.SERVICE_UNAVAILABLE)]
+    assert result == expected
+
+    assert executor.mock_calls == []
+    assert helper.mock_calls == []
+    exp_calls = [call.s3_key_path(identification, 21), call.content_type_text()]
+    assert cycle_data.mock_calls == exp_calls
+    exp_calls = [
+        call("theNoteId"),
+        call().add_waiting_cycle(),
+        call().add_waiting_cycle().set_ended(True),
+        call().add_waiting_cycle().set_ended().save(),
+        call().waiting_cycles(),
+    ]
+    assert stop_and_go.mock_calls == exp_calls
+    exp_calls = [
+        call(aws_s3_credentials),
+        call().upload_binary_to_s3("theS3Path", b"theTranscript", "text/plain"),
+    ]
+    assert aws_s3.mock_calls == exp_calls
+    exp_calls = [call.info("Failed to save transcript with status None: None")]
+    assert log.mock_calls == exp_calls
+    exp_calls = [call.get(id="theNoteId")]
+    assert note_db.mock_calls == exp_calls
+    reset_mocks()
+
+    # successful upload
+    stop_and_go.return_value.waiting_cycles.side_effect = [[21]]
+    cycle_data.s3_key_path.side_effect = ["theS3Path"]
+    cycle_data.content_type_text.side_effect = ["text/plain"]
+    aws_s3.return_value.upload_binary_to_s3.side_effect = [SimpleNamespace(content=b"Good", status_code=200)]
+    note_db.get.side_effect = [SimpleNamespace(provider=SimpleNamespace(id="theProviderId"))]
+
+    tested.request = SimpleNamespace(
+        path_params={"patient_id": "thePatientId", "note_id": "theNoteId"},
+        json=lambda: {"transcript": "theTranscript"},
+        headers={"canvas-logged-in-user-id": "theUserId"},
+    )
+    result = tested.transcript_session_post()
+    expected = [Response(b"Transcript session cycle 21 started", HTTPStatus.CREATED)]
+    assert result == expected
+
+    exp_calls = [call.submit(helper.with_cleanup.return_value, identification, "theUserId")]
+    assert executor.mock_calls == exp_calls
+    exp_calls = [call.with_cleanup(tested.run_commander)]
+    assert helper.mock_calls == exp_calls
+    exp_calls = [call.s3_key_path(identification, 21), call.content_type_text()]
+    assert cycle_data.mock_calls == exp_calls
+    exp_calls = [
+        call("theNoteId"),
+        call().add_waiting_cycle(),
+        call().add_waiting_cycle().set_ended(True),
+        call().add_waiting_cycle().set_ended().save(),
+        call().waiting_cycles(),
+    ]
+    assert stop_and_go.mock_calls == exp_calls
+    exp_calls = [
+        call(aws_s3_credentials),
+        call().upload_binary_to_s3("theS3Path", b"theTranscript", "text/plain"),
+    ]
+    assert aws_s3.mock_calls == exp_calls
+    assert log.mock_calls == []
+    exp_calls = [call.get(id="theNoteId")]
+    assert note_db.mock_calls == exp_calls
     reset_mocks()
 
 
@@ -545,11 +738,11 @@ def test_draft_chunk_post(get_cache):
     expected = [Response(status_code=HTTPStatus(201))]
     assert result == expected
 
-    calls = [
+    exp_calls = [
         call(),
         call().set("draft_thePatientId_theNoteId", "theTranscript"),
     ]
-    assert get_cache.mock_calls == calls
+    assert get_cache.mock_calls == exp_calls
     reset_mocks()
 
 
@@ -570,11 +763,11 @@ def test_draft_chunk_get(get_cache):
     ]
     assert result == expected
 
-    calls = [
+    exp_calls = [
         call(),
         call().get("draft_thePatientId_theNoteId"),
     ]
-    assert get_cache.mock_calls == calls
+    assert get_cache.mock_calls == exp_calls
     reset_mocks()
 
 
@@ -631,24 +824,24 @@ def test__add_cycle(executor, helper, cycle_data, stop_and_go, aws_s3, log, note
 
     assert executor.mock_calls == []
     assert helper.mock_calls == []
-    calls = [call.s3_key_path(identification, 21)]
-    assert cycle_data.mock_calls == calls
-    calls = [call.get("theNoteId")]
-    assert stop_and_go.mock_calls == calls
-    calls = [
+    exp_calls = [call.s3_key_path(identification, 21)]
+    assert cycle_data.mock_calls == exp_calls
+    exp_calls = [call.get("theNoteId")]
+    assert stop_and_go.mock_calls == exp_calls
+    exp_calls = [
         call(aws_s3_credentials),
         call().upload_binary_to_s3("theS3Path", b"theContent", "content/type"),
     ]
-    assert aws_s3.mock_calls == calls
-    calls = [call.info("Failed to save chunk 21 with status 501: b'theProblem'")]
-    assert log.mock_calls == calls
-    calls = [call.get(id="theNoteId")]
-    assert note_db.mock_calls == calls
-    calls = [
+    assert aws_s3.mock_calls == exp_calls
+    exp_calls = [call.info("Failed to save chunk 21 with status 501: b'theProblem'")]
+    assert log.mock_calls == exp_calls
+    exp_calls = [call.get(id="theNoteId")]
+    assert note_db.mock_calls == exp_calls
+    exp_calls = [
         call.add_waiting_cycle(),
         call.add_waiting_cycle().save(),
     ]
-    assert stop_and_go_not_running.mock_calls == calls
+    assert stop_and_go_not_running.mock_calls == exp_calls
     assert stop_and_go_is_running.mock_calls == []
     reset_mocks()
     # -- invalid response from AWS S3
@@ -667,24 +860,24 @@ def test__add_cycle(executor, helper, cycle_data, stop_and_go, aws_s3, log, note
 
     assert executor.mock_calls == []
     assert helper.mock_calls == []
-    calls = [call.s3_key_path(identification, 21)]
-    assert cycle_data.mock_calls == calls
-    calls = [call.get("theNoteId")]
-    assert stop_and_go.mock_calls == calls
-    calls = [
+    exp_calls = [call.s3_key_path(identification, 21)]
+    assert cycle_data.mock_calls == exp_calls
+    exp_calls = [call.get("theNoteId")]
+    assert stop_and_go.mock_calls == exp_calls
+    exp_calls = [
         call(aws_s3_credentials),
         call().upload_binary_to_s3("theS3Path", b"theContent", "content/type"),
     ]
-    assert aws_s3.mock_calls == calls
-    calls = [call.info("Failed to save chunk 21 with status None: None")]
-    assert log.mock_calls == calls
-    calls = [call.get(id="theNoteId")]
-    assert note_db.mock_calls == calls
-    calls = [
+    assert aws_s3.mock_calls == exp_calls
+    exp_calls = [call.info("Failed to save chunk 21 with status None: None")]
+    assert log.mock_calls == exp_calls
+    exp_calls = [call.get(id="theNoteId")]
+    assert note_db.mock_calls == exp_calls
+    exp_calls = [
         call.add_waiting_cycle(),
         call.add_waiting_cycle().save(),
     ]
-    assert stop_and_go_not_running.mock_calls == calls
+    assert stop_and_go_not_running.mock_calls == exp_calls
     assert stop_and_go_is_running.mock_calls == []
     reset_mocks()
     # AWS S3 upload succeeded
@@ -703,27 +896,27 @@ def test__add_cycle(executor, helper, cycle_data, stop_and_go, aws_s3, log, note
     expected = [Response(b"Chunk 21 saved OK", HTTPStatus(201))]
     assert result == expected
 
-    calls = [call.submit(helper.with_cleanup.return_value, identification, "theUserId")]
-    assert executor.mock_calls == calls
-    calls = [call.with_cleanup(tested.run_commander)]
-    assert helper.mock_calls == calls
-    calls = [call.s3_key_path(identification, 21)]
-    assert cycle_data.mock_calls == calls
-    calls = [call.get("theNoteId")]
-    assert stop_and_go.mock_calls == calls
-    calls = [
+    exp_calls = [call.submit(helper.with_cleanup.return_value, identification, "theUserId")]
+    assert executor.mock_calls == exp_calls
+    exp_calls = [call.with_cleanup(tested.run_commander)]
+    assert helper.mock_calls == exp_calls
+    exp_calls = [call.s3_key_path(identification, 21)]
+    assert cycle_data.mock_calls == exp_calls
+    exp_calls = [call.get("theNoteId")]
+    assert stop_and_go.mock_calls == exp_calls
+    exp_calls = [
         call(aws_s3_credentials),
         call().upload_binary_to_s3("theS3Path", b"theContent", "content/type"),
     ]
-    assert aws_s3.mock_calls == calls
+    assert aws_s3.mock_calls == exp_calls
     assert log.mock_calls == []
-    calls = [call.get(id="theNoteId")]
-    assert note_db.mock_calls == calls
-    calls = [
+    exp_calls = [call.get(id="theNoteId")]
+    assert note_db.mock_calls == exp_calls
+    exp_calls = [
         call.add_waiting_cycle(),
         call.add_waiting_cycle().save(),
     ]
-    assert stop_and_go_not_running.mock_calls == calls
+    assert stop_and_go_not_running.mock_calls == exp_calls
     assert stop_and_go_is_running.mock_calls == []
     reset_mocks()
     # -- commander is running
@@ -743,24 +936,24 @@ def test__add_cycle(executor, helper, cycle_data, stop_and_go, aws_s3, log, note
 
     assert executor.mock_calls == []
     assert helper.mock_calls == []
-    calls = [call.s3_key_path(identification, 28)]
-    assert cycle_data.mock_calls == calls
-    calls = [call.get("theNoteId")]
-    assert stop_and_go.mock_calls == calls
-    calls = [
+    exp_calls = [call.s3_key_path(identification, 28)]
+    assert cycle_data.mock_calls == exp_calls
+    exp_calls = [call.get("theNoteId")]
+    assert stop_and_go.mock_calls == exp_calls
+    exp_calls = [
         call(aws_s3_credentials),
         call().upload_binary_to_s3("theS3Path", b"theContent", "content/type"),
     ]
-    assert aws_s3.mock_calls == calls
+    assert aws_s3.mock_calls == exp_calls
     assert log.mock_calls == []
-    calls = [call.get(id="theNoteId")]
-    assert note_db.mock_calls == calls
+    exp_calls = [call.get(id="theNoteId")]
+    assert note_db.mock_calls == exp_calls
     assert stop_and_go_not_running.mock_calls == []
-    calls = [
+    exp_calls = [
         call.add_waiting_cycle(),
         call.add_waiting_cycle().save(),
     ]
-    assert stop_and_go_is_running.mock_calls == calls
+    assert stop_and_go_is_running.mock_calls == exp_calls
     reset_mocks()
 
 
@@ -785,14 +978,14 @@ def test_render_effect_post(stop_and_go):
     result = tested.render_effect_post()
     assert result == effects
 
-    calls = [
+    exp_calls = [
         call.get("noteId"),
         call.get().paused_effects(),
         call.get().reset_paused_effect(),
         call.get().reset_paused_effect().set_delay(),
         call.get().reset_paused_effect().set_delay().save(),
     ]
-    assert stop_and_go.mock_calls == calls
+    assert stop_and_go.mock_calls == exp_calls
     reset_mocks()
 
     # there are NO paused effects
@@ -801,11 +994,11 @@ def test_render_effect_post(stop_and_go):
     result = tested.render_effect_post()
     assert result == []
 
-    calls = [
+    exp_calls = [
         call.get("noteId"),
         call.get().paused_effects(),
     ]
-    assert stop_and_go.mock_calls == calls
+    assert stop_and_go.mock_calls == exp_calls
     reset_mocks()
 
 
@@ -863,7 +1056,7 @@ def test_feedback_post(aws_s3, requests_post, mock_datetime):
     expected = [Response(content=b"Storage is not made available", status_code=HTTPStatus.INTERNAL_SERVER_ERROR)]
     assert result == expected
 
-    calls = [
+    exp_calls = [
         call(
             AwsS3Credentials(
                 aws_key="theKey",
@@ -874,7 +1067,7 @@ def test_feedback_post(aws_s3, requests_post, mock_datetime):
         ),
         call().is_ready(),
     ]
-    assert aws_s3.mock_calls == calls
+    assert aws_s3.mock_calls == exp_calls
     assert mock_datetime.mock_calls == []
     reset_mocks()
 
@@ -892,7 +1085,7 @@ def test_feedback_post(aws_s3, requests_post, mock_datetime):
     expected = [Response(content=b"Feedback saved OK", status_code=HTTPStatus.CREATED)]
     assert result == expected
 
-    calls = [
+    exp_calls = [
         call(
             AwsS3Credentials(
                 aws_key="theKey",
@@ -907,16 +1100,16 @@ def test_feedback_post(aws_s3, requests_post, mock_datetime):
             "theFeedback",
         ),
     ]
-    assert aws_s3.mock_calls == calls
-    calls = [call.now(timezone.utc)]
-    assert mock_datetime.mock_calls == calls
-    expected_data = NotionFeedbackRecord(
+    assert aws_s3.mock_calls == exp_calls
+    exp_calls = [call.now(timezone.utc)]
+    assert mock_datetime.mock_calls == exp_calls
+    exp_data = NotionFeedbackRecord(
         instance="customerIdentifier",
         note_uuid="theNoteId",
         date_time=date_0.strftime("%Y%m%d-%H%M%S"),
         feedback="theFeedback",
     ).to_json("theNotionFeedbackDatabaseId")
-    calls = [
+    exp_calls = [
         call(
             Constants.VENDOR_NOTION_API_BASE_URL,
             headers={
@@ -924,10 +1117,10 @@ def test_feedback_post(aws_s3, requests_post, mock_datetime):
                 "Content-Type": "application/json",
                 "Notion-Version": Constants.VENDOR_NOTION_API_VERSION,
             },
-            data=expected_data,
+            data=exp_data,
         )
     ]
-    assert requests_post.mock_calls == calls
+    assert requests_post.mock_calls == exp_calls
     reset_mocks()
 
     # Notion API failure
@@ -947,6 +1140,42 @@ def test_feedback_post(aws_s3, requests_post, mock_datetime):
         match="Feedback failed to save via Notion API, status 500, text: Internal Server Error",
     ):
         tested.feedback_post()
+
+    exp_calls = [
+        call(
+            AwsS3Credentials(
+                aws_key="theKey",
+                aws_secret="theSecret",
+                region="theRegion",
+                bucket="theBucketLogs",
+            )
+        ),
+        call().is_ready(),
+        call().upload_text_to_s3(
+            "hyperscribe-customerIdentifier/feedback/theNoteId/20250829-101457",
+            "theFeedback",
+        ),
+    ]
+    assert aws_s3.mock_calls == exp_calls
+    exp_calls = [call.now(timezone.utc)]
+    assert mock_datetime.mock_calls == exp_calls
+    exp_calls = [
+        call(
+            Constants.VENDOR_NOTION_API_BASE_URL,
+            headers={
+                "Authorization": "Bearer theNotionAPIKey",
+                "Content-Type": "application/json",
+                "Notion-Version": Constants.VENDOR_NOTION_API_VERSION,
+            },
+            data=NotionFeedbackRecord(
+                instance="customerIdentifier",
+                note_uuid="theNoteId",
+                date_time=date_0.strftime("%Y%m%d-%H%M%S"),
+                feedback="theFeedback",
+            ).to_json("theNotionFeedbackDatabaseId"),
+        )
+    ]
+    assert requests_post.mock_calls == exp_calls
     reset_mocks()
 
 
@@ -1001,8 +1230,8 @@ def test_run_reviewer(session_progress_log, log, implemented_commands, llm_decis
     tested.secrets["AuditLLMDecisions"] = "theNoteId"
     tested.run_reviewer(identification, date_0, 7)
 
-    calls = [call("patientId", "noteId", "EOF")]
-    assert session_progress_log.mock_calls == calls
+    exp_calls = [call("patientId", "noteId", "EOF")]
+    assert session_progress_log.mock_calls == exp_calls
     assert log.mock_calls == []
     assert implemented_commands.mock_calls == []
     assert llm_decision_reviewer.mock_calls == []
@@ -1033,17 +1262,17 @@ def test_run_reviewer(session_progress_log, log, implemented_commands, llm_decis
 
     tested.run_reviewer(identification, date_0, 7)
 
-    calls = [
+    exp_calls = [
         call.info("  => final audit started...noteId / 7 cycles"),
         call.info("  => final audit done (noteId / 7 cycles)"),
     ]
-    assert log.mock_calls == calls
-    calls = [call.schema_key2instruction()]
-    assert implemented_commands.mock_calls == calls
+    assert log.mock_calls == exp_calls
+    exp_calls = [call.schema_key2instruction()]
+    assert implemented_commands.mock_calls == exp_calls
 
-    calls = [call("patientId", "noteId", "EOF")]
-    assert session_progress_log.mock_calls == calls
-    calls = [
+    exp_calls = [call("patientId", "noteId", "EOF")]
+    assert session_progress_log.mock_calls == exp_calls
+    exp_calls = [
         call.review(
             identification,
             settings,
@@ -1058,13 +1287,13 @@ def test_run_reviewer(session_progress_log, log, implemented_commands, llm_decis
             7,
         ),
     ]
-    assert llm_decision_reviewer.mock_calls == calls
+    assert llm_decision_reviewer.mock_calls == exp_calls
     assert progress.mock_calls == []
-    calls = [
+    exp_calls = [
         call.filter(patient__id="patientId", note__id="noteId", state="staged"),
         call.filter().order_by("dbid"),
     ]
-    assert command_db.mock_calls == calls
+    assert command_db.mock_calls == exp_calls
     reset_mocks()
 
 
@@ -1177,11 +1406,11 @@ def test_run_commander(
     assert run_reviewer.mock_calls == []
     assert session_progress_log.mock_calls == []
     assert log.mock_calls == []
-    calls = [
+    exp_calls = [
         call.get("noteId"),
         call.get().is_running(),
     ]
-    assert stop_and_go.mock_calls == calls
+    assert stop_and_go.mock_calls == exp_calls
     assert memory_log.mock_calls == []
     assert progress.mock_calls == []
     assert commander.mock_calls == []
@@ -1211,15 +1440,15 @@ def test_run_commander(
 
         tested.run_commander(identification, "theUserId")
 
-        calls = [
+        exp_calls = [
             call("patientId", "noteId", "theUserId"),
             call("patientId", "noteId", "theUserId"),
         ]
-        assert trigger_render.mock_calls == calls
+        assert trigger_render.mock_calls == exp_calls
         assert run_reviewer.mock_calls == exp_call_reviewed
         assert session_progress_log.mock_calls == exp_call_progress
         assert log.mock_calls == []
-        calls = [
+        exp_calls = [
             call.get("noteId"),
             call.get().is_running(),
             call.get().set_running(True),
@@ -1247,36 +1476,36 @@ def test_run_commander(
             call.get().is_ended(),
         ]
         if is_ended:
-            calls.extend(
+            exp_calls.extend(
                 [
                     call.get().created(),
                     call.get().cycle(),
                 ]
             )
-        assert stop_and_go.mock_calls == calls
-        calls = [
+        assert stop_and_go.mock_calls == exp_calls
+        exp_calls = [
             call.instance(identification, "main", credentials),
             call.instance().output("SDK: theVersion - Text: theVendorTextLLM - Audio: theVendorAudioLLM - Workers: 5"),
             call.end_session("noteId"),
             call.end_session("noteId"),
             call.end_session("noteId"),
         ]
-        assert memory_log.mock_calls == calls
+        assert memory_log.mock_calls == exp_calls
         assert progress.mock_calls == []
-        calls = [
+        exp_calls = [
             call.compute_cycle(identification, settings[0], credentials, 2),
             call.compute_cycle(identification, settings[0], credentials, 3),
             call.compute_cycle(identification, settings[0], credentials, 4),
         ]
-        assert commander.mock_calls == calls
-        calls = [
+        assert commander.mock_calls == exp_calls
+        exp_calls = [
             call.end_session("noteId"),
             call.end_session("noteId"),
             call.end_session("noteId"),
         ]
-        assert llm_turns_store.mock_calls == calls
-        calls = [call.custom_prompts_as_secret(credentials, "customerIdentifier", "theUserId")]
-        assert customization.mock_calls == calls
+        assert llm_turns_store.mock_calls == exp_calls
+        exp_calls = [call.custom_prompts_as_secret(credentials, "customerIdentifier", "theUserId")]
+        assert customization.mock_calls == exp_calls
         reset_mocks()
 
     # error in Commander.compute_audio
@@ -1294,13 +1523,13 @@ def test_run_commander(
     assert trigger_render.mock_calls == []
     assert run_reviewer.mock_calls == []
     assert session_progress_log.mock_calls == []
-    calls = [
+    exp_calls = [
         call.info("************************"),
         call.error("Error while running commander: Test error", exc_info=True),
         call.info("************************"),
     ]
-    assert log.mock_calls == calls
-    calls = [
+    assert log.mock_calls == exp_calls
+    exp_calls = [
         call.get("noteId"),
         call.get().is_running(),
         call.get().set_running(True),
@@ -1313,16 +1542,16 @@ def test_run_commander(
         call.get().set_running().save(),
         call.get().is_ended(),
     ]
-    assert stop_and_go.mock_calls == calls
-    calls = [
+    assert stop_and_go.mock_calls == exp_calls
+    exp_calls = [
         call.instance(identification, "main", credentials),
         call.instance().output("SDK: theVersion - Text: theVendorTextLLM - Audio: theVendorAudioLLM - Workers: 5"),
     ]
-    assert memory_log.mock_calls == calls
+    assert memory_log.mock_calls == exp_calls
     assert progress.mock_calls == []
-    calls = [call.compute_cycle(identification, settings[1], credentials, 7)]
-    assert commander.mock_calls == calls
+    exp_calls = [call.compute_cycle(identification, settings[1], credentials, 7)]
+    assert commander.mock_calls == exp_calls
     assert llm_turns_store.mock_calls == []
-    calls = [call.custom_prompts_as_secret(credentials, "customerIdentifier", "theUserId")]
-    assert customization.mock_calls == calls
+    exp_calls = [call.custom_prompts_as_secret(credentials, "customerIdentifier", "theUserId")]
+    assert customization.mock_calls == exp_calls
     reset_mocks()


### PR DESCRIPTION
This PR allows to upload a text to Hyperscribe for a transcript-to-commands run.

The external caller is authenticated through the secret `APISigningKey` when accessing the endpoint `/capture/transcript-session/<patient_id>/<note_id>`.

There are several checks against the note before running Hyperscribe:
- does the note exist?
- is the note editable?
- was Hyperscribe already used on the note?


