### PR TITLE
Scribe: read-only mode, locked-note handling, transcript polish

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-.gitignore
 .idea/
 __pycache__
 debug/
@@ -11,9 +10,12 @@ cases_runs/
 evaluations.db
 local_env.sh
 .claude
-evaluations.db
-local_env.sh
 **/.DS_Store
 .DS_Store
 .cpa-workflow-artifacts/
 artifacts/
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+htmlcov/
+*.egg-info/

--- a/hyperscribe/scribe/api/scribe_view.py
+++ b/hyperscribe/scribe/api/scribe_view.py
@@ -51,6 +51,7 @@ class ScribeView(StaffSessionAuthMixin, SimpleAPI):
         patient_birth_date = patient.birth_date.isoformat() if patient.birth_date else ""
         patient_gender = str(patient.sex_at_birth) if patient.sex_at_birth else ""
         note_editable = Helper.editable_note(note.dbid)
+        is_author = bool(note.provider and str(note.provider.id) == str(staff_id))
 
         # Use the provider stored with the transcript (the user who recorded it).
         # Fall back to the note author, then a generic label.
@@ -85,6 +86,7 @@ class ScribeView(StaffSessionAuthMixin, SimpleAPI):
                 "staff_name": logged_in_staff.credentialed_name,
                 "debug_mode": "true" if self.secrets.get("ScribeDebugStaffers") else "",
                 "note_editable": "true" if note_editable else "",
+                "is_author": "true" if is_author else "",
                 "alert_facility_enabled": "true" if self.secrets.get("AlertFacilityEnabled") else "",
                 "initial_data": _safe_json(initial_data),
             },

--- a/hyperscribe/scribe/api/session_view.py
+++ b/hyperscribe/scribe/api/session_view.py
@@ -33,6 +33,7 @@ from canvas_sdk.v1.data.patient import Patient
 
 from hyperscribe.libraries.canvas_science import CanvasScience
 from hyperscribe.libraries.constants import Constants
+from hyperscribe.libraries.helper import Helper
 
 import hyperscribe.scribe.clients.nabla  # noqa: F401 — register backends
 from hyperscribe.scribe.backend import (
@@ -68,6 +69,31 @@ def _format_icd10_code(raw: str) -> str:
     if len(code) > 3:
         return code[:3] + "." + code[3:]
     return code
+
+
+def _authorize_edit(note_uuid: str, request: Any) -> JSONResponse | None:
+    """Return a JSONResponse to short-circuit when the staff cannot edit the note's Scribe tab.
+
+    Authorized when the note exists, is in an editable state, and the logged-in
+    staff (from `canvas-logged-in-user-id` request header) matches the note's
+    provider. Returns None on success.
+    """
+    if not note_uuid:
+        return JSONResponse({"error": "note_uuid is required"}, status_code=HTTPStatus.BAD_REQUEST)
+    try:
+        note = Note.objects.select_related("provider").get(id=note_uuid)
+    except Note.DoesNotExist:
+        return JSONResponse({"error": "Note not found"}, status_code=HTTPStatus.NOT_FOUND)
+    if not Helper.editable_note(note.dbid):
+        return JSONResponse({"error": "Note is not editable"}, status_code=HTTPStatus.FORBIDDEN)
+    headers = getattr(request, "headers", {}) or {}
+    staff_id = headers.get("canvas-logged-in-user-id") or ""
+    if not staff_id or not note.provider or str(note.provider.id) != str(staff_id):
+        return JSONResponse(
+            {"error": "Only the note author can modify the Scribe tab"},
+            status_code=HTTPStatus.FORBIDDEN,
+        )
+    return None
 
 
 def audit_event(note_uuid: str, event_type: str, details: dict[str, Any] | None = None) -> None:
@@ -516,9 +542,11 @@ class ScribeSessionView(StaffSessionAuthMixin, SimpleAPI):
         note_id = str(data.get("note_id", ""))
         if not note_id:
             return [JSONResponse({"error": "note_id is required"}, status_code=HTTPStatus.BAD_REQUEST)]
+        if denial := _authorize_edit(note_id, self.request):
+            return [denial]
+        staff_id = self.request.headers.get("canvas-logged-in-user-id") or ""
         items = data.get("transcript", {}).get("items", [])
         finalized = bool(data.get("finalized", False))
-        staff_id = self.request.headers.get("canvas-logged-in-user-id") or ""
         _save_transcript(note_id, items, finalized=finalized, provider_id=staff_id)
         return [JSONResponse({"status": "ok"}, status_code=HTTPStatus.OK)]
 
@@ -541,6 +569,8 @@ class ScribeSessionView(StaffSessionAuthMixin, SimpleAPI):
         note_id = str(data.get("note_id", ""))
         if not note_id:
             return [JSONResponse({"error": "note_id is required"}, status_code=HTTPStatus.BAD_REQUEST)]
+        if denial := _authorize_edit(note_id, self.request):
+            return [denial]
         payload: dict[str, Any] = {
             "note": data.get("note", {}),
             "commands": data.get("commands", []),
@@ -593,6 +623,8 @@ class ScribeSessionView(StaffSessionAuthMixin, SimpleAPI):
         note_id = str(data.get("note_id", ""))
         if not note_id:
             return [JSONResponse({"error": "note_id is required"}, status_code=HTTPStatus.BAD_REQUEST)]
+        if denial := _authorize_edit(note_id, self.request):
+            return [denial]
 
         total = len(SUMMARY_STEPS)
 
@@ -1057,6 +1089,8 @@ class ScribeSessionView(StaffSessionAuthMixin, SimpleAPI):
         note_uuid = str(data.get("note_uuid", ""))
         if not note_uuid:
             return [JSONResponse({"error": "note_uuid is required"}, status_code=HTTPStatus.BAD_REQUEST)]
+        if denial := _authorize_edit(note_uuid, self.request):
+            return [denial]
         commands = data.get("commands", [])
         validation_errors = validate_proposals(commands)
         if validation_errors:
@@ -1104,6 +1138,11 @@ class ScribeSessionView(StaffSessionAuthMixin, SimpleAPI):
             data: dict[str, Any] = json.loads(self.request.body)
         except (json.JSONDecodeError, ValueError) as exc:
             return [JSONResponse({"error": f"Invalid JSON: {exc}"}, status_code=HTTPStatus.BAD_REQUEST)]
+        note_uuid = str(data.get("note_uuid", ""))
+        if not note_uuid:
+            return [JSONResponse({"error": "note_uuid is required"}, status_code=HTTPStatus.BAD_REQUEST)]
+        if denial := _authorize_edit(note_uuid, self.request):
+            return [denial]
         pending = data.get("pending", [])
         if not pending:
             return [JSONResponse({"ok": True}, status_code=HTTPStatus.OK)]
@@ -1172,6 +1211,8 @@ class ScribeSessionView(StaffSessionAuthMixin, SimpleAPI):
         note_uuid = str(data.get("note_uuid", ""))
         if not note_uuid:
             return [JSONResponse({"error": "note_uuid is required"}, status_code=HTTPStatus.BAD_REQUEST)]
+        if denial := _authorize_edit(note_uuid, self.request):
+            return [denial]
         audit_event(note_uuid, "SIGN_NOTE", {})
         note_effect = NoteEffect(instance_id=note_uuid)
         return [JSONResponse({"ok": True}, status_code=HTTPStatus.OK), note_effect.lock(), note_effect.sign()]

--- a/hyperscribe/scribe/api/session_view.py
+++ b/hyperscribe/scribe/api/session_view.py
@@ -77,18 +77,22 @@ def _authorize_edit(note_uuid: str, request: Any) -> JSONResponse | None:
     Authorized when the note exists, is in an editable state, and the logged-in
     staff (from `canvas-logged-in-user-id` request header) matches the note's
     provider. Returns None on success.
+
+    Uses `.values()` to fetch only the two scalars we need — this runs on every
+    mutating endpoint, so we want it cheap.
     """
     if not note_uuid:
         return JSONResponse({"error": "note_uuid is required"}, status_code=HTTPStatus.BAD_REQUEST)
     try:
-        note = Note.objects.select_related("provider").get(id=note_uuid)
+        note = Note.objects.values("dbid", "provider__id").get(id=note_uuid)
     except Note.DoesNotExist:
         return JSONResponse({"error": "Note not found"}, status_code=HTTPStatus.NOT_FOUND)
-    if not Helper.editable_note(note.dbid):
+    if not Helper.editable_note(note["dbid"]):
         return JSONResponse({"error": "Note is not editable"}, status_code=HTTPStatus.FORBIDDEN)
     headers = getattr(request, "headers", {}) or {}
     staff_id = headers.get("canvas-logged-in-user-id") or ""
-    if not staff_id or not note.provider or str(note.provider.id) != str(staff_id):
+    provider_id = note.get("provider__id")
+    if not staff_id or not provider_id or str(provider_id) != str(staff_id):
         return JSONResponse(
             {"error": "Only the note author can modify the Scribe tab"},
             status_code=HTTPStatus.FORBIDDEN,

--- a/hyperscribe/scribe/application/transcript_app.py
+++ b/hyperscribe/scribe/application/transcript_app.py
@@ -7,6 +7,8 @@ from canvas_sdk.events import Event
 from canvas_sdk.v1.data.staff import Staff
 
 from hyperscribe.libraries.constants import Constants
+from hyperscribe.libraries.helper import Helper
+from hyperscribe.models.scribe import ScribeSummary, ScribeTranscript
 from hyperscribe.structures.settings import Settings
 
 _CACHE_KEY_PREFIX = "scribe_transcript:"
@@ -48,6 +50,31 @@ def is_scribe_visible(secrets: dict[str, str], event: Event) -> bool:
         return False
 
 
+def _scribe_tab_has_content(note_dbid: int) -> bool:
+    """Return True when the Scribe tab has meaningful documentation.
+
+    Used to decide whether to hide the tab on locked notes that were never
+    used. Covers manual-mode users (who may have a ScribeSummary row from
+    template selection but no actual content) by inspecting the persisted
+    payloads instead of relying on row existence alone.
+    """
+    items = ScribeTranscript.objects.filter(note_id=note_dbid).values_list("items", flat=True).first()
+    if items:
+        return True
+
+    summary = (
+        ScribeSummary.objects.filter(note_id=note_dbid)
+        .values("note_data", "commands", "approved")
+        .first()
+    )
+    if not summary:
+        return False
+    if summary["approved"] or summary["commands"]:
+        return True
+    sections = (summary.get("note_data") or {}).get("sections") or []
+    return any((s.get("text") or "").strip() for s in sections)
+
+
 def is_debug_visible(secrets: dict[str, str], event: Event) -> bool:
     """Return True when debug apps (Audit, Cache) should be visible for this staff."""
     if not is_scribe_visible(secrets, event):
@@ -71,7 +98,13 @@ class ScribeApp(NoteApplication):
         return self.secrets.get(Constants.SECRET_SCRIBE_TAB_NAME) or "Scribe"
 
     def open_by_default(self) -> bool:
-        """Return True when no transcript has been saved yet or it hasn't been finalized."""
+        # Defer to the legacy Canvas note tab when the note is locked AND the
+        # Scribe tab was never used for documentation, so users land on the
+        # canonical note instead of an empty Scribe surface. The tab itself
+        # remains in the tab bar for users who want to inspect it.
+        note_dbid = self.event.context.get("note_id")
+        if note_dbid and not Helper.editable_note(note_dbid) and not _scribe_tab_has_content(note_dbid):
+            return False
         return True
 
     def visible(self) -> bool:

--- a/hyperscribe/scribe/static/app.js
+++ b/hyperscribe/scribe/static/app.js
@@ -6,7 +6,7 @@ import { Audit } from '/plugin-io/api/hyperscribe/scribe/static/audit.js';
 
 const html = htm.bind(h);
 
-export function App({ noteId, view, providerName, providerPhotoUrl, patientName, patientBirthDate, patientGender, patientId, staffId, staffName, debugMode, noteEditable, alertFacilityEnabled, initialData }) {
+export function App({ noteId, view, providerName, providerPhotoUrl, patientName, patientBirthDate, patientGender, patientId, staffId, staffName, debugMode, noteEditable, isAuthor, alertFacilityEnabled, initialData }) {
   if (view === 'audit') {
     return html`<${Audit} noteId=${noteId} />`;
   }
@@ -28,6 +28,7 @@ export function App({ noteId, view, providerName, providerPhotoUrl, patientName,
       patientGender=${patientGender}
       debugMode=${debugMode}
       noteEditable=${noteEditable}
+      isAuthor=${isAuthor}
       alertFacilityEnabled=${alertFacilityEnabled}
       initialData=${initialData}
     />`;

--- a/hyperscribe/scribe/static/index.html
+++ b/hyperscribe/scribe/static/index.html
@@ -62,6 +62,7 @@
       staffName: '{{ staff_name }}',
       debugMode: '{{ debug_mode }}' === 'true',
       noteEditable: '{{ note_editable }}' === 'true',
+      isAuthor: '{{ is_author }}' === 'true',
       alertFacilityEnabled: '{{ alert_facility_enabled }}' === 'true',
       initialData: initialData,
     };

--- a/hyperscribe/scribe/static/recording-hook.js
+++ b/hyperscribe/scribe/static/recording-hook.js
@@ -131,6 +131,13 @@ export function useRecording(noteId, initialTranscript) {
   // per-client binding, each client's late events keep their own offset and
   // session B's events get the new one.
   const sessionOffsetMsRef = useRef(0);
+  // Wall-clock anchor for the recording. Set lazily on the first connect of
+  // this hook instance; persists across pause/resume and internal reconnects
+  // so per-session offsets stay aligned to true wall-clock time. When we
+  // hydrate from a saved transcript, the anchor is back-dated by the saved
+  // entries' max end_offset so previously-saved audio time lines up with the
+  // continuing wall-clock timeline.
+  const recordingStartedAtMsRef = useRef(0);
 
   const handleTranscriptItem = useCallback((item, sessionOffsetMs) => {
     const offset = sessionOffsetMs || 0;
@@ -226,18 +233,32 @@ export function useRecording(noteId, initialTranscript) {
   }, []);
 
   const connectAndRecord = useCallback(async () => {
-    // Capture the session base offset for THIS connection. Bound into the
-    // client.onTranscriptItem closure below so late drain events from a
-    // prior pause/resume cycle keep using their own session's offset and
-    // can't pick up the new value mid-flight.
+    // Session offset for THIS scribeClient instance. Stored in a mutable
+    // holder (not a closed-over const) so internal reconnects — JWT refresh,
+    // network blip, anything that triggers scribeClient._reconnect() — can
+    // recompute it without going through connectAndRecord again.
     //
-    // First start: entries is empty → 0. Resume: max end_offset of what's
-    // already there, so new offsets continue monotonically from that point.
-    const sessionOffsetMs = entriesRef.current.reduce(
-      (max, e) => Math.max(max, e.end_offset_ms || e.start_offset_ms || 0),
-      0,
-    );
-    sessionOffsetMsRef.current = sessionOffsetMs;
+    // Each new Nabla session restarts start_offset_ms at 0, so we have to
+    // shift incoming offsets by "wall-clock time since the recording
+    // started." That makes the displayed timeline match the actual visit
+    // duration rather than collapsing to the spoken-audio duration.
+    //
+    // Anchor the recording start the first time this hook connects. If
+    // we're hydrating from a saved transcript, back-date the anchor by the
+    // saved max end_offset so subsequent items continue the saved timeline.
+    if (recordingStartedAtMsRef.current === 0) {
+      const savedMaxEnd = entriesRef.current.reduce(
+        (max, e) => Math.max(max, e.end_offset_ms || e.start_offset_ms || 0),
+        0,
+      );
+      recordingStartedAtMsRef.current = Date.now() - savedMaxEnd;
+    }
+    const sessionOffsetHolder = { current: 0 };
+    const refreshSessionOffset = () => {
+      sessionOffsetHolder.current = Date.now() - recordingStartedAtMsRef.current;
+      sessionOffsetMsRef.current = sessionOffsetHolder.current;
+    };
+    refreshSessionOffset();
     let config;
     try {
       const res = await fetch(`${API_BASE}/config`, { cache: 'no-store' });
@@ -259,11 +280,11 @@ export function useRecording(noteId, initialTranscript) {
     let client;
     try {
       client = createScribeClient({ ...config, refreshConfig });
-      // Bind THIS client's session offset into its handler closure. Any
-      // late events delivered through this client (drain after pause,
-      // post-reauth replays, etc.) will apply this offset, not whatever
-      // the next connectAndRecord captures.
-      client.onTranscriptItem = (item) => handleTranscriptItem(item, sessionOffsetMs);
+      // Bind THIS client's session-offset holder into its handler closure.
+      // Reading holder.current at delivery time (not at bind time) means
+      // when onReconnect bumps the offset for a fresh Nabla session, the
+      // very next item this client processes already uses the new value.
+      client.onTranscriptItem = (item) => handleTranscriptItem(item, sessionOffsetHolder.current);
       client.onError = (msg, code) => {
         if (code === 83011) {
           // Stream timeout — Nabla closes the connection if a stream receives
@@ -285,6 +306,13 @@ export function useRecording(noteId, initialTranscript) {
         // finalized through the normal flow since the old WebSocket session
         // is gone, and the ACK'd audio that produced them won't be replayed.
         finalizePartials();
+        // Recompute the session offset for the NEW Nabla session. Nabla
+        // restarts start_offset_ms at 0 on every fresh WebSocket, so unless
+        // we bump the offset to the current max end_offset, every item from
+        // this point forward would land back at 0:00 in the displayed
+        // timeline. Runs after finalizePartials so partials' end_offset is
+        // included in the max.
+        refreshSessionOffset();
       };
       await client.connect();
     } catch (err) {

--- a/hyperscribe/scribe/static/recording-hook.js
+++ b/hyperscribe/scribe/static/recording-hook.js
@@ -119,18 +119,25 @@ export function useRecording(noteId, initialTranscript) {
 
   // Nabla restarts start_offset_ms from 0 on every (re)connection, so a fresh
   // post-resume partial would interleave into the middle of pre-pause content
-  // when sorted chronologically. We add a per-session base — recalculated at
+  // when sorted chronologically. We add a per-session base — captured at
   // connect time from the current entries' max end offset — so the displayed
-  // offsets stay monotonically increasing across pause/resume cycles. New ids
-  // synthesized via normalizeEntry inherit the session-shifted start so they
-  // remain distinct between sessions.
+  // offsets stay monotonically increasing across pause/resume cycles.
+  //
+  // The offset is captured into the *client's onTranscriptItem closure* at
+  // connect time rather than read from a shared ref. This closes a race in
+  // the pause-immediate-resume path: late drain events from the prior client
+  // would otherwise pick up the new session's offset (because the ref had
+  // already been recomputed when resume opened the new connection). With
+  // per-client binding, each client's late events keep their own offset and
+  // session B's events get the new one.
   const sessionOffsetMsRef = useRef(0);
 
-  const handleTranscriptItem = useCallback((item) => {
+  const handleTranscriptItem = useCallback((item, sessionOffsetMs) => {
+    const offset = sessionOffsetMs || 0;
     const adjusted = {
       ...item,
-      start_offset_ms: (item.start_offset_ms || 0) + sessionOffsetMsRef.current,
-      end_offset_ms: (item.end_offset_ms || 0) + sessionOffsetMsRef.current,
+      start_offset_ms: (item.start_offset_ms || 0) + offset,
+      end_offset_ms: (item.end_offset_ms || 0) + offset,
     };
     const normalized = normalizeEntry(adjusted);
     setEntries(prev => {
@@ -219,13 +226,18 @@ export function useRecording(noteId, initialTranscript) {
   }, []);
 
   const connectAndRecord = useCallback(async () => {
-    // Capture the session base offset before any new transcript items arrive.
+    // Capture the session base offset for THIS connection. Bound into the
+    // client.onTranscriptItem closure below so late drain events from a
+    // prior pause/resume cycle keep using their own session's offset and
+    // can't pick up the new value mid-flight.
+    //
     // First start: entries is empty → 0. Resume: max end_offset of what's
     // already there, so new offsets continue monotonically from that point.
-    sessionOffsetMsRef.current = entriesRef.current.reduce(
+    const sessionOffsetMs = entriesRef.current.reduce(
       (max, e) => Math.max(max, e.end_offset_ms || e.start_offset_ms || 0),
       0,
     );
+    sessionOffsetMsRef.current = sessionOffsetMs;
     let config;
     try {
       const res = await fetch(`${API_BASE}/config`, { cache: 'no-store' });
@@ -247,7 +259,11 @@ export function useRecording(noteId, initialTranscript) {
     let client;
     try {
       client = createScribeClient({ ...config, refreshConfig });
-      client.onTranscriptItem = handleTranscriptItem;
+      // Bind THIS client's session offset into its handler closure. Any
+      // late events delivered through this client (drain after pause,
+      // post-reauth replays, etc.) will apply this offset, not whatever
+      // the next connectAndRecord captures.
+      client.onTranscriptItem = (item) => handleTranscriptItem(item, sessionOffsetMs);
       client.onError = (msg, code) => {
         if (code === 83011) {
           // Stream timeout — Nabla closes the connection if a stream receives

--- a/hyperscribe/scribe/static/recording-hook.js
+++ b/hyperscribe/scribe/static/recording-hook.js
@@ -1,5 +1,6 @@
 import { useState, useRef, useCallback, useEffect } from 'https://esm.sh/preact@10.25.4/hooks';
 import { createScribeClient } from './scribeClient.js';
+import { logEvent } from '/plugin-io/api/hyperscribe/scribe/static/audit-log.js';
 
 const API_BASE = '/plugin-io/api/hyperscribe/scribe-session';
 const TARGET_SAMPLE_RATE = 16000;
@@ -24,6 +25,14 @@ function cleanupAudio(audioCtxRef, streamRef, workletNodeRef) {
 const SILENCE_RMS_THRESHOLD = 0.005;
 // Seconds of continuous silence before showing a warning.
 const SILENCE_WARNING_SECONDS = 7.5;
+// Hard upper bounds on how long we keep the WebSocket open after the user
+// hits Pause / Finish, waiting for Nabla to push final speaker attribution
+// for in-flight partials. Bail out early as soon as every entry is final
+// with an attributed speaker. The user sees the existing "Finalizing
+// transcript…" / "Paused" state during the wait, so it's transparent.
+const FINISH_WAIT_MS = 8000;
+const PAUSE_WAIT_MS = 3000;
+const SPEAKER_POLL_INTERVAL_MS = 200;
 const DING_URL = 'data:audio/wav;base64,UklGRmhWAABXQVZFZm10IBAAAAABAAEAIlYAAESsAAACABAATElTVBoAAABJTkZPSVNGVA4AAABMYXZmNjIuMTIuMTAwAGRhdGEiVgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAP////8AAAAA//8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAABAAEAAQAAAAAA//8AAAAAAAD//////v///wAAAQABAAEA/P/4/wEABgAFAAUABQAKAAsACAAFAAQAAwAGAAoADAAUABMAEQAPAA8ADwATABgAFAAWAA4ACQACAPz/8//r/+7/6f/v//T/8//x/+7/8f/x//H/7//v//P/8v/z//f//v8FABIABADs//D/AQAEAAwADwAJAAkA+//x//r/HQAOAOn/9v/4/+n/8P/6/wkACgAFAPD/4/8YABYA9v/s/wkALgDx/+H/BwDz/7r/1P///xAAIgDl/8r/FgA3AN3/CwD9/xgAb//3AE7/tvzH/WUMvSK3As/O8eXDCgn9bvSoBgcUJhQxBaP/rg2dCp76Oe1w8CMA2vhn6ObsKgTFF3AVFg6IFgkvMDHHE0j77+si5Uro8uN03vfPjsIXzmHqmhBdJGcVC/r18EURgjZaM64Uge9C6AH8jgFi/WD2Cu7D4qzV7eT4EZQ04y9xEwQQtSoKRuNA2Bks+4XpgNgo0vzdbPYM/LHmfNfA52ET3C+gI08IRvZ+/B4Jgf+o8Nzoet/J0yHRLOgxBkMLAPsf8Q8I5iUCLEcZqPk78pD9RfyN8FLn1uqc6wTkZu5iDmQwvTJfGiYR0B0BM080nRbk+mDv5etJ59fkdPD4+zr6+fAT+kYhyj9EPF8h3waJA4YJNwZE+B3k2tStxw/DtdNt8RwGlf5I7271dw4qKQsqGRCT9szrjexu6pvjNt311JnNvc98530Mpx7gGYMR6BTzJlYxXCbBDo76sPAD7Cjth/NP+CL53PUK+4oSmC1KOfIvLh+bGSsduxxeE6AEA/WS5/HhrePn7P77rgFQ+lL0LP9AGCUlkRsvCTH6qvEm6w/nOORL3tvTfsZYxkrdNPltBqADKf4JBAoSTBmWE/UHq/kA6bbeA+As6TXx/+2j5rnscwQwHnIp0CdyI4UjPiSsIQUfsBr6Dhv84+uS7AH8RgelBNH8BgE7FdwnuyzaKFkknBwwDswCWv+i/CXw5tpJzgbVDOay8WHzYfNE+HoAhwd7CqcMNQhd9/Dh0daO3CzlQuHa1WnRydoe7ZH+VQngDu4Rmg8fC7YOixdzGI4HYe0g4nTr+vmtAdQCvwTpCr0V4SNLMIQ27DDOH2APQgw8E0oUMwWC70HnPfCA/D4DHQW7BzsLBw1qEWQZdx3iE4T+BOzm59nszOo03cfRJtK52WTjg+19+RMDWwNW/dP8yAUxDKgD9u783obfOOd16ojqyuvT7ijymPhiBwEbYSUDIFUVAxLOGXohNxzZC7H9ZPlp+1AA3gbvDA8PqQtlDCEaCS0pNYQqHhcDCzUMIQ/UB2X5Kewe5P3ivehH8+X9H/+H9zb0tPyACVIMoAFU8N3jWOE44ZbeQNrF1RfSO9Ll3E3v6f/KBZ0C6QA6BA8MKxE3Cwz9cvAe7CLuzPI4+OH8k/8cAogJnhl1K80zGi9LJCQewh9xIR8cdBCYA5T6G/jF/MAHNhFhEC0KhgqpFdEi1iRPGtgKTf44+Kn0nO/26Czg7dVC0YnZYuo59u/2TPJA8Xj3rP4A/+f3Ke264rXbN9qq3rzkxOWJ4FzfU+ul/mIM2Q/SDc4NUhF2FQ8XjBRED1UHvv5E/IAD1A04EWwNXg3PFp8kgC0lLZIosCOIHRgXHhM4EacN7ANv91TyMPkcAgID0v4R/CX+ygKABYIFGQPH/Inx6ebl4zTm0OUd3dnR48+K2Mzkruyl7TPt8u/h9B76qv1t/mb6RPHe6avqDPJ3+Nb3fvLS8/b/Og9IGSkdEx99IPQgPyEFI98kkiA/FLAIpAbQDHwR1Q9zDEcN1xMSHI8iDSfZJYodERI2CXgGTQXO/FTrONyV2dbfsuZJ6WTq8ezS7i/xPPZ1/HT9pPO65GvbKtyL31Dds9Z30TDTAdu55Xbx4ftEAzYF3AT0CW8TdxkRFW0I1/6C/sUE+whkCGwIuAvyECEYhCK5LEQwsCuvJKIhpSQfJvse1RHPBuoD3wUzByoGcgRIBHsETwX0CEANhgzfAt/1ae7y7RXuxuc93N3TE9Ly0xDYad3B4pPmVufI58XrNfOU9ynz3ui+4VHjp+hR693qt+lN6pnuf/itBscSJhjYFh4V2hpMJN4oCiXGGr8RdA6tEPAUEBfpFdwSKhLSF6siTy3sL2YpzCCxGxobfhnJES4FFvi+7mPr/OxA8NPxJu8z7DHup/W1/Pj9Q/fm7H7mBuXL4wXfAtiQ0e/ML8wd0hPeJeno7fvuKPMv/b0HSg2OC9gE4P4N/AH80v3C/6j/1v7HAc8KQBgqJawr+ypZKMYpcS6IL/QpUSD+FX4N4AjSCRcNTg3dCV8GTwkBE/IaBBu6E00LNQWTAI/7BvWj7Cvi/tdg0knUiNtQ4EffMd6c46rt/vTX9Zvxz+zm6KTkiuGV4UHiEd+D2T3a6uRK8+X9bAMGCY0RXBkDHc8dYR7yHacYshBFDewQERXlEjsOIw9qF/UgmiahKbEsYy3PKbwkYyKtIXwbrQ3s/nH4Ffrd+hH2APDy7szz2fhT+zv9uP6X+0TyZ+mb5gPm9t+a03fJjMh3zrjUDdgJ2zzhP+m07+j0Ofv8ACYAkfiX8tDzA/lW+uj1ofJz9m//6AhsEXYabSKPJrInBCq9L/MyCS70ImYYOhT8E2kSPA/hDGoN5BASFsYciiPuJU0hhxg0ES8NgQiy/iPwS+NI3dnci97g39Pg3eIM5i/pdu1C9Ir4SPRr6iLi6d753SLanNOyzlDOwdPd3PTmufHX+hwBjAZCDmEX7BtDGKEPuAjeBnEHBQfwBSwGbQnGD0oYkCKsLIkyvTKTMIcvpy+RLG0jdxeiDUEHFQMVAFL+Zv63/ov+KQH/Bs8LWgxGB9X+M/cq8iTtNeV+2zzT9c3Fy2vN1NJ/2X7eVOKx5nztS/UK+fX10u4K6tDokOgR6KDnjOc+6X3uGPj7A2gPwhcqHG4f1iPzKBcrLyiXISEakhSiEW4RLhJLEq4S7hQFGxEj/CnoLZwsACi4Il4dxxdGD50DE/eX7CDn8eUl50Do0egf61bvzPSX+Zv6BPcL8MzoCeO53RfY1tEjzL7I7Ml40BrZOuHq6G/wYPh/AIIHtAs9DBcJrgOX/rn8MP6E/33/egDBBY8PuRpHJHErDTAUMp8yVDL1MOAsAiXjGiMSywzDCo8KBgp2Ca8K8Q3HEvwWyReTFAEOggZ//3L5XvKr6Nvdg9V70sLThNY42S/cEOCZ5DzpYe3471rv1epv5ajhBeCx3urbFtpa26zg+eil8nb91wfpD+QVKho1Hs8gmx9bGzsWbBMpEs0QoA/jD8ISkRd7HSgk7ConMNwxri9tLLgpKiYqHtwSvggnAfb6gPVo8gTy1vLo8/f1R/ky/Rf/Qfy/9bnvr+uv5grfadZgz2XLCsosy7XP7tb43Xnj6ugL8KT3afzX/Nf6b/lU+Uf4efYR9nb3rfmj/DoC7wq+FL8cjCLHJ/UsjzCRMNcsuydoIt8cXhcgE5sRDxJzEr4SJhVhGkwfjiD8HUYaXBY9EFMHM/6g9YDtnuV13+DcE96p4CjhSuHc49Po4+zg7Zzs2enH5VngJdvJ18vVNtQ50tnR7da54Pjq+vI5+ncC4AqmEWIVHxaMFBIRtwyQCfMIZQrUC+kMXxBaFyggdCf6K+YuVTHKMmAxcS00KMAhLBqIEYsJrwQhAvH/4f3t/GP+LwFTA4cDSwIzADP8RvYC737nLuCY2GfRAM3PzCPPXtIp1hnbj+HF5zTsCe+y8DrxBvAt7Y7q2enV6lXsBu4H8S335f+9CPwPKhZPHNwh7SUIKC8oTSZjIjsdnBisFgkXgxcUF2AXvhqSIN0lbij3JywmgCO0Hi4YfxCFB8j9WvRd7dzpmuj659vnEOm86+3u+/Bo8TPwXO3s6KLjld7j2QLVbNCxze/NzNCN1TPc7+OX613yCPknAGkG5QnfCeYHBQalBE8DkgJsAxIGaAlGDnQVIB4hJhQrxi14L1kw/S+MLVYpoyPRHE8WRRHZDjcO7AzlCgQK9QuyDsMPGA4ICjAFUQCr+h70WO3M5vnfwtnD1gTX5Ni32jjcDd5h4bHltuiK6e/oXucm5djiluGU4ZPhqeFv4/XogfGN+jICewgID4wVshrQHeseGB7RGz4ZFBfbFeEVNhbFFl0Y3htIIaMmtiq+LJMs5CogKCkk5B74F1wPWQbH/k/56/Us9LLyePEy8fHyo/VH99r2I/RS8Nvr6ea74R/cptaf0TDO7c140GbUotiT3a3j8+lT8C32d/pm/Pn78vrW+oj7D/xq/KP9AgDuA/EJABHdF6sdaiJ/JgEqFiwHLBIqqCZHItIddhpkGAYXDxYiFX4UdhWUF0IZzhjGFS0RKwxNB9EBJvv/84Lt3OcL49Lf595q327gUuFu4pDkJ+eh6JjnqeS/4Tbf+tzs2nvZadle2k/cVuAj52rvd/et/vgE+AqAEBIU8xTwE2YSqhDrDlcOgw+ZEbwTTRbyGRYfJSUqKpAs9yz6LFosZykvJBMeqxf5EHQKIgWRASD/8fwG+6j6KPzD/dj90vsE+VP2n/Ii7cfmzOBr25HWHtPZ0e3SYNUP2Dvbld9B5ZDqyO0F77bvjPDd8FnwgPBy8qH0fPYM+bX9iwRuC9cQShUNGiUfJyPGJMAkDSRbIj4fBBxcGlAaKhrkGBIYxxlMHe0fKyAIH6Ud9hoXFqAPegmnA3n8Y/T57dPq6ukZ6cznEOcC6B7qPuv86jrqMenx5rbiSt7P26Ha09gx1vbUX9dx3MDhi+Y27G3zwfqDANYE5wjzC4UMBAtjCZ0JuArrCtcKxgyZEXUXdBznIHIloCkmLHYs5iuWKo4nTCI1HFUX6hPREDoNwAmWB/gGsQYBBi4FYQTmAgMAJfz99+nzpO4k6LThIN2J2rHYqtf416rZJ9zD3srhNOXu50vpCulZ6DLonOgH6fjocOn063HwEPZB/N0CXgkAD4ATjReyG9Qedh+JHQcbvhntGboZrBhFGGAZtxtoHjIh7iP4Jfsl0yPpIFAe/RruFI4MfwRb/o35fPXw8cvva+94767v4fDA8nfzhfH97XXqX+ck5LPfodqk1sLUdtRK1dPXVdyt4WDmEusO8ab3cPzb/gQA9wAOAuACIQMmA9sDVwWEBzcLuRD+FkwcKyBsI8Umvym/KjMpFiaAIv4evhvNGEMW8RP0EXgQ5A+QEAgR7A+HDaIKhAe4AxL/qfka9J/uXekC5SniveDr31/fbN+y4PviEOX/5SLm9uWe5avkX+N84vzhsOHh4YLjwuf/7VL0Ifrt/1sGlQwyETkU3xVgFoUVDRR5E+4TdhRaFEoUvBVKGQ0eAiJjJAsmMSdhJ0ImsyMVICMbwBTQDbQHfQM5AG78h/hE9oX29Pfb+Jv4dvfx9dTze/A+7PrnnOOx3tHZq9Yq1lDXrNgv2jXdEOI450/rd+6G8UT0nfUS9r/2RvgY+iv7EPwq/gwCwwYSC00P/RMaGbgdtCBfIk0jTyOuIeMetBykG0sa6xeBFewUaBY7GPIYgBi9F5EW9RP8DzUL/AUhAKT5mvNW7+fs1eqL6IXm4+Xx5ljoEelt6aPpC+kY55Pks+Kd4ULg193S29/bN97z4Q3mrup68Nn2uvwoAnwHyQvLDW8NLgz3C5kM/wyMDHIMOA6gEcAV2hkJHh4iziTNJRwmeib6JQQjwB0sGOQTXxBeDDkI3gTmAp8BaQAAAFsAZACb/nP7kfhM9hrzu+1k53ril9+j3cnbpdoj2wTdBN/54B/kLOg36xPspOv/667tKe+E73Tvg/BK8wL3Bfus/xYFKAr/DUwRghULGgQdTx3KG2ka6BmgGaUYjRf6FhQXzxdZGc4bQB4dH9gdxBv9GQ0YXRRODmYHJQEi/Az4jvQJ8izwtO7l7TTuhe+f8HLwn+4d7ADqIOit5VHi696s3J3bstv+3ILfBOOW5mzqMO/C9E/6j/45ARoDugTMBUIGkAb3BqAHqAiHChIOlBLFFhMa9BwRIAUjDCVTJeojfSF9HmAboxg9FqQThRCdDdALdguzC0QLpgkoB+MErgIWAIf8H/h286nuNOrW5uTkmuMT4urgBeGP4hzlOucg6GLoxOgm6f/oiOhW6GbooOhW6W7rWe9z9GH5qv0yAmYHhQxsEOkScxR4FfQVohUNFQMVahWJFVoVFxYvGP4afR0HH9wfZCBXIEkfGx3OGXsVVRC9CqEFkAEw/vH65/f29Y/1M/as9i/27PRE81jxNe+n7GrpneWz4azeFN343L/d6d6D4NriXebV6kLv+PKW9ZH3ifli+xv9gf6Y/2QAVgEAA8MFWwkdDZMQ/BOcF0MbXR5NIA8hkSAJHx4daxvuGTQYGBYKFKsSSRJpEksSbxHuDwwOrgv5COkFPwKs/bz4PPS/8Brurusp6SnnVeZ/5kXnKOi+6JXoDOie52/nP+es5mvl/+Nw41Hko+aa6QXtz/AN9QT6NP8YBDcIMwvYDKMNTQ4KD74PCBAoEGIQFRHnEnwVGxiFGpEcDh4NH6cf2x8LH5kc0xiWFLAQPQ2uCb0F8AH7/iP9Efx2+wD7W/oO+U73rfXk84vxFu7D6bnl5OIq4QPgSt8w3/vfnOHu49vm5uls7FHuA/DN8ZnzMvV99n73lPhi+uf8AABLA3IGmgn7DNAQuRTiFw0aJBtdGwwbqRpGGnkZIBh8FkAVERWXFRMW/RVXFXkUnRN3EmQQMg0LCUQEvf/C+yH40PTX8STvHO057EDsoeyG7AfsXuvD6lnqwelq6IDmjeQa433iseKb4xrlQuc46hnuxfKj90b8WgBzA7EFpQdbCVQKigpKCnMKgws0DVIPjxH+E6MWQhm2GwAevh9PIDofHR3yGtIYMRbDEhoP2AtHCTUHcQUpBC8D7AFaAPf+GP7W/Gb6ovam8nbvoOyU6WvmAuTT4mficOIy4yvljudK6Xbq7Ovi7Wjvze+O78Tv7/CH8ib0YPZc+er8iQAcBCwIlAxeEOgSiRQWFmwXDRiVF3YWwhWUFa4VxhUFFsAWphdlGPUYZBltGYkYixaREwgQOwwBCFQDxP4L+zz46/Xx873yVfJS8h7ysvFH8aDwVO9R7fvqw+ii5o7kzeL24UviPeO55BXnb+pu7mzyEfZn+X38N/8oAYQCjQNjBPsEkQWcBkUIjQpKDScQBRPpFboYMRvtHM4d+B09HcQb1xmmF4cVTBPvELMOFw0yDGYLSwr9CJ4H/AXlA4IB5v7s+2r4kvTy8PPtjOuC6bznkeZh5hDnJuga6fbptuo165jr7+sk7Brst+to6wvs8e2e8GnzKvaD+cD9QwJbBtQJpwzCDhQQ/hDqEYASjBLsETgRYxGTEgkUZBWXFs8XIxlIGu0awRq7GZwXeRTqEEQNqAnqBQUCZf6C+8f5p/jg90H3ofYg9k71MPTd8hDxhe5766bog+bo5LDj5+Ko4jjj6eSa57zqx+2A8BDzoPUH+Az6nPuI/Cv99/0n/+gA8wI2BbkHgwrIDT4RaxT8FsAYwRkWGvwZkhmLGOsWBBVRExoSORGZEAwQag/fDlwOkA0tDEkK6AfJBBYBQf29+Y72WPMr8I7txuvt6sHq5Oow65vrC+ws7CHsEuy868nqWek16OXnQugz6cTq6+zS73zzqPf1+wgArQOFBp0IUwq3C6oMAw3LDKwMNA15DtgPJhG/EpQUkxZ2GCAaVRuRG7saAhnQFmEUjxEsDncKIAeDBGcCngAp/wj+WP2T/Jz7efo6+Yz3BvUY8hvva+zv6bXn+OX25NjkXOU85s3nFup17Gfu6O9o8R3zkvRe9dv1vfYg+Kv5cfuZ/T0AMgMlBlAJxQxCEOwSUxQ0FR4WxRafFr8VdBR9EycT/BLcEuUSEhMKE9wSvBKGErIR0g8FDdkJwAaVAwQALfy2+AH27vNk8nPx7/C28HTwCfDL74nv+e7E7Tjsy+qP6YjopedU5+vnFOmV6rTsmu8t89r2Afrf/I//JgJCBJQFRwbSBnMHMggvCcIKpwyGDlEQPxKVFOoWqxhkGWEZCxlyGFYXkRVoEyER3g6oDK4KJQn3B58G/wR4A0cCNgHA/6D9T/sA+W32k/PD8G7ui+zi6onp2ugD6bXpceoi6w7sK+0d7tzub+8J8NrwfPET8hbztPT19m35B/zH/rcBzAS9B18K4Qz4DlYQJRGjEUQSzRLMEmMSFRJUEu8SiRMMFIMU0xTCFE4UqxPVEk0Rmg5JCyoIXwWZAqD/tvxM+o/4Rvcd9kv1vvQX9CjzBPL58PfvwO4o7U7r2ekA6YXoUeiB6Gjp7+rA7BHv8fHK9FP3cPlj+3n9Z//oAOUBrQKkA+UEbwZLCFcKcgyIDoAQhRKSFDAWAhcKF5EW3hUUFRUUyxJOEdkPcQ4fDRYMRgtSCuAILge4BXAEzwKVAOn9D/tG+M31ffNW8XDv2e2q7AXsBux37Nns8uwr7YTt7e027inuD+4i7oXuUu+I8C7yP/SM9ib5APwk/1wCJwVhByYJ6gqADIMNBg5VDp0O9A5wDyQQDREREvcSpRNqFDoVxBV6FV0U4hIhERUPogzlCS4HhwTxAbH/8f2v/KH7Y/oG+dv3J/dK9uf0HvMz8Xfvz+0o7MTq4elq6S/pTukt6rzriO1G7+3w4/IA9ej2ePiu+Qf7T/xY/Zb+SQA9AisE7AXiB0kK4gxODxcRcBJ/E0QUlhRrFPoTUxOCEnERhRAMEKcPDQ9CDmkNugz+C+EKQwklB8cEUQK5/xH9avrX93D1WvPa8eHwV/D+76bvVe8g7wXv3O5+7gnudO3j7IzsjOwJ7eDtBe+L8ILy/vTV98T6e/3f/wQCHAT2BXYHjQhCCewJtAqrC7kM5g0RDycQNBFrEtwT6xRGFf8UVhSIE4ISGRFJDzANCgv2CAoHbgX8A3MC3wBY/yH+PP0Y/Gz6ZPiB9q70yPLS8B7vx+2V7JfrFutX6xjs8uyd7Vnuj+/58DDyKvMy9Ff1cPZn95r4Ovot/Aj+tP+fAf0DrQYYCQkLvgxfDqEPmRBMEcsRCxLZEU8R0xDEEP8Q5hBXEMwPkg9vD/EO9g2KDMAKvQh7BiEE6AG0/zD9lPpt+Af3GfYd9fXz/vJo8uTxX/Hj8FHwje+R7qftFe0b7UrtWe2P7Vju7u8D8jP0bfau+ND62fzg/ucAsQL3A8QEigWfBvsHgAm2CsYLAA2PDjwQrRHGEnITqROQE0kT0BITEt8QMg9wDfMLvwqNCTAIqQYwBesDygKvAVMArf6q/Hr6e/jP9iv1PPM38YLvc+4E7v/tD+4m7lTu1e6I71TwGfGW8eTxNfLi8t7zDPVR9qD3E/nw+kv92v9OAocEjgZiCBsKwgsrDSYOmw7ADuMOGg9VD5cPxg/WD/QPNhCfEOYQ0hA7ECoP0w1GDG8KXwgeBqIDLAEI/zz9xftp+gr56fcD90L2hPW69MvztvK28b/wv+/n7k7uu+1A7Tvtye3P7gnwafEX8wT1CPf9+Nr6kvwP/kr/ZACAAakCuQPRBCwGvgd8CT0L9gx0DscP8RDPEUwScBJDEsURABEGEP8OAA4HDRQMCAsCCg4JGggCB74FZQTvAjsBQf8s/SH7K/ki9yz1hvMq8hDxVPD77/XvEPAo8EvwjfDt8DbxQ/E88VzxtPFX8inzNvSj9Vv3QvlX+679EgBKAksEGgayBygJYwo3C8MLPQzJDD4NjA38DZUOQA/bD14Q5RA/ET4RvhDfD8wOZw2bC44JeQd5BY8DxQEkALr+gf1T/Cn7KPpG+UT4APew9Wn0D/PA8Y/wke/D7iPu2e3w7W7uRu9k8KTx6fJM9Of1fvft+CT6K/sj/Cr9T/6P/9kARQLVA5kFnwe9CaILMw2KDo8PQRCqEMsQmxAfEHgPwg4iDqINIg2sDC4MoAv2CioKSAkqCMcGFAUaAxEBHP8d/QP77fgp96z1a/Rv89PykvJq8i3y/vHx8dTxm/FD8ePwpvCF8J3wAfG58djyW/QM9u/3Ivpx/Ij+WQD5AXMDwgTZBb0Gdgc4CBoJBArfCs4L2wzoDeUOrQ9QEMsQ7xCeEBIQUg9XDgcNaQvHCTsIyAZIBdIDkAJ0AXcAbv9V/ir90ftP+sn4OPem9R30kvIz8TPwkO9L70Dvbu/l75LwXvEt8gbz1/Om9HD1PfYw9z34S/ln+q/7IP3O/p8AdAJgBEwGGwi1CQ0LLwwQDaMNAA40DkQOMQ4WDvsN2g3IDbQNhw1BDfAMgwzHC6wKSQm9Bx8GVQRtAowAuv71/D77uvl4+Hz3oPbM9Qn1dPQE9I3z7PJU8tPxSvHM8IzwpvDx8EHxtvGf8gD0r/Vf9/n4qfpy/Bj+f//FAAYCPQNDBCoFMQZWB4QImwmjCsML7gzyDbYOWQ/fDyYQ8A9KD48O7A0rDSAM2QqICVIIKgcOBuwE1APPAqoBdAA+/wL+jvzJ+vj4ZfcI9rn0c/Na8pnxNvEY8STxXvG/8Sryg/IA86bzWPTv9Gz1+vXH9tb37/gg+oz7Mv31/rQAewJXBCkGsQfqCAAKAgvKC0YMewyrDNIM6QwWDU8Nhg2pDaINlQ15DTYNswzQC6cKOgmdB+kFDgQwAmYAs/4+/Qf8AvsW+kD5fvjK9xb3ZPau9eH06/P28jDyk/Er8drwzfAY8bzxv/L680n1rfYn+Kj5Jvue/PX9C//0/9IA0QHrAgIEEQUmBloHxggyCosLrwycDVUO1w4wD0YP/g5dDokNqgzRCwALNgpgCXwIjge5BvkFKwUiBN8CeAH1/2T+ufwV+3P5y/dE9gr1PPS280rz6/LC8t7yGPNW84jzpfO288Lz4vMq9KX0TPUX9hn3Z/j4+cv7rP2A/zsB5QJ9BOYFFwfsB44IGQmLCfsJdgr2CnAL1AtGDPEMlg36DQMOxw14DQYNRAwrC74JHghuBsAEPgPeAZIAUf8x/kn9iPzZ+wr7B/rt+N331fa69Yj0b/N78q/xNPEl8W3x2fFs8iTzEvRB9W32Z/dZ+Fn5UPpH+z/8Qf1A/lX/agCTAfUCggQWBnYHtQgACjILFgy2DBkNNw0VDdAMfwwlDMALOwuyCk4KCwrVCWIJoQipB6AGgwU3BLICCwFM/4799fuG+kf5Mfgz91X2tvVO9fT0rfRz9DT09vOy83HzSPNC80HzU/OP8xj0FPVQ9qf3H/mp+kb84f11/+4ALAI9AygE9QTHBYoGLwfTB5YIeglRChUL0gt3DP8MTg10DWsNCw1qDKULugqvCX0IPAcGBtkErgOSAo4BpQDO/+r+6f3L/KL7avo5+QD4ufZ59Vf0j/MH87Hyg/KL8tLyQvPj86H0VvXs9Wn2//bK9634hflW+jj7UvyH/dj+RgDIAVcDwQQZBmgHrAjBCYMKAgtbC6ELyAvKC78LpQt6C1cLRQtDCzQL9QqCCt0JAgkJCOkGkgX3A1QCxwBE/+D9kPxg+1j6bPmw+Cb4sfcx95r29fVb9dT0UPTL823zNfMm807zsvNY9Cb1GPY394f4Bfp/+978HP5G/2YAawFSAjMDEQTiBK8FlwafB58IgwlhCjYL9guPDO0MGg0ODckMOwyQC+EKIgo+CTcILQc8Bm8FpATBA8wC1gHQALv/l/5U/fP7fvol+f33Avcu9mv1t/Q89BX0JPQ/9Gv0m/TP9CD1gPXx9XX2AveP9zf4E/kp+mP7n/zm/TL/lwAOAn0D3QQWBhYH5werCFYJ3glFCnoKpgrXChALUAt9C5sLowuPC18LBgt6CrgJuAiIBzoG5QSWA0UC8QCc/2D+S/1X/Hv7pfrR+Q/5Wfi39zD3oPb09Tn1nfQy9AL09fPm8//zV/Ty9Mv1yvbb9/v4HvpM+3T8mv2w/q7/oACMAYsCjAN8BHAFZwZjB08IKQn0CagKOguTC8UL3gvcC7kLXwveCkUKnQn2CDwIbAeSBrEFugS4A80C1AGiAFz/Kv4S/fv7y/qM+W34hffT9j32rvU69eL0oPR99Jb03PQZ9TX1W/Wz9UP25PZ79y/4//j9+Rz7W/zK/Tb/ewCVAawC3wMVBSMG2QZXB+cHgwgLCXMJ1AkYCkAKawqnCv4KOwsMC4YK/gmMCQEJJQgHB9IFlQRUAxYC9gDu/+7+4/3k/CP8e/u0+t75BPk9+Iv31vYn9on1+/R59Cb0DvQ69JH0/PSG9Tv2FPcT+CH5H/oS+wL88/zo/d7+zv/BALQBoAKRA64E4gXzBuEHsQiBCTIKswoICzMLKQvqCpoKUwoICqgJFgluCN0HXAfFBgkGJgUkBCMDFwIEAeL/sP5j/RL83/rV+e/4EfhI96/2Ofb29df1vPWh9Y/1h/V89Yn1uvUE9k32l/YY9+L35vgR+kT7cfym/eL+KABpAZ4CsQOCBDYF9gXFBoAH+gdVCLgIOAnNCVEKtArtCv0K6Aq8CpcKWwrACdEIwQfDBtUFxwSZA1gCKwEzAF//o/7e/fT8+PsN+0j6q/kC+R74HvdK9rH1VvUQ9cv0s/TI9A31mvVb9i334veC+Dv5K/pL+0j8EP3A/Xv+aP9qAGsBhgKdA5MEhwWXBr4HwAhvCdcJHApqCrUK1Aq4Cm8KGQq2CVUJEwnICFQIrAfoBicGeAWvBKcDXwINAdr/uf6f/X/8YftX+nb5zPhO+Oz3e/fz9nX2MvYm9hz2/fXL9bf11vUY9oj2HffA93r4Uvlk+qv7/vw4/jr/LQA3AT0CNQMMBL4EWQX7BbYGdAclCMoIVAm3CRQKgArcCvgK0AqEChsKnAkHCVoIkAejBpkFjQSUA7UC4gH/AAkAGf80/lT9f/yk+7n6w/nb+Ar4T/e19jX2yPV19VP1b/W39Rv2ivb69mf37/eh+Hf5Sfr8+qj7aPxW/WL+b/97AHIBZQJvA3YEhwWCBkoH7QeFCBUJkgnjCfwJ8QnVCb0JmQl0CUMJ9AiMCBcIkAf9BlMGcgVoBFADMQIYAQQA4v6//a/8uvvp+jP6lvn++GH40Pdr9x/3w/ZV9u/1uvWw9cD16fUp9oL2CvfI97b4vfm7+qz7ovyz/df+4v/JAJ8BYgIqA/IDtQR4BSkGxwZhBwwItghICbMJAAozCkgKMwoCCqsJKAl2CK0H4QYeBlMFeQSIA5oCuAHlACgAXP99/of9k/yl+7763PkB+S/4dPfa9mX2Kfb29dH1wvXi9SX2gPb69n33BPiE+B351vmj+mz7K/z3/Nz92f7k/wIBIAIpAxsEFQULBt8GfAf9B1sIqAjhCP8IIQkxCS0JGAn0CMkIoQhoCA8Ilwf5Bj0GaQVzBGcDRwIkAQAA2P7T/eH8Afws+3X65vlt+ff4iPgo+Mj3YPf19of2OvYL9vX1CfZJ9rL2S/cH+Of45Pnr+vX79/zy/en+0f+eAE4B/gG4AmcDGQTOBI8FVwYUB8IHXwgACZYJ8gkNCgEK1Al+CQIJcgjTBycHbga0BQ0FcATDAwIDRQKSAd0ACQAW/xv+HP0Z/A37E/pB+Xr4zPdK9/f22vbS9sf21/YG90X3fffC9xf4a/i9+BL5kPk++g377/vZ/OH9+v4pAGcBgAJ8A18EDwXEBWkG5QZNB58H2Af+B1IInwjiCCUJJgk1CTMJMQkCCZcI2gf+BikGKgU0BD0DQwIkAQMA//4v/p79/fw8/Lr7WPu5+g/6YPnA+DL4tPcX9572WvYu9hv2JPam9of3Pvjr+Jz5TfoW+/P7yPyD/Ub+Av+C//n/4gADAsoCqwNmBE8FkwaBByQIwgj7COUINgk/CQkJJgnzCIUIvgdOB/UGqQZzBpEFqgQzBNADOwNiApABmwBv/3D+Q/34+x/7Yfpn+eb4jPgA+MT3nPd098v3yfew96z3mveN90z3rfdC+K74Ifnr+Y76y/tH/AD/cP7u/ED/PQ5oJJAGydVO7M0PPQNc+wsNTBoUGzwN7Qd9FTYTmgSk92T6bwnNAWfxEvWkCoYc/Bh5EdoYiS8iMd8TNPsM65HjiObg4avbLcx/vWvIKOQ2CcUbKgzp8Gnn9gYBLBcpJAtK56bgDvWZ+xP42vH86aveQ9KJ4gUPMTGTLc8SjxCYK01H8EMTH6MBlPBr4PPaUOfi//wEfO8g4AjwJhusNiAqJw8y/ekCew+KBqr3Ae/w5CzZydUd65MHKwu3+WDujwMsILUlJBOn83zrf/YW9vTqOOHh4xDkUdzL5pUFGyaeKA0RXQjKFAEqwSwBEZf28etV6WXmquXO8Un94vvj81399iOTQgZAACbSC/EIqA/hDUgBhO1z3mbRjM2r3iP7XA5aBi72Q/tUE7QsEC1wE6r53e0o7k7sdOXD3n7Vj8zQzX/kKwgHGSkTFwp0DFgdWycmHTwGB/Jb6NTjkuUB7YTy1/M18Jn0FgylJ9Ezyyp0GksVwBnxGlgTCwbE93jr5+a76cTzgwMjCVEBJfvEBZwekitbIkoQWgEm+UfzsO8i7QrnXtyFzoTNY+P2/fwJ7QVA/8MDUxCzFsEQKAVi9gblmNrg27/kZuyW6JHgEea2/FkVLiAnHm8ZZBkDGu8XqRZ8E2kIqvbO54fpgPlUBVgDQ/wDAeYUgicyLSYqLibdHo4RqQdIBVQD2Pe+49DXnN6b7zH7c/zZ+xMAaAesDT4QDhIQDa37W+aA27Hgt+jG5O/YotPJ27jsH/3rBg8LgAwTCRkEeAfUD2QQnP/25fzab+RU80T7U/zs/cIDsA4ZHYMpcy/kKZ4ZOwpMCFYQfxLRBJ/wgekl81sACQhJCsAMBxAREgAX8x7PIr4ZEQVV86/v3vRj80LmANvz2t/hPOuM9FP/dAepBvH/Ov4KBrQL7AJB7und5t1d5XroVei66MvqW+3O8rYAFROFHOwWygtxCHQQTxj0E4sEM/eJ81L2PfxlA54JtAumCAAKvhevKikzNSkAF+IL/g1DEnoMY//88o3rD+s58d77DwbMBgD/ZPs9A3QPKhKRB2v2z+kx50DnkeTk387ah9b31ZTfqPDd/3UEDwBR/XX/gQZdCyYF6PZf6gnmAuh57OPxefbB+AL7LgKxES8jfCsPJ6kc8hYiGbsbrRcdDYUBqPkb+On9iAksE90SIQ3yDTMZWSbrKA0fNBA5BMH+GfzW96zxDunw3mLaUOKI8pP9mf07+Bj2RPvLAc4BZfrm7t/jnNze2u3eVuSd5ILeftyK59j53QaeCZ4GswXKCPAMrg5XDBUHWv9t96j1WP35B7ALTgh/CPgRDCB0KbwpuCU6IdQbrxb6ExETdxDCB0r8/vdS/6YI7gnhBeACsQRFCSUMbgz3CXMDUvgN7ivrQu2S7LPjKthp1QrdbOhd70zvxu0/7yTzzvfL+uT6MvbJ7GLl+eUA7Q3zAfJk7ELty/ijB2kRFhWlFtcXoxiVGSccpB74GqYPLwUmBCgLeRB7D58M2w3DFHAdoySRKcQoESE5FjsOWwzNC+ADKfOb5BTiX+hC78bxZ/Ie9Fb1Pvff+3wBygFd9wPobt6t3obh9d7019/Ri9Kb2Ynjje4R+Df+Pf9o/iUDPAzNESMNogBQ9xD3lP1BAv0BLQJyBc8KfRI2HYQnWytJJ/ggwB6OIvIkyx64ErgIugafCbsLXAsWCgwKWApfC0EPmhPZEkIJcPw79d30MfUw75jjBNv92GzaHd7K4hzn4ema6S7pW+zK8kb2IPFT5r/e5d/S5Dvnj+bs5ArlAOl68hkAjwtbELwO4gyeEiEcCSGuHRQU2gtVCV0MehFqFPgTjxFnEYEXyCLBLbAwyCrbIlgemx7SHeoWFQue/t31AfP89F34zPnm9qvzU/U4/MACggNd/Lrx7OoX6YTnWeL62ivU7M5lzaHSsd2y54nrvesC7yL46QHzBuIE9P349yH1K/U/90/5V/ml+KL7twQkEv0ehyUcJdIilyS8KacrKyeGHjQVww1CCjkMRBArEUMOMAtUDhAYECBIIDIZ5hDyCp8GFwLj+63zb+l03+zZr9uJ4sPmBuUR43TnYfC19sT2v/Ef7J3n9uKc31vfld8U3FrWvNbB4E7uNfg8/SoC6QkuEbMUjBU+FggWNREXCnEHsQuDECEPNQuODCgVGx8iJYco0ivGLMopniUuJDck3B4gElcEpf70AEEC2v3j96r2H/vG/xICiANdBNgAWvdf7mvrrOqC5AvYrc03zG/RBder2b/btOBh573sJvGl9pT7Nfp/8oPss+3r8nv0UvAE7a3wgfniAk8LFRTKG78f/SCtI7kpjC2QKZMfLRYAE9UTbRMrEXEPYBApFKAZiyBRJ7kpVSXkHOwVWxJWDj8FPvfG6g7l3OSQ5qbnJOhi6ZXr0e1E8Sn3gPp79RrrbuL23vTd69kL08HN7MzI0Tzad+NR7Yz1zPpq/5IGWA++EzcQ2wd0AToAcQG+AUwB9QGTBUcM9BRAH3IpYi/LLxcuqC2TLnksdySsGeMQiAtTCB8G7gRBBZsFRAWPB/4MchHIEZkMFQR+/JL3svIE62/hEdmW0xnRPNLi1oXcTeDu4ijm4+u/8rP1IvKf6orlSuQR5LjjV+MN43rkcOma8vb91Ai7EMkUyRctHJghTyQbIlMc8RWTEbYPXRDgEagShxMjFmsclSSvK9wv3S6VKtMlHCE6HIsUwQkP/kD0Ku8W7hrv7O8P8KLxFfW8+bz9D/7k+YPy7urz5JPfztlP02jNssk5ytfPi9e83nLl7Ovo8kn6tgCLBOQEzQGy/AP4mPaC+Ez6qvrc+yABzgr0FYwfwSZqK7gtzi4pL6sukCvQJOYbORTMD4sOAg/uDqcO+A8lE9YX+BvJHKsZSRP2CzEFaP+m+EXviOQn3OfY0NkB3Ojd+d/Y4mPmDupE7RXv4u3o6CnjIN8x3ajb2NjL1qnXcdwd5EXtb/caAaoIVw54EoEWWxm1GC8V0xC6DjsOqQ02DTEOexGXFr8cgCOAKgwwKTJ+MM4t0SsBKewhlBc/Dk8HlgGO/L35Svny+cT6TPwB/2UC3wOxANb5hfM97x/qaOKz2YXSKs40zJbMTdCZ1r7cUuG55ejrzvIe9zj3+/R+81/zbPLX8JXwB/JC9ET3xfxMBRYPIhf/HFQiwSfuK6IsuCmYJS8hfhzWF3wUuROyFIgVLhbFGB4eRyPDJFci0R4wG30VFw1fBB78NfRp7Crma+Nb5ITmaebG5YnnuesW72Xvee0i6onls9892qvWWtRU0tzPAM+d09jccebc7X70HfweBLAKWw4sD9QNtArOBlEEWgRLBjEIwgmjDd8U7R2PJXYqvC2GMGcymDF5LhMqcCSVHbAVbw46CikISQZXBFgDvARNBycJJwmzBz4F8wDv+pfzAuye5NTcU9Wb0PjPvNE61EDXZNvf4Cfmz+nu6+bs3uxU60bok+Xm5OHlaecO6ejr5fFf+hUDRQpaEHgWFhxjINIiaiMrIvUeoBrpFsUV2Rb4Fy4Y+Ri8HAAjmShnKxsriSkyJ8giqRxcFeMMpAOX+u/zkfBW74nuG+7f7vDwi/Pt9J30uPJH71nqpeRG31naPdVw0FHNDc1dz4TTh9mZ4ITnle2u8zv6AQBAA0YDaQGe/4T+sP2C/c7+zgFuBZ4KJhIJGykjTyhVK2Itpi7QLggtkimtJKUe/Ri9FAQT7hIGElMQow+cETkUMBVxE0sPUApTBaP/F/lM8qHrtuR13kbbGNtZ3HzdYN6D3wfieOW+597nmeZ05MrhQ9/a3aDdXN1D3freU+SM7Dn1jvynAv4IYg+aFOwXVhnbGPgW/RShEy8T0BOmFNAV+hfxG78hdyf1K2Quly47LdoqUid8Ivob5BNvC00EL//w+0T63PiW9xP3Zfio+tT76frG93rzje4m6Ynjnd3T14XSss75zQnQZ9MQ117bx+B+5lzsovFr9fz2XPZC9ST1z/VZ9t32WPgG+zX/YQWXDJ4TrBm/HigjCCeLKfkphSixJQAiPh6OGykahBkyGdYYpBjgGTkcIR7PHdcaSRZDEV8M4QY+ACX5qvLq7PvnqeSE46/jPeSW5AblbOZG6Anpbuf142ngNN1Y2uLXQdYJ1sLWbtg/3Mrizuqw8sP54P+SBdUKOA4hD2QOJQ2sC0cKRgoeDNwOsRHpFDQZ7B5bJboqjC1YLq8uXi7PKwMnRCFQGxcV/w4TCt8GugS/AvQAmAD2AUYD7gJ/AEn9Jfrv9e7vLuni4ibd8Nce1IzSPtM81XzXL9r03dTiYecL6t/qHet763rr4OoS6xntdO+C8T/0FfkKABkH1AyVEXYWkhuzH68hHCLcIaQgEh50G3kaLxvhG14bMRtnHUEhQyTXJNkjYyKGH5EaHhQQDmAIPAEy+d3yv+/H7uHtfex76+PrXu3f7QLtouvZ6dbm/+EL3RXafthi1onTIdJJ1AvZGd6z4hno5u7b9V/7if9/A3AGAwedBTUE1gR1BkIH0QdWCq8PEhaQG24gXiXXKZMsMC3/LBcshinHJD8f+hoaGHkVWRI8D0UNpAxUDI4LfAplCZ0HbAQwAJ/7MveU8dnqOeRc32XcLdrH2J/Yydmy26Ld+d+14sLkgOXD5LHjPuNv49Pj2ONp5BPnretg8an3Wf7pBI4KGg9QE60XFRsXHLEawRgLGOIYfhk2GXQZJhsFHiwhZySBJ70p4inXJxwltyJ/H4wZTxFlCVwDl/6F+uL2l/QS9NzzofNT9J/1uPVA8zLvF+tk55zjxN5n2SPV3NId0oHStNTr2PDdQeKW5kDslPI194v5r/qs+9H80P1j/sn+5f/HAVcEZwhPDv4UvBoZH8kihibeKUwrSCq6J60ksCEBH5ccfBp9GM0WnhU2FeIVUBY1FcgSsg85DBIIKwOT/cv3AfJq7LrnheS34n7hi+Ao4MfgUuLB4yzk4uMt4z3i0OAt3//dRt3W3Pvcmt7V4grpa+9f9Vn73QEUCMIM9w/MEZESIRIlEQsRGRI+E8cTahR+Fpca1x9VJEUnYSnfKk8rXyoEKI4kvx+DGa0SmgxvCD0FgwGg/UH7T/uC/BT9cvzb+r348/Xu8RHtNuhY4wHertgE1RTU8NQO1k7X8NlS3grjyOab6Vrs6+4i8HHwB/Gq8tX0Vfan9xj6Sv5mAyMI3AwMEpEXexy/H70hIiO8I6siYSCaHgYeUB2iG88ZoRliG2wdYR4dHmsdJhxOGfsU1A9gCl0Evf2D9/TyK/DP7Uvr/+ju52XoLOk76e3olOh55+3kqeER337d+tuD2VDXF9c72eHcAOHA5bDrBPK29xL9jAIqB4AJXwlNCGEIfAmCCtIKfQvUDaoRPBb8GtUfZSRmJ5soIinPKcYpRic+IsQcqBhyFccR5w2oCpMI/AZkBa4EzwSSBFkCjP4B+0T4wfQM7z7oyOJh3/DcldoZ2UvZqtrq2yPd0d+m44LmEOc95kvm7+eM6SfqYOqp643ubvLL9vL73gE7Bx0Lfw4QEy0YxxuaHIsbnRqeGvUathpZGlwa1BrGG5cdfyBiI2ck/CK2INQe6BxNGUwTUwzdBYgAJPx++N71vPPP8W/wOfAR8b3xDvGJ7kPrcugJ5h/jYN+f2//Yitc71zbYndod3pbhOOXf6XHvK/Wr+YT8mP56AMwBiQI5AwoEGwV/Br4IwgzbEboWsBoWHp4hBiWqJ5EoqCeVJcgi3x9gHTsbzhjGFdQS2hBjEJUQKBB7DrcLDgluBo8Dyf8k+xz2sPCH647nI+Vq42Lhkd8E3w3gKuLv443keOR35Grk4uM64w/jMONe4+zj4OX/6Ynv5PSW+Wb+2wNSCa0NtBDBEicU5xTlFMMUWBVsFhMXTBd3GBAbfB6nIbYjzSR2JZMltCStImMf4RpwFYUPLQr+BXIC6v6R+1H5qvgT+V/5pPjo9pL04/Eb7wbsROjJ4w7fRdsi2a/YXNl/2vbbDt5V4c/lXOo57ubwwvKZ9Gn2TfgM+oD7ivy2/bj/9QI3B74L8A/kE9kX8hu+H2EisSOCIxkiVSDgHsEdbRyxGt0YhBcrF5IX3hcvF4YVSROeELYNYQpMBioBn/uO9o7yeO+s7M/pVOf55a7lGeau5t7mIObk5NrjOeOe4qnhHeBu3qbdYd6/4Pvjy+fk60vwc/X2+lAA6QRECCUKDgvcC/YMQw48D/8PtBDVETQUhxf+GhgeiSBGIo8jfyQDJW0kDyIkHpAZbxUNEqwOvQqtBlwDOAEBAFT/sP6j/bz7Pfno9pn0yfG57ano1ONN4Cve1tzi22jbxtsT3TnfIOIt5Y3nHel56iXsBu7Q71vxg/K489/1+Pi8/KwAXgTkB4oL1w93FGYYJRt6HNQc0BzzHDAd6hz1G6UasRnJGbAaqxvaGygbFRoOGeEXvRUqEmwNEggHA6j+zPpD9wP06fBO7uDsi+ys7DzsFuub6Vfocedk5pbkJuKs39Hd8NwW3RTepN/Q4cvkz+ja7S7zFPhD/Gz/5AFGBGkGxAdSCGcIAQmsChMN8Q/KEsIV4hj7GwMf5iEUJOQk6CPzIQcgHR6ZGygYYRT0EEYOJAxECtQIpQcIBvMDDALXAEP/a/wS+HLzoe8y7JXo4uT14TzgOd+43h3f5eAX44jkXOWU5nvoCepw6j3qhurK65Ptdu8H8mn1WPlV/UoB0AXLCioPMxJZFHoWWRhtGWQZshhpGKcYMBmnGToaUhuVHJwdWx72HisfZB5cHC8ZURUqEZoMigeNAmr+H/tF+Nf1TfSM8xDzVPJj8Yfwe+++7TvrVOiP5dziOuAG3tvc6dyf3ebeF+GG5N3oP+0x8cr0Kvg7+3b9G/+HAMMBnAJdA8EEGQcgCmENmxD+E5sXIBspHmogyCFbItohjSDkHu0c1Bp9GBwW7hNaEmQRbxAvD8ENMQxLCt4HGAX4AVr+K/q29X3x0u2x6gjo0+VV5NHjGOTI5G/lFOaX5rzmuebG5svmg+bb5XzlUeZ76F7ra+6a8Xf1Ofo9/9YD0QcoC74NkQ/+EGASVxOxE1wTFxPPE34VZBc3GeUalxxjHu0f1iCqIJsfdB0fGkMWSBJADgwKuQW8AZ3+s/xL+zD6KfkX+CP32/U19Dvyre9d7K3oWeXG4rLg79693U3dyd2A30PidOWM6Dzr0e2X8E3ziPU79034LflT+vn7Qf7UAKUDwQYzCh4ONxIOFjcZYxuvHFIdlx2NHdgcbRutGSsYMhePFhAWmRUMFX0UyROuEgUR0Q72CzoI5wOB/3T7xPcV9HHwXO0h68XpG+ng6Nvo5OjO6Gbo7OeB58nmauW243LiFOJw4mHjFOWQ5+jq+O6M81P45PzdAPUDZwaRCFkKiwskDGQM9AwhDukP0RG/E/0VVhiyGvccEB+VIOggDiBfHj0cvRm5Fh0TRQ/KC/UIkgaABLsCNgEFALz+av3p+yX6zfea9BzxlO1G6j7nleRy4gjhheDA4G7hx+LS5Avn++iV6jHs7e1o72fwL/Fi8ij0FPY8+NP68/1oAdkEjgiDDGQQfRNyFesWXRhmGYgZ/xghGJoXnxe2F98XJxhwGHEYRBgmGOAX0xaRFGkR9g2ACt8G5AKj/rH6bvfO9NrymvG78AHwGe8Q7mrt2ezl6zzqSOh/5uXkkeOH4iTineKU4/rkP+eD6nfuZ/LP9Qz5M/xE/8YBdwObBJoFlAakBwoJGwt4Db0P+RF7FHEXXBqNHKAdER4oHrwdoBzaGrYYSBa/E1URTQ+sDScMZwqDCNYGfQUMBBICkf/u/Db6Gfes8zvwL+2g6nHovOaz5WXlkuXq5YLmiuem6GnpC+qY6jfrF+zY7JvtuO5l8MnykPWj+Or7Wf/dAkoGjQmyDFAPJxFpEkoTQRQdFWcVXRV7FQcW1BarF48YdRn7GfAZhhnuGA0YTBZJE6gPKQzLCGgFBQLa/hL8yfkC+Ib2jfXI9MrzbPLR8Frv1+0d7Bjqxuey5T7kcuMy423jS+S/5aLnNOqB7dDwo/Pm9QT4V/qD/Er+nv+/AOkBXQNTBdIHjwo3DdAPZxIeFc0X4RkPG18bFhtjGnoZcBhCF9EVRBS1EmMReRC7D7oOIg09C3wJwwecBecCuv9B/Lb4iPXD8krwAO7o61Lqjel96bnpx+mU6ZXpsenU6czpfulH6Ubpmelf6sfrv+0W8Lzy3PVL+eP8bAClA2sGugjaCpIMvA2MDk8P+w+gEH4RqBIDFHsV1hb8FxIZ9BmDGksaOhmxF7wVZBOZEIwNlgq5B+sEaAJaALP+Nf22+yv6pvhf98713POg8TrvB+3v6uHoCOfA5Rvl0+Tw5MflO+cA6dvqruzA7uPw0/KC9Pn1n/cy+ZT6J/xD/roANAOSBSQIBAv7DcYQ7xKlFPwV9xZ8F30XPBfPFjsWZRWyFFgUERSYE9cS8REaER8QxA7eDFUKdQd3BFwBM/4V+xv4ZfUH8zXx3O8B73Du8u1p7c7sMeyj6/bqLuo66WHo3Oey5xPo8+hR6hrsW+4e8Un0uvcM+/L9aADSAgsF1gYqCCgJOApTC3wMww1XDwgRshJLFOQVnBf3GJsZhhnzGCkYBBdjFUIT7xC9Do8MUgpMCJYG9wRDA2oBu/9T/rf8r/o++PT1x/OD8Qbvwuwg693ps+jI56bnNugN6bPpWep569nsCu747hXwafG48tLzEPXc9lH52fsN/lQAEgNPBl8J4Av8DQIQiBGbEmITExSqFLsURhTSE+8TghTTFIkUIRT+E/oTfBNQEqcQoA5KDH8JhwbCAyMBRv5I+6n43fa49Yf0HvPs8SnxUfBY74Dutu3B7G/rB+oD6cfo5Ojw6Bzp7Omh6/Ttd/Ae8+T1aviu+ur8Nv9cAf4CDATvBB8GxgfLCYML+AygDqgQwBKLFBAWJReZF4sXLRewFhUW6hQPEwsRWQ8CDrQMSgvHCToIpgYYBboDNgJJANL9Eft6+EP2IPS98WzvdO0Q7FTrHOse60TrW+uH6+vroOxm7eHtHe5B7tfu1+828eHyn/Rv9pL4MPsm/jUB8ANKBlcIPAovDP4NVA8HEGsQ2RBYEd0RdBIHE2YTtRMfFLIUIRUhFW4UGBNvEaIPlQ1LC8UI6wUdA6oAkv7y/IL76PlT+OP2wfXB9KjzS/Kw8Crvye2C7Hnrs+oA6nHpT+nP6fzqguwT7sXvxPH38zH2T/gg+rD7H/2O/gAAdQHvAo8EYQY+CEQKdwy7DqYQPBKbE7UUXRWIFW0VFBV6FIUTYBJPEWgQlw+IDkcNDAzgCqQJMAiPBssExgKBABT+rft1+Rv3ufSh8u3wne+l7u3tfe1W7VLtT+1S7XztqO2x7a7t0+1A7gXv+O8Y8ZjyifTJ9iT5n/st/sAAKQNJBSIH7QiXCskLngxnDV0OQA/eD3MQNhEsEhUTxBNeFNoUAxWLFIcTRBLMEP0OxAxGCucH1gXrA/wBIQCX/j/91Pto+ir5+veA9sD06PIz8b/vV+7t7LXr6+qb6onqw+qF68TsKO5o77/whvJq9BL2YPeN+Or5Xfur/PX9ev9oAXoDgAWzByEKeQx2DiQQfhGNEkQTgBNXExYT0BJVEqIR7hBqEBsQuQ8RDzMOQg05DN4KMQlDBygF5AJvAOz9k/tg+UD3LvVz8y7yTPGy8EHw2++D7zjv1u547jHu3e2A7TXtLO197TLuW+/w8NfyC/WD9w/6e/zH/uQAswI0BIoFxQblB+kI3QnqCg8MTQ2cDvIPUxF3ElET7xNIFEIU2BP+Et8RfRDKDuMM8go1CX0H1AVIBM8ClAFsAD7/7v1a/KL61Pji9un0A/Ma8VLv3+277AvsxOvO6zHs1ey87cPuze/S8Ojx9/Lq8+H06PUD90X4wvlS+wb98v4UAXED3gU3CEsKDQyTDdQOyQ9uEL4Q2BDKELMQpxCXEJMQhRB3EFUQDhCgD+sO3g17DMkK6QjJBnoEJwLn/8D9p/u++SH44vbY9eD09/M585Dy7vEl8VTwie+i7sLtKe397B7tYe3m7ffugfBZ8ln0cfaf+L76qPxd/vD/XQGtAuID+AQYBlAHrQgtCrQLQw3ODi0QTRFLEhoTlxOEE9wS/BErEVAQIw+fDQMMjApGCSsIFwf6Bc0EagP6AYUABv9H/SD7zvio9sb0EPOD8SzwK++c7mXuYu6b7gbvfu/D7xXwmPBA8dfxUPLT8p3z0fQ19rn3c/l/+7796/8RAk4EfwZRCLgJ7AoKDPcMpQ0TDngO4Q5GD64PDRB4EOIQJRE6EQYRnBABEP8OiQ2+C88J3QfDBZ8DqQHQ/y3+vvx9+2z6a/lX+Cf3/fX49Prz5fKW8UnwQ++A7gbuq+2g7Qju1O7w7z/xuvJX9PH1cvfr+Hn6B/xe/Xj+g/++ACkCnwMlBc0Gfwg4Cs4LWw3SDg8Q7hBtEbYRyxGaER8RaxCbD8cO8Q0ODSMMUwtwCloJMAgJB8cFWgS6AuMA//4K/Rf7Hvk193319fOz8sTxLvHA8G/wOvAy8FfwffCX8Lrw7/At8YHxA/LK8snz8/RT9vL35/n6+wr++v/ZAcQDkQUiB1oIaAldCh8LvwteDBgN3w1zDuAOZQ/0D38QwRCbEEEQvg/8DtsNbAzgCi0JSAdbBYwD9QF4AAT/tP2I/Ij7f/pV+RX44fav9U30yfJz8WvwjO/S7mHuWe6i7jPv7O/p8DPyh/Ot9NX1LveY+OL57/rv+wf9Uv6a/+oAawImBPkFqwdaCRYLwAwTDv4OkA/wDy4QGhCtDyQPqQ4iDogN+QyHDCAMiAusCqYJrQiRBx4GVARYAmMAgf6X/KT62vhQ9/H1u/TS80DzzfJk8gDyqvF18Trx5/CP8GHw';
 
 /**
@@ -31,12 +40,62 @@ const DING_URL = 'data:audio/wav;base64,UklGRmhWAABXQVZFZm10IBAAAAABAAEAIlYAAESs
  * Returns: { status, entries, error, finalized, audioLevel, silenceWarning,
  *            startRecording, pauseRecording, resumeRecording, finishRecording }
  */
+
+// If Nabla emits a partial without a stable id, derive one from its start
+// offset so re-emitted partials of the same utterance dedupe instead of
+// stacking up as separate rows. start_offset_ms is stable across updates of
+// the same partial (only end_offset grows), so it's the right key. No data
+// is dropped.
+function normalizeEntry(item) {
+  if (item && item.item_id) return item;
+  return {
+    ...item,
+    item_id: `__noid_${(item && item.start_offset_ms) || 0}`,
+  };
+}
+
+// Keep transcript entries chronological so out-of-order arrivals (backfilled
+// finals, replay during reconnect) slot into their correct position rather
+// than landing at the bottom.
+function sortEntries(items) {
+  return [...items].sort((a, b) => {
+    const aMs = a.start_offset_ms || 0;
+    const bMs = b.start_offset_ms || 0;
+    if (aMs !== bMs) return aMs - bMs;
+    return (a.item_id || '').localeCompare(b.item_id || '');
+  });
+}
+
+// A partial entry is "stuck" when at least one final entry has a later
+// start_offset_ms — Nabla has moved on past this segment without ever
+// finalizing it, so the row stays partial forever and accumulates text
+// from later speaker turns under a "Listening" label. Promote those to
+// final so they render with whatever speaker they have (or Unspecified)
+// instead of staying in the listening intermediate state.
+function promoteStalePartials(items) {
+  let latestFinalMs = -Infinity;
+  for (const e of items) {
+    if (e.is_final) {
+      const ms = e.start_offset_ms || 0;
+      if (ms > latestFinalMs) latestFinalMs = ms;
+    }
+  }
+  if (latestFinalMs === -Infinity) return items;
+  return items.map(e =>
+    !e.is_final && (e.start_offset_ms || 0) < latestFinalMs
+      ? { ...e, is_final: true }
+      : e,
+  );
+}
+
 export function useRecording(noteId, initialTranscript) {
   const [status, setStatus] = useState(() => {
     if (initialTranscript?.started && !initialTranscript.finalized) return 'paused';
     return 'idle';
   });
-  const [entries, setEntries] = useState(() => initialTranscript?.items ?? []);
+  const [entries, setEntries] = useState(
+    () => promoteStalePartials(sortEntries((initialTranscript?.items ?? []).map(normalizeEntry))),
+  );
   const [error, setError] = useState(null);
   const [finalized, setFinalized] = useState(() => initialTranscript?.finalized ?? false);
   const [audioLevel, setAudioLevel] = useState(0);
@@ -58,19 +117,115 @@ export function useRecording(noteId, initialTranscript) {
   const entriesRef = useRef(entries);
   entriesRef.current = entries;
 
+  // Nabla restarts start_offset_ms from 0 on every (re)connection, so a fresh
+  // post-resume partial would interleave into the middle of pre-pause content
+  // when sorted chronologically. We add a per-session base — recalculated at
+  // connect time from the current entries' max end offset — so the displayed
+  // offsets stay monotonically increasing across pause/resume cycles. New ids
+  // synthesized via normalizeEntry inherit the session-shifted start so they
+  // remain distinct between sessions.
+  const sessionOffsetMsRef = useRef(0);
+
   const handleTranscriptItem = useCallback((item) => {
+    const adjusted = {
+      ...item,
+      start_offset_ms: (item.start_offset_ms || 0) + sessionOffsetMsRef.current,
+      end_offset_ms: (item.end_offset_ms || 0) + sessionOffsetMsRef.current,
+    };
+    const normalized = normalizeEntry(adjusted);
     setEntries(prev => {
-      const idx = prev.findIndex(e => e.item_id && e.item_id === item.item_id);
-      if (idx !== -1) {
-        const updated = [...prev];
-        updated[idx] = item;
-        return updated;
-      }
-      return [...prev, item];
+      const idx = prev.findIndex(e => e.item_id === normalized.item_id);
+      const next = idx !== -1
+        ? prev.map((e, i) => (i === idx ? normalized : e))
+        : [...prev, normalized];
+      return promoteStalePartials(sortEntries(next));
     });
   }, []);
 
+  // Promote any in-flight partial entries to final. Used on pause, finish, and
+  // reconnect — once the live audio path stops, partial-with-unspecified-speaker
+  // rows must not keep rendering as "Listening". The transcript content itself
+  // is preserved; only the is_final flag flips. The ref is updated inline so a
+  // save call immediately after this helper sees the finalized snapshot.
+  const finalizePartials = useCallback(() => {
+    const finalized = entriesRef.current.map(e => e.is_final ? e : { ...e, is_final: true });
+    entriesRef.current = finalized;
+    setEntries(finalized);
+  }, []);
+
+  // Keep the WebSocket open briefly after the user pauses or finishes so Nabla
+  // can push final speaker assignments for utterances that were still being
+  // resolved when the audio stopped. Returns as soon as every entry is final
+  // with an attributed speaker, or after maxMs — whichever comes first. Hard
+  // timeout ensures the user is never blocked indefinitely.
+  //
+  // The "attributed" check mirrors the UI logic in summary.js:TranscriptEntry
+  // exactly — only Provider/Doctor or Patient values count. Anything else
+  // (UNSPECIFIED, empty, OTHER, UNKNOWN, ...) renders as "Unspecified" in the
+  // SOAP body, so we must keep waiting.
+  //
+  // A SPEAKER_WAIT audit event is emitted at the end of every wait so we can
+  // tune FINISH_WAIT_MS / PAUSE_WAIT_MS empirically from real sessions.
+  const waitForSpeakerAttribution = useCallback(async (maxMs, reason) => {
+    const isResolved = (e) => {
+      if (!e.is_final) return false;
+      const s = (e.speaker || '').toUpperCase();
+      const isProvider = s === 'DOCTOR' || s.includes('PROVIDER') || s.includes('DOCTOR');
+      const isPatient = s === 'PATIENT' || s.includes('PATIENT');
+      return isProvider || isPatient;
+    };
+    const countUnresolved = (entries) => entries.filter((e) => !isResolved(e)).length;
+    const startedAt = Date.now();
+    const initialUnresolved = countUnresolved(entriesRef.current);
+    let resolution = 'timeout';
+    while (Date.now() - startedAt < maxMs) {
+      if (entriesRef.current.every(isResolved)) {
+        resolution = 'completed';
+        break;
+      }
+      await new Promise((r) => setTimeout(r, SPEAKER_POLL_INTERVAL_MS));
+    }
+    logEvent('SPEAKER_WAIT', {
+      reason,
+      resolution,
+      elapsed_ms: Date.now() - startedAt,
+      max_ms: maxMs,
+      entries_total: entriesRef.current.length,
+      initial_unresolved: initialUnresolved,
+      final_unresolved: countUnresolved(entriesRef.current),
+    });
+  }, []);
+
+  // Stop the mic + audio context + worklet without touching the WebSocket.
+  // Lets Nabla finish processing buffered audio while we wait for trailing
+  // speaker-attribution updates.
+  const stopAudioCapture = useCallback(() => {
+    cleanupAudio(audioCtxRef, streamRef, workletNodeRef);
+    setAudioLevel(0);
+    setSilenceWarning(false);
+    if (silenceTimerRef.current) {
+      clearInterval(silenceTimerRef.current);
+      silenceTimerRef.current = null;
+    }
+  }, []);
+
+  // Tell Nabla "no more audio coming" so it drains the buffer, sends END, and
+  // pushes any trailing TRANSCRIPT_ITEM updates with final speaker tags. We
+  // do not await — the outer wait + force-close enforce our own timeout.
+  const signalEndOfStream = useCallback(() => {
+    if (clientRef.current) {
+      clientRef.current.end().catch(() => {});
+    }
+  }, []);
+
   const connectAndRecord = useCallback(async () => {
+    // Capture the session base offset before any new transcript items arrive.
+    // First start: entries is empty → 0. Resume: max end_offset of what's
+    // already there, so new offsets continue monotonically from that point.
+    sessionOffsetMsRef.current = entriesRef.current.reduce(
+      (max, e) => Math.max(max, e.end_offset_ms || e.start_offset_ms || 0),
+      0,
+    );
     let config;
     try {
       const res = await fetch(`${API_BASE}/config`, { cache: 'no-store' });
@@ -113,7 +268,7 @@ export function useRecording(noteId, initialTranscript) {
         // Promote non-final (partial) entries to final — they'll never be
         // finalized through the normal flow since the old WebSocket session
         // is gone, and the ACK'd audio that produced them won't be replayed.
-        setEntries(prev => prev.map(e => e.is_final ? e : { ...e, is_final: true }));
+        finalizePartials();
       };
       await client.connect();
     } catch (err) {
@@ -241,9 +396,26 @@ export function useRecording(noteId, initialTranscript) {
 
   const pauseRecording = useCallback(async () => {
     setStatus('paused');
-    await disconnectAll();
+    // Stop sending audio + tell Nabla we're done so it flushes any trailing
+    // speaker-attribution updates over the still-open WebSocket. Then poll
+    // the entries until everything resolves or PAUSE_WAIT_MS elapses. If
+    // the user hits Resume during the wait, abort — resumeRecording has
+    // already kicked off a new connection and we must not tear it down.
+    stopAudioCapture();
+    signalEndOfStream();
+    await waitForSpeakerAttribution(PAUSE_WAIT_MS, 'pause');
+    if (statusRef.current !== 'paused') return;
+    await disconnectAll({ force: true });
+    finalizePartials();
     await saveTranscriptToCache();
-  }, [disconnectAll, saveTranscriptToCache]);
+  }, [
+    disconnectAll,
+    finalizePartials,
+    saveTranscriptToCache,
+    signalEndOfStream,
+    stopAudioCapture,
+    waitForSpeakerAttribution,
+  ]);
 
   const resumeRecording = useCallback(async () => {
     setError(null);
@@ -262,7 +434,17 @@ export function useRecording(noteId, initialTranscript) {
 
   const finishRecording = useCallback(async () => {
     setStatus('finishing');
+    // Stop sending audio + tell Nabla we're done so it flushes trailing
+    // speaker-attribution updates. Hold the WebSocket open through the wait
+    // — the longer FINISH_WAIT_MS reflects that speaker accuracy matters
+    // most here because the transcript is about to be sent to the LLM.
+    // finalizePartials() below is the safety net for anything that doesn't
+    // resolve within the timeout.
+    stopAudioCapture();
+    signalEndOfStream();
+    await waitForSpeakerAttribution(FINISH_WAIT_MS, 'finish');
     await disconnectAll({ force: true });
+    finalizePartials();
     // Save transcript with finalized flag.
     if (noteId && entriesRef.current.length > 0) {
       try {
@@ -281,7 +463,14 @@ export function useRecording(noteId, initialTranscript) {
     }
     setFinalized(true);
     setStatus('idle');
-  }, [noteId, disconnectAll]);
+  }, [
+    noteId,
+    disconnectAll,
+    finalizePartials,
+    signalEndOfStream,
+    stopAudioCapture,
+    waitForSpeakerAttribution,
+  ]);
 
   // Load cached transcript on mount — skip if initial data was provided server-side.
   useEffect(() => {
@@ -296,7 +485,7 @@ export function useRecording(noteId, initialTranscript) {
         }
         const data = await res.json();
         if (!cancelled && data.items && data.items.length > 0) {
-          setEntries(data.items);
+          setEntries(promoteStalePartials(sortEntries(data.items.map(normalizeEntry))));
         }
         if (!cancelled && data.started && !data.finalized) {
           setStatus('paused');

--- a/hyperscribe/scribe/static/styles.css
+++ b/hyperscribe/scribe/static/styles.css
@@ -388,6 +388,36 @@ h2 { margin-bottom: 4px; }
   background: #fff;
 }
 
+/* Read-only / locked state: subtle desaturation + dim. The actual disabling of
+   inputs is handled by row-level `readOnly` props; this class only sets the
+   visual cue. */
+.summary-container--readonly .summary-body,
+.summary-container--readonly .transcript-panel,
+.summary-container--readonly .summary-generating-banner,
+.summary-container--readonly .summary-generate-banner,
+.summary-container--readonly .verification-banner {
+  opacity: 0.65;
+  filter: saturate(0.85);
+  transition: opacity 120ms ease-out;
+}
+
+.readonly-banner {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 24px;
+  background: #f5f6f8;
+  border-bottom: 1px solid #e8e8ec;
+  color: #4b5563;
+  font-size: 13px;
+  line-height: 1.4;
+}
+
+.readonly-banner-icon {
+  flex-shrink: 0;
+  color: #6b7280;
+}
+
 .summary-header {
   display: flex;
   align-items: center;
@@ -1460,15 +1490,6 @@ h2 { margin-bottom: 4px; }
 .audit-expand { font-size: 10px; color: #999; cursor: pointer; }
 .audit-details { width: 100%; margin: 4px 0 0; padding: 8px; font-family: 'SF Mono', Monaco, monospace; font-size: 11px; background: #f5f5f8; border-radius: 4px; overflow-x: auto; white-space: pre-wrap; word-break: break-word; color: #333; }
 .audit-empty { padding: 24px; text-align: center; color: #999; font-size: 14px; }
-
-/* Signed-note blocking screen */
-.signed-note-block {
-    display: flex; flex-direction: column; align-items: center; justify-content: center;
-    padding: 60px 24px; text-align: center; min-height: 300px;
-}
-.signed-note-icon { font-size: 48px; margin-bottom: 16px; }
-.signed-note-title { font-size: 20px; font-weight: 700; color: #111; margin-bottom: 8px; }
-.signed-note-message { font-size: 15px; color: #6b7280; max-width: 480px; line-height: 1.5; }
 
 /* Task recommendation extras */
 .rec-reason {

--- a/hyperscribe/scribe/static/summary.js
+++ b/hyperscribe/scribe/static/summary.js
@@ -121,6 +121,7 @@ const SKELETON_SECTIONS = [
   { key: 'assessment_and_plan', title: 'Assessment & Plan', text: '' },
 ];
 
+const FINALIZE_LABEL = 'Finalizing transcript';
 const PROGRESS_STEPS = [
   'Generating note',
   'Structuring the note',
@@ -128,6 +129,9 @@ const PROGRESS_STEPS = [
   'Generating recommendations',
   'Suggesting diagnoses',
 ];
+// Total steps shown to the user = "Finalizing transcript" + the server-driven
+// SUMMARY_STEPS pipeline. Used for the % progress calculation.
+const TOTAL_PROGRESS_STEPS = PROGRESS_STEPS.length + 1;
 
 function buildCommandBySectionKey(commands) {
   const map = {};
@@ -199,7 +203,7 @@ function renderSoapGroups(sections, commandBySectionKey, onEditCommand, onDelete
     .filter(Boolean);
 }
 
-export function Scribe({ noteId, patientId, staffId, staffName, providerName, providerPhotoUrl, patientName, patientBirthDate, patientGender, debugMode, noteEditable = true, alertFacilityEnabled = false, initialData = null }) {
+export function Scribe({ noteId, patientId, staffId, staffName, providerName, providerPhotoUrl, patientName, patientBirthDate, patientGender, debugMode, noteEditable = true, isAuthor = false, alertFacilityEnabled = false, initialData = null }) {
   const initSummary = initialData?.summary ?? null;
   const [noteData, setNoteData] = useState(initSummary?.note ?? null);
   const [generating, setGenerating] = useState(false);
@@ -233,6 +237,13 @@ export function Scribe({ noteId, patientId, staffId, staffName, providerName, pr
     return cached;
   });
   const [transcriptCollapsed, setTranscriptCollapsed] = useState(false);
+  // Auto-scroll the transcript body to the latest entry whenever live capture
+  // is producing or refining content. We deliberately don't try to "respect"
+  // a user's scroll-up while recording — clinicians want to keep seeing the
+  // running transcription as proof the capture is working, and the scroll
+  // would just keep losing fights with new entries anyway. Once the session
+  // is finalized, entries stop changing and the user can scroll freely.
+  const transcriptBodyRef = useRef(null);
   const [cachedTemplateName, setCachedTemplateName] = useState(initSummary?.selected_template_name ?? null);
   const cacheLoadedRef = useRef(!!initialData);
   const addNowAttemptedRef = useRef([]);
@@ -241,6 +252,24 @@ export function Scribe({ noteId, patientId, staffId, staffName, providerName, pr
 
   // Recording hook.
   const recording = useRecording(noteId, initialData?.transcript);
+
+  // Keep the transcript pinned to the latest entry as new ones stream in or
+  // get refined (in-place partial updates, speaker-attribution flips, etc.).
+  // RAF defers the scroll until after layout so scrollHeight reflects the
+  // post-update height. Skipped once the recording is finalized so we don't
+  // yank a user reading the saved transcript on later mounts.
+  useEffect(() => {
+    if (transcriptCollapsed) return;
+    if (recording.finalized) return;
+    const el = transcriptBodyRef.current;
+    if (!el) return;
+    const rafId = requestAnimationFrame(() => {
+      const node = transcriptBodyRef.current;
+      if (!node) return;
+      node.scrollTo({ top: node.scrollHeight, behavior: 'smooth' });
+    });
+    return () => cancelAnimationFrame(rafId);
+  }, [recording.entries, transcriptCollapsed, recording.finalized]);
 
   const [showSavedToast, setShowSavedToast] = useState(false);
   useEffect(() => {
@@ -266,6 +295,11 @@ export function Scribe({ noteId, patientId, staffId, staffName, providerName, pr
   }, [noteId]);
 
   const noteLocked = !isNoteEditable && !approved;
+  const canEdit = isAuthor && isNoteEditable && !approved;
+  // Lock takes precedence over authorship in the banner messaging.
+  const readOnlyReason = noteLocked
+    ? 'locked'
+    : (!isAuthor && !approved ? 'non_author' : null);
 
   const saveSummaryToCache = useCallback(async (note, cmds, isApproved, extras = {}) => {
     try {
@@ -540,6 +574,7 @@ export function Scribe({ noteId, patientId, staffId, staffName, providerName, pr
 
 
   const handleSelectTemplate = useCallback((e) => {
+    if (!canEdit) return;
     const templateName = e.target.value;
     if (!templateName) {
       logEvent('DESELECT_TEMPLATE');
@@ -617,9 +652,10 @@ export function Scribe({ noteId, patientId, staffId, staffName, providerName, pr
       });
       return updated;
     });
-  }, [templates, noteData, approved, recommendations, unmatchedConditions, diagnosisSuggestions, saveSummaryToCache]);
+  }, [templates, noteData, approved, canEdit, recommendations, unmatchedConditions, diagnosisSuggestions, saveSummaryToCache]);
 
   const handleStartAI = useCallback(async () => {
+    if (!canEdit) return;
     logEvent('START_AI');
     setMode('ai');
     const ok = await recording.startRecording();
@@ -627,9 +663,10 @@ export function Scribe({ noteId, patientId, staffId, staffName, providerName, pr
       logEvent('START_AI_FAILED');
       setMode(null);
     }
-  }, [recording]);
+  }, [recording, canEdit]);
 
   const handleStartManual = useCallback(() => {
+    if (!canEdit) return;
     logEvent('START_MANUAL');
     setMode('manual');
     // Pre-populate empty commands for all narrative sections so they render as editable text areas.
@@ -654,7 +691,7 @@ export function Scribe({ noteId, patientId, staffId, staffName, providerName, pr
       });
       return [...manualCommands, ...existing];
     });
-  }, [selectedTemplate]);
+  }, [selectedTemplate, canEdit]);
 
 
   // Compute unmatched conditions when loading from old cache format (no unmatched_conditions key).
@@ -681,7 +718,7 @@ export function Scribe({ noteId, patientId, staffId, staffName, providerName, pr
 
   const handleEdit = useCallback((index, newData, newType) => {
     logEvent('EDIT_COMMAND', { index, commandType: newType || commands[index]?.command_type, sectionKey: commands[index]?.section_key, data: newData });
-    if (approved) return;
+    if (!canEdit) return;
     setCommands(prev => {
       const updated = prev.map((cmd, i) => {
         if (i !== index) return cmd;
@@ -795,21 +832,21 @@ export function Scribe({ noteId, patientId, staffId, staffName, providerName, pr
       saveSummaryToCache(noteData, updated, false, { recommendations, unmatched_conditions: unmatchedConditions, diagnosis_suggestions: diagnosisSuggestions });
       return updated;
     });
-  }, [approved, noteData, saveSummaryToCache, recommendations, unmatchedConditions, diagnosisSuggestions]);
+  }, [canEdit, noteData, saveSummaryToCache, recommendations, unmatchedConditions, diagnosisSuggestions]);
 
   const handleDelete = useCallback((index) => {
     logEvent('DELETE_COMMAND', { index, commandType: commands[index]?.command_type });
-    if (approved) return;
+    if (!canEdit) return;
     setCommands(prev => {
       const updated = prev.filter((_, i) => i !== index);
       saveSummaryToCache(noteData, updated, false, { recommendations, unmatched_conditions: unmatchedConditions, diagnosis_suggestions: diagnosisSuggestions });
       return updated;
     });
-  }, [approved, noteData, saveSummaryToCache, recommendations, unmatchedConditions, diagnosisSuggestions]);
+  }, [canEdit, noteData, saveSummaryToCache, recommendations, unmatchedConditions, diagnosisSuggestions]);
 
   const handleAddTask = useCallback(() => {
     logEvent('ADD_TASK');
-    if (approved) return;
+    if (!canEdit) return;
     setCommands(prev => [...prev, {
       command_type: 'task',
       display: '',
@@ -818,11 +855,11 @@ export function Scribe({ noteId, patientId, staffId, staffName, providerName, pr
       section_key: '_ad_hoc',
       already_documented: false,
     }]);
-  }, [approved]);
+  }, [canEdit]);
 
   const handleAddOrder = useCallback(() => {
     logEvent('ADD_ORDER');
-    if (approved) return;
+    if (!canEdit) return;
     setCommands(prev => [...prev, {
       command_type: 'prescribe',
       display: '',
@@ -831,11 +868,11 @@ export function Scribe({ noteId, patientId, staffId, staffName, providerName, pr
       section_key: '_ad_hoc',
       already_documented: false,
     }]);
-  }, [approved]);
+  }, [canEdit]);
 
   const handleAddPlan = useCallback(() => {
     logEvent('ADD_PLAN');
-    if (approved) return;
+    if (!canEdit) return;
     setCommands(prev => [...prev, {
       command_type: 'plan',
       display: '',
@@ -844,11 +881,11 @@ export function Scribe({ noteId, patientId, staffId, staffName, providerName, pr
       section_key: '_ad_hoc',
       already_documented: false,
     }]);
-  }, [approved]);
+  }, [canEdit]);
 
   const handleAddHistory = useCallback((commandType) => {
     logEvent('ADD_HISTORY', { type: commandType });
-    if (approved) return;
+    if (!canEdit) return;
     setCommands(prev => [...prev, {
       command_type: commandType,
       display: '',
@@ -857,11 +894,11 @@ export function Scribe({ noteId, patientId, staffId, staffName, providerName, pr
       section_key: '_history_ad_hoc',
       already_documented: false,
     }]);
-  }, [approved]);
+  }, [canEdit]);
 
   const handleAddMedication = useCallback(() => {
     logEvent('ADD_MEDICATION');
-    if (approved) return;
+    if (!canEdit) return;
     setCommands(prev => [...prev, {
       command_type: 'medication_statement',
       display: '',
@@ -870,11 +907,11 @@ export function Scribe({ noteId, patientId, staffId, staffName, providerName, pr
       section_key: '_objective_ad_hoc',
       already_documented: false,
     }]);
-  }, [approved]);
+  }, [canEdit]);
 
   const handleAddVitals = useCallback(() => {
     logEvent('ADD_VITALS');
-    if (approved) return;
+    if (!canEdit) return;
     setCommands(prev => [...prev, {
       command_type: 'vitals',
       display: '',
@@ -883,9 +920,10 @@ export function Scribe({ noteId, patientId, staffId, staffName, providerName, pr
       section_key: '_objective_ad_hoc',
       already_documented: false,
     }]);
-  }, [approved]);
+  }, [canEdit]);
 
   const handleEditRecommendation = useCallback((index, newData, newType) => {
+    if (!canEdit) return;
     logEvent('EDIT_REC', { index, commandType: newType, data: newData });
     setRecommendations(prev => prev.map((cmd, i) => {
       if (i !== index) return cmd;
@@ -905,26 +943,29 @@ export function Scribe({ noteId, patientId, staffId, staffName, providerName, pr
       }
       return { ...cmd, data: newData, accepted: true };
     }));
-  }, []);
+  }, [canEdit]);
 
   const handleAcceptRecommendation = useCallback((index) => {
+    if (!canEdit) return;
     logEvent('ACCEPT_REC', { index });
     setRecommendations(prev => prev.map((cmd, i) =>
       i === index ? { ...cmd, accepted: true, rejected: false } : cmd
     ));
-  }, []);
+  }, [canEdit]);
 
   const handleRejectRecommendation = useCallback((index) => {
+    if (!canEdit) return;
     logEvent('REJECT_REC', { index });
     setRecommendations(prev => prev.map((cmd, i) =>
       i === index ? { ...cmd, rejected: true, accepted: false } : cmd
     ));
-  }, []);
+  }, [canEdit]);
 
   const handleDeleteRecommendation = useCallback((index) => {
+    if (!canEdit) return;
     logEvent('DELETE_REC', { index });
     setRecommendations(prev => prev.filter((_, i) => i !== index));
-  }, []);
+  }, [canEdit]);
 
   const handleEditingChange = useCallback((key, isEditing) => {
     setEditingFields(prev => {
@@ -937,7 +978,7 @@ export function Scribe({ noteId, patientId, staffId, staffName, providerName, pr
 
   const handleAddAllergy = useCallback(() => {
     logEvent('ADD_ALLERGY');
-    if (approved) return;
+    if (!canEdit) return;
     setCommands(prev => [...prev, {
       command_type: 'allergy',
       display: '',
@@ -946,11 +987,11 @@ export function Scribe({ noteId, patientId, staffId, staffName, providerName, pr
       section_key: '_objective_ad_hoc',
       already_documented: false,
     }]);
-  }, [approved]);
+  }, [canEdit]);
 
   const handleAddStopMedication = useCallback(() => {
     logEvent('ADD_STOP_MED');
-    if (approved) return;
+    if (!canEdit) return;
     setCommands(prev => [...prev, {
       command_type: 'stop_medication',
       display: '',
@@ -959,11 +1000,11 @@ export function Scribe({ noteId, patientId, staffId, staffName, providerName, pr
       section_key: '_objective_ad_hoc',
       already_documented: false,
     }]);
-  }, [approved]);
+  }, [canEdit]);
 
   const handleAddRemoveAllergy = useCallback(() => {
     logEvent('ADD_REMOVE_ALLERGY');
-    if (approved) return;
+    if (!canEdit) return;
     setCommands(prev => [...prev, {
       command_type: 'remove_allergy',
       display: '',
@@ -972,11 +1013,11 @@ export function Scribe({ noteId, patientId, staffId, staffName, providerName, pr
       section_key: '_objective_ad_hoc',
       already_documented: false,
     }]);
-  }, [approved]);
+  }, [canEdit]);
 
   const handleAddResolveCondition = useCallback(() => {
     logEvent('ADD_RESOLVE_CONDITION');
-    if (approved) return;
+    if (!canEdit) return;
     setCommands(prev => [...prev, {
       command_type: 'resolve_condition',
       display: '',
@@ -985,11 +1026,11 @@ export function Scribe({ noteId, patientId, staffId, staffName, providerName, pr
       section_key: '_ad_hoc',
       already_documented: false,
     }]);
-  }, [approved]);
+  }, [canEdit]);
 
   const handleAddQuestionnaire = useCallback(() => {
     logEvent('ADD_QUESTIONNAIRE');
-    if (approved) return;
+    if (!canEdit) return;
     setCommands(prev => [...prev, {
       command_type: 'questionnaire',
       display: '',
@@ -998,11 +1039,11 @@ export function Scribe({ noteId, patientId, staffId, staffName, providerName, pr
       section_key: '_subjective_ad_hoc',
       already_documented: false,
     }]);
-  }, [approved]);
+  }, [canEdit]);
 
   const handleAddCharge = useCallback(() => {
     logEvent('ADD_CHARGE');
-    if (approved) return;
+    if (!canEdit) return;
     setCommands(prev => [...prev, {
       command_type: 'perform',
       display: '',
@@ -1011,11 +1052,11 @@ export function Scribe({ noteId, patientId, staffId, staffName, providerName, pr
       section_key: '_charges_ad_hoc',
       already_documented: false,
     }]);
-  }, [approved]);
+  }, [canEdit]);
 
   const handleAddTemplateCharge = useCallback((cptCode, description) => {
     logEvent('ADD_TEMPLATE_CHARGE', { cptCode, description });
-    if (approved) return;
+    if (!canEdit) return;
     setCommands(prev => {
       // Re-select if already exists but deselected.
       const existing = prev.find(c => c.command_type === 'perform' && c.data.cpt_code === cptCode);
@@ -1035,21 +1076,21 @@ export function Scribe({ noteId, patientId, staffId, staffName, providerName, pr
         already_documented: false,
       }];
     });
-  }, [approved]);
+  }, [canEdit]);
 
   const handleRemoveChargeByCpt = useCallback((cptCode) => {
     logEvent('REMOVE_CHARGE', { cptCode });
-    if (approved) return;
+    if (!canEdit) return;
     setCommands(prev => prev.map(c =>
       c.command_type === 'perform' && c.data.cpt_code === cptCode
         ? { ...c, selected: false }
         : c
     ));
-  }, [approved]);
+  }, [canEdit]);
 
   const handleAddCondition = useCallback((icd10Code, icd10Display, conditionId) => {
     logEvent('ADD_CONDITION', { icd10Code, display: icd10Display });
-    if (approved) return;
+    if (!canEdit) return;
     const apKey = commands.find(c =>
       (c.command_type === 'diagnose' || c.command_type === 'assess') && ['assessment_and_plan', 'plan'].includes(c.section_key)
     )?.section_key || 'assessment_and_plan';
@@ -1092,10 +1133,10 @@ export function Scribe({ noteId, patientId, staffId, staffName, providerName, pr
     if (icd10Code) {
       setUnmatchedConditions(prev => prev.filter(c => !(c.coding || []).some(cd => cd.code === icd10Code)));
     }
-  }, [approved, commands]);
+  }, [canEdit, commands]);
 
   const handleInsert = useCallback(async () => {
-    if (approved || inserting) return;
+    if (!canEdit || inserting) return;
     setValidationError(null);
     logEvent('APPROVE_START', { totalCommands: commands.length, commandTypes: commands.map(c => c.command_type) });
     setInserting(true);
@@ -1191,7 +1232,7 @@ export function Scribe({ noteId, patientId, staffId, staffName, providerName, pr
             await fetch(`${API_BASE}/insert-metadata`, {
               method: 'POST',
               headers: { 'Content-Type': 'application/json' },
-              body: JSON.stringify({ pending: data.metadata_pending }),
+              body: JSON.stringify({ note_uuid: noteId, pending: data.metadata_pending }),
             });
           } catch (metaErr) {
             console.error('Failed to insert metadata:', metaErr);
@@ -1266,9 +1307,10 @@ export function Scribe({ noteId, patientId, staffId, staffName, providerName, pr
     } finally {
       setInserting(false);
     }
-  }, [commands, recommendations, noteId, noteData, saveSummaryToCache, unmatchedConditions, diagnosisSuggestions, approved, inserting]);
+  }, [commands, recommendations, noteId, noteData, saveSummaryToCache, unmatchedConditions, diagnosisSuggestions, canEdit, inserting]);
 
   const handleAddNow = useCallback(async (command, isRecommendation, index) => {
+    if (!canEdit) return;
     logEvent('ADD_NOW', { commandType: command.command_type, isRecommendation, index });
     // Mark as adding to show spinner and prevent double-clicks.
     const setAdding = (flag) => {
@@ -1294,7 +1336,7 @@ export function Scribe({ noteId, patientId, staffId, staffName, providerName, pr
           await fetch(`${API_BASE}/insert-metadata`, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ pending: data.metadata_pending }),
+            body: JSON.stringify({ note_uuid: noteId, pending: data.metadata_pending }),
           });
         } catch (metaErr) { console.error('Add Now metadata failed:', metaErr); }
       }
@@ -1318,7 +1360,7 @@ export function Scribe({ noteId, patientId, staffId, staffName, providerName, pr
       setAdding(false);
       logEvent('ADD_NOW_ERROR', { commandType: command.command_type, index });
     }
-  }, [noteId]);
+  }, [noteId, canEdit]);
 
 
   const commandBySectionKey = buildCommandBySectionKey(commands);
@@ -1346,7 +1388,14 @@ export function Scribe({ noteId, patientId, staffId, staffName, providerName, pr
   const RX_TYPES = new Set(['prescribe', 'refill', 'adjust_prescription']);
   const hasRxCommands = commands.some(c => c.display && RX_TYPES.has(c.command_type))
     || recommendations.some(c => c.display && !c.rejected && RX_TYPES.has(c.command_type));
-  const showFooter = !approved && (mode === 'manual' || insertableCount > 0);
+  // Accept and Sign is only offered once the user has committed to a flow
+  // and reached its natural completion point. Manual mode shows it as soon
+  // as the user opts in (so they can sign with empty / template-only fields
+  // if that's what they want). AI mode requires recording to be finalized
+  // AND the note to have been generated — we don't want a half-finished
+  // transcript or an in-flight LLM call to be signable.
+  const aiFlowComplete = mode === 'ai' && recording.finalized && noteData !== null;
+  const showFooter = canEdit && (mode === 'manual' || aiFlowComplete);
 
   const INCOMPLETE_LABELS = { diagnose: 'diagnose', imaging_order: 'imaging order', prescribe: 'prescription', refer: 'referral', lab_order: 'lab order' };
   const _isRxIncomplete = (d) => !d.fdb_code || !d.sig || d.quantity_to_dispense == null || !d.type_to_dispense || d.refills == null;
@@ -1428,25 +1477,51 @@ export function Scribe({ noteId, patientId, staffId, staffName, providerName, pr
     return missing.length > 0 ? [...base, ...missing] : base;
   })();
   const isRecording = recording.status === 'recording' || recording.status === 'paused';
-  const showTopControls = !approved && !noteData && !isRecording && !recording.finalized && !generating && mode === null;
+  // Suppress "Recording in progress" / "Paused" labels (and the recording dot)
+  // once a note has been generated or the transcript was finalized — at that
+  // point the transcript is a static record, not a live capture.
+  const transcriptHeaderIsLive = isRecording && !noteData && !recording.finalized;
+  const showTopControls = canEdit && !noteData && !isRecording && !recording.finalized && !generating && mode === null;
 
-  if (noteLocked) {
-    return html`
-      <div class="summary-container">
-        <div class="signed-note-block">
-          <div class="signed-note-icon">${'\uD83D\uDD12'}</div>
-          <h2 class="signed-note-title">Note Locked</h2>
-          <p class="signed-note-message">
-            This note is no longer editable. To make changes, please amend the note first.
-          </p>
-        </div>
-      </div>
-    `;
+  // Unified progress display: "Finalizing transcript" is step 0 of a sequence
+  // that continues through the server-driven generate pipeline. Showing one
+  // bar that ticks across all 6 steps gives the user a clear sense of motion
+  // during the speaker-attribution wait + LLM run rather than a long stretch
+  // of dead "Finalizing..." text followed by a separate progress bar.
+  const isFinalizing = recording.status === 'finishing';
+  const isInGenerationPipeline = generating || (recording.finalized && mode === 'ai' && !noteData);
+  const showProgressBanner = isFinalizing || isInGenerationPipeline;
+  let progressIndex = 0;
+  let progressLabel = FINALIZE_LABEL;
+  if (!isFinalizing && isInGenerationPipeline) {
+    const serverStep = Math.max(progress.step, 0);
+    progressIndex = serverStep + 1; // +1 because finalize occupies index 0
+    progressLabel = PROGRESS_STEPS[serverStep] || PROGRESS_STEPS[0];
   }
+  const progressPct = Math.max(((progressIndex + 1) / TOTAL_PROGRESS_STEPS) * 100, 5);
 
   return html`
-    <div class="summary-container">
-      ${!approved && html`
+    <div class=${`summary-container${!canEdit && !approved ? ' summary-container--readonly' : ''}`}>
+      ${readOnlyReason === 'locked' && html`
+        <div class="readonly-banner" role="status" aria-live="polite">
+          <svg class="readonly-banner-icon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <rect x="3" y="11" width="18" height="11" rx="2" ry="2" />
+            <path d="M7 11V7a5 5 0 0 1 10 0v4" />
+          </svg>
+          <span>This note is locked. To make changes, amend the note first.</span>
+        </div>
+      `}
+      ${readOnlyReason === 'non_author' && html`
+        <div class="readonly-banner" role="status" aria-live="polite">
+          <svg class="readonly-banner-icon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <circle cx="12" cy="12" r="10" />
+            <line x1="12" y1="8" x2="12" y2="12" />
+            <line x1="12" y1="16" x2="12.01" y2="16" />
+          </svg>
+          <span>Read-only — only the note author can edit the Scribe tab.</span>
+        </div>
+      `}
+      ${canEdit && html`
         <div class="unified-top-bar">
           ${templates.length > 0 && html`
             <select
@@ -1487,9 +1562,6 @@ export function Scribe({ noteId, patientId, staffId, staffName, providerName, pr
               <${FinishRecordingButton} onFinish=${recording.finishRecording} />
             </div>
           `}
-          ${recording.status === 'finishing' && html`
-            <span class="generating-label">Finalizing transcript...</span>
-          `}
           ${false && debugMode && noteData && !approved && !generating && !isRecording && html`
             <button class="regenerate-btn" onClick=${handleGenerate} disabled=${!selectedTemplate}>
               Regenerate${!selectedTemplate ? ' (select visit type)' : ''}
@@ -1499,9 +1571,9 @@ export function Scribe({ noteId, patientId, staffId, staffName, providerName, pr
       `}
       ${(isRecording || recording.entries.length > 0) && html`
         <div class="transcript-panel">
-          <button class="transcript-panel-header ${isRecording ? '' : 'finalized'}" onClick=${() => setTranscriptCollapsed(prev => !prev)}>
-            <div class="transcript-panel-status ${isRecording ? '' : 'finalized'}">
-              ${isRecording && recording.status === 'recording' && html`
+          <button class="transcript-panel-header ${transcriptHeaderIsLive ? '' : 'finalized'}" onClick=${() => setTranscriptCollapsed(prev => !prev)}>
+            <div class="transcript-panel-status ${transcriptHeaderIsLive ? '' : 'finalized'}">
+              ${transcriptHeaderIsLive && recording.status === 'recording' && html`
                 <span class="recording-dot recording-dot-live"
                   style=${{
                     transform: `scale(${1 + Math.min(recording.audioLevel * 8, 1)})`,
@@ -1509,17 +1581,17 @@ export function Scribe({ noteId, patientId, staffId, staffName, providerName, pr
                   }}
                 ></span>
               `}
-              ${isRecording && recording.status === 'paused' && html`<span class="recording-dot recording-dot-paused"></span>`}
-              <span>${isRecording
+              ${transcriptHeaderIsLive && recording.status === 'paused' && html`<span class="recording-dot recording-dot-paused"></span>`}
+              <span>${transcriptHeaderIsLive
                 ? (recording.status === 'paused' ? 'Paused' : 'Recording in progress')
                 : 'Transcript'}</span>
-              ${!isRecording && html`<span class="transcript-entry-count">(${recording.entries.filter(e => e.is_final).length})</span>`}
+              ${!transcriptHeaderIsLive && html`<span class="transcript-entry-count">(${recording.entries.filter(e => e.is_final).length})</span>`}
             </div>
             <span class="transcript-panel-toggle">${transcriptCollapsed ? 'Show' : 'Hide'}</span>
           </button>
           ${showSavedToast && html`<div class="transcript-saved-toast">Transcript saved</div>`}
           ${!transcriptCollapsed && html`
-            <div class="transcript-panel-body">
+            <div class="transcript-panel-body" ref=${transcriptBodyRef}>
               ${recording.entries.length > 0
                 ? html`
                   <div class="transcript-list">
@@ -1581,20 +1653,20 @@ export function Scribe({ noteId, patientId, staffId, staffName, providerName, pr
         </div>
       `}
       ${recording.error && html`<p class="error" style="padding: 0 16px;">${recording.error}</p>`}
-      ${generating && html`
+      ${showProgressBanner && html`
         <div class="summary-generating-banner">
-          <div class="generating-bar" style="width: ${Math.max(((progress.step + 1) / PROGRESS_STEPS.length) * 100, 5)}%" />
-          <span class="generating-label">${PROGRESS_STEPS[Math.max(progress.step, 0)] || 'Generating...'}...</span>
+          <div class="generating-bar" style="width: ${progressPct}%" />
+          <span class="generating-label">${progressLabel}...</span>
         </div>
       `}
-      ${!noteData && !generating && recording.finalized && mode === 'ai' && html`
+      ${canEdit && !noteData && !generating && recording.finalized && mode === 'ai' && html`
         <div class="summary-generate-banner">
           <p class="summary-banner-description">Recording complete. Generate a structured summary from your transcript.</p>
           <button class="generate-btn" onClick=${handleGenerate}>Generate Summary</button>
         </div>
       `}
       ${error && html`<p class="error" style="padding: 0 16px;">${error}</p>`}
-      ${!approved && recommendations.length > 0 && html`
+      ${canEdit && recommendations.length > 0 && html`
         <div class="hide-rejected-toggle">
           <label class="hide-rejected-label" onClick=${() => setHideRejected(prev => !prev)}>
             <div class="toggle-switch${hideRejected ? ' on' : ''}">
@@ -1612,22 +1684,22 @@ export function Scribe({ noteId, patientId, staffId, staffName, providerName, pr
           subjectiveAdHocCommands,
           chargeAdHocCommands,
           assignees,
-          onAddTask: approved ? null : handleAddTask,
-          onAddOrder: approved ? null : handleAddOrder,
-          onAddPlan: approved ? null : handleAddPlan,
-          onAddVitals: approved ? null : handleAddVitals,
-          onAddMedication: approved ? null : handleAddMedication,
-          onAddAllergy: approved ? null : handleAddAllergy,
-          onAddStopMedication: approved ? null : handleAddStopMedication,
-          onAddRemoveAllergy: approved ? null : handleAddRemoveAllergy,
-          onAddResolveCondition: approved ? null : handleAddResolveCondition,
-          onAddHistory: approved ? null : handleAddHistory,
-          onAddQuestionnaire: approved ? null : handleAddQuestionnaire,
-          onAddCharge: approved ? null : handleAddCharge,
-          onAddTemplateCharge: approved ? null : handleAddTemplateCharge,
-          onRemoveChargeByCpt: approved ? null : handleRemoveChargeByCpt,
+          onAddTask: canEdit ? handleAddTask : null,
+          onAddOrder: canEdit ? handleAddOrder : null,
+          onAddPlan: canEdit ? handleAddPlan : null,
+          onAddVitals: canEdit ? handleAddVitals : null,
+          onAddMedication: canEdit ? handleAddMedication : null,
+          onAddAllergy: canEdit ? handleAddAllergy : null,
+          onAddStopMedication: canEdit ? handleAddStopMedication : null,
+          onAddRemoveAllergy: canEdit ? handleAddRemoveAllergy : null,
+          onAddResolveCondition: canEdit ? handleAddResolveCondition : null,
+          onAddHistory: canEdit ? handleAddHistory : null,
+          onAddQuestionnaire: canEdit ? handleAddQuestionnaire : null,
+          onAddCharge: canEdit ? handleAddCharge : null,
+          onAddTemplateCharge: canEdit ? handleAddTemplateCharge : null,
+          onRemoveChargeByCpt: canEdit ? handleRemoveChargeByCpt : null,
           templateCharges: selectedTemplate ? (selectedTemplate.charges || []) : [],
-          readOnly: approved,
+          readOnly: !canEdit,
           sectionConditions,
           patientId,
           noteId,
@@ -1638,10 +1710,10 @@ export function Scribe({ noteId, patientId, staffId, staffName, providerName, pr
           onDeleteRecommendation: handleDeleteRecommendation,
           onAcceptRecommendation: handleAcceptRecommendation,
           onRejectRecommendation: handleRejectRecommendation,
-          onAddCondition: approved ? null : handleAddCondition,
+          onAddCondition: canEdit ? handleAddCondition : null,
           unmatchedConditions,
           diagnosisSuggestions,
-          onAddNow: approved ? null : handleAddNow,
+          onAddNow: canEdit ? handleAddNow : null,
           hideRejected,
           alertFacilityEnabled,
           onEditingChange: handleEditingChange,

--- a/hyperscribe/scribe/static/summary.js
+++ b/hyperscribe/scribe/static/summary.js
@@ -1508,7 +1508,7 @@ export function Scribe({ noteId, patientId, staffId, staffName, providerName, pr
             <rect x="3" y="11" width="18" height="11" rx="2" ry="2" />
             <path d="M7 11V7a5 5 0 0 1 10 0v4" />
           </svg>
-          <span>This note is locked. To make changes, amend the note first.</span>
+          <span>Scribe documentation is incomplete. Click <strong>Amend</strong> in the note footer to finish.</span>
         </div>
       `}
       ${readOnlyReason === 'non_author' && html`

--- a/tests/hyperscribe/scribe/api/test_session_view.py
+++ b/tests/hyperscribe/scribe/api/test_session_view.py
@@ -4,6 +4,7 @@ from http import HTTPStatus
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
+import pytest
 from django.db.models import QuerySet
 
 from canvas_sdk.effects.simple_api import JSONResponse
@@ -28,6 +29,18 @@ from hyperscribe.scribe.backend.models import (
 
 # Disable automatic route resolution
 ScribeSessionView._ROUTES = {}
+
+
+@pytest.fixture(autouse=True)
+def _bypass_authorize_edit(request: pytest.FixtureRequest, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Default to authorized for the existing endpoint tests so they don't need
+    to mock the Note/Helper.editable_note interaction the auth check performs.
+    Tests that exercise the auth helper directly use a separate test file."""
+    if request.node.get_closest_marker("no_authorize_bypass"):
+        return
+    from hyperscribe.scribe.api import session_view
+
+    monkeypatch.setattr(session_view, "_authorize_edit", lambda *_args, **_kwargs: None)
 
 
 def _helper_instance(staff_id: str = "staff-key-abc") -> ScribeSessionView:
@@ -803,7 +816,7 @@ def test_insert_metadata_success(mock_meta: MagicMock) -> None:
             "metadata": {"alert_facility": "true"},
         },
     ]
-    view.request = SimpleNamespace(body=json.dumps({"pending": pending}))
+    view.request = SimpleNamespace(body=json.dumps({"note_uuid": "note-uuid", "pending": pending}))
     result = view.post_insert_metadata()
 
     assert result[0].status_code == HTTPStatus.OK
@@ -816,7 +829,7 @@ def test_insert_metadata_success(mock_meta: MagicMock) -> None:
 
 def test_insert_metadata_empty_pending() -> None:
     view = _helper_instance()
-    view.request = SimpleNamespace(body=json.dumps({"pending": []}))
+    view.request = SimpleNamespace(body=json.dumps({"note_uuid": "note-uuid", "pending": []}))
     result = view.post_insert_metadata()
 
     assert result[0].status_code == HTTPStatus.OK

--- a/tests/hyperscribe/scribe/api/test_session_view_auth.py
+++ b/tests/hyperscribe/scribe/api/test_session_view_auth.py
@@ -8,9 +8,8 @@ from canvas_sdk.v1.data.note import Note as RealNote
 from hyperscribe.scribe.api.session_view import _authorize_edit
 
 
-def _mock_note(dbid: int, provider_id: str | None) -> SimpleNamespace:
-    provider = SimpleNamespace(id=provider_id) if provider_id is not None else None
-    return SimpleNamespace(dbid=dbid, provider=provider)
+def _note_dict(dbid: int, provider_id: str | None) -> dict[str, object]:
+    return {"dbid": dbid, "provider__id": provider_id}
 
 
 def _request(staff_id: str = "staff-1") -> SimpleNamespace:
@@ -26,7 +25,7 @@ def test_authorize_edit_missing_note_uuid() -> None:
 
 @patch("hyperscribe.scribe.api.session_view.Note")
 def test_authorize_edit_note_not_found(mock_note: MagicMock) -> None:
-    mock_note.objects.select_related.return_value.get.side_effect = RealNote.DoesNotExist
+    mock_note.objects.values.return_value.get.side_effect = RealNote.DoesNotExist
     mock_note.DoesNotExist = RealNote.DoesNotExist
 
     result = _authorize_edit("note-uuid", _request())
@@ -38,7 +37,7 @@ def test_authorize_edit_note_not_found(mock_note: MagicMock) -> None:
 @patch("hyperscribe.scribe.api.session_view.Helper.editable_note", return_value=False)
 @patch("hyperscribe.scribe.api.session_view.Note")
 def test_authorize_edit_note_not_editable(mock_note: MagicMock, _editable: MagicMock) -> None:
-    mock_note.objects.select_related.return_value.get.return_value = _mock_note(42, "staff-1")
+    mock_note.objects.values.return_value.get.return_value = _note_dict(42, "staff-1")
 
     result = _authorize_edit("note-uuid", _request())
     assert result is not None
@@ -49,7 +48,7 @@ def test_authorize_edit_note_not_editable(mock_note: MagicMock, _editable: Magic
 @patch("hyperscribe.scribe.api.session_view.Helper.editable_note", return_value=True)
 @patch("hyperscribe.scribe.api.session_view.Note")
 def test_authorize_edit_no_provider(mock_note: MagicMock, _editable: MagicMock) -> None:
-    mock_note.objects.select_related.return_value.get.return_value = _mock_note(42, None)
+    mock_note.objects.values.return_value.get.return_value = _note_dict(42, None)
 
     result = _authorize_edit("note-uuid", _request())
     assert result is not None
@@ -60,7 +59,7 @@ def test_authorize_edit_no_provider(mock_note: MagicMock, _editable: MagicMock) 
 @patch("hyperscribe.scribe.api.session_view.Helper.editable_note", return_value=True)
 @patch("hyperscribe.scribe.api.session_view.Note")
 def test_authorize_edit_different_provider(mock_note: MagicMock, _editable: MagicMock) -> None:
-    mock_note.objects.select_related.return_value.get.return_value = _mock_note(42, "other-staff")
+    mock_note.objects.values.return_value.get.return_value = _note_dict(42, "other-staff")
 
     result = _authorize_edit("note-uuid", _request("staff-1"))
     assert result is not None
@@ -71,7 +70,7 @@ def test_authorize_edit_different_provider(mock_note: MagicMock, _editable: Magi
 @patch("hyperscribe.scribe.api.session_view.Helper.editable_note", return_value=True)
 @patch("hyperscribe.scribe.api.session_view.Note")
 def test_authorize_edit_missing_staff_id(mock_note: MagicMock, _editable: MagicMock) -> None:
-    mock_note.objects.select_related.return_value.get.return_value = _mock_note(42, "staff-1")
+    mock_note.objects.values.return_value.get.return_value = _note_dict(42, "staff-1")
 
     result = _authorize_edit("note-uuid", _request(""))
     assert result is not None
@@ -81,8 +80,9 @@ def test_authorize_edit_missing_staff_id(mock_note: MagicMock, _editable: MagicM
 @patch("hyperscribe.scribe.api.session_view.Helper.editable_note", return_value=True)
 @patch("hyperscribe.scribe.api.session_view.Note")
 def test_authorize_edit_matching_provider(mock_note: MagicMock, editable: MagicMock) -> None:
-    mock_note.objects.select_related.return_value.get.return_value = _mock_note(42, "staff-1")
+    mock_note.objects.values.return_value.get.return_value = _note_dict(42, "staff-1")
 
     result = _authorize_edit("note-uuid", _request("staff-1"))
     assert result is None
     editable.assert_called_once_with(42)
+    mock_note.objects.values.assert_called_once_with("dbid", "provider__id")

--- a/tests/hyperscribe/scribe/api/test_session_view_auth.py
+++ b/tests/hyperscribe/scribe/api/test_session_view_auth.py
@@ -1,0 +1,88 @@
+import json
+from http import HTTPStatus
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from canvas_sdk.v1.data.note import Note as RealNote
+
+from hyperscribe.scribe.api.session_view import _authorize_edit
+
+
+def _mock_note(dbid: int, provider_id: str | None) -> SimpleNamespace:
+    provider = SimpleNamespace(id=provider_id) if provider_id is not None else None
+    return SimpleNamespace(dbid=dbid, provider=provider)
+
+
+def _request(staff_id: str = "staff-1") -> SimpleNamespace:
+    return SimpleNamespace(headers={"canvas-logged-in-user-id": staff_id} if staff_id else {})
+
+
+def test_authorize_edit_missing_note_uuid() -> None:
+    result = _authorize_edit("", _request())
+    assert result is not None
+    assert result.status_code == HTTPStatus.BAD_REQUEST
+    assert "note_uuid" in json.loads(result.content)["error"]
+
+
+@patch("hyperscribe.scribe.api.session_view.Note")
+def test_authorize_edit_note_not_found(mock_note: MagicMock) -> None:
+    mock_note.objects.select_related.return_value.get.side_effect = RealNote.DoesNotExist
+    mock_note.DoesNotExist = RealNote.DoesNotExist
+
+    result = _authorize_edit("note-uuid", _request())
+    assert result is not None
+    assert result.status_code == HTTPStatus.NOT_FOUND
+    assert json.loads(result.content) == {"error": "Note not found"}
+
+
+@patch("hyperscribe.scribe.api.session_view.Helper.editable_note", return_value=False)
+@patch("hyperscribe.scribe.api.session_view.Note")
+def test_authorize_edit_note_not_editable(mock_note: MagicMock, _editable: MagicMock) -> None:
+    mock_note.objects.select_related.return_value.get.return_value = _mock_note(42, "staff-1")
+
+    result = _authorize_edit("note-uuid", _request())
+    assert result is not None
+    assert result.status_code == HTTPStatus.FORBIDDEN
+    assert "not editable" in json.loads(result.content)["error"]
+
+
+@patch("hyperscribe.scribe.api.session_view.Helper.editable_note", return_value=True)
+@patch("hyperscribe.scribe.api.session_view.Note")
+def test_authorize_edit_no_provider(mock_note: MagicMock, _editable: MagicMock) -> None:
+    mock_note.objects.select_related.return_value.get.return_value = _mock_note(42, None)
+
+    result = _authorize_edit("note-uuid", _request())
+    assert result is not None
+    assert result.status_code == HTTPStatus.FORBIDDEN
+    assert "note author" in json.loads(result.content)["error"]
+
+
+@patch("hyperscribe.scribe.api.session_view.Helper.editable_note", return_value=True)
+@patch("hyperscribe.scribe.api.session_view.Note")
+def test_authorize_edit_different_provider(mock_note: MagicMock, _editable: MagicMock) -> None:
+    mock_note.objects.select_related.return_value.get.return_value = _mock_note(42, "other-staff")
+
+    result = _authorize_edit("note-uuid", _request("staff-1"))
+    assert result is not None
+    assert result.status_code == HTTPStatus.FORBIDDEN
+    assert "note author" in json.loads(result.content)["error"]
+
+
+@patch("hyperscribe.scribe.api.session_view.Helper.editable_note", return_value=True)
+@patch("hyperscribe.scribe.api.session_view.Note")
+def test_authorize_edit_missing_staff_id(mock_note: MagicMock, _editable: MagicMock) -> None:
+    mock_note.objects.select_related.return_value.get.return_value = _mock_note(42, "staff-1")
+
+    result = _authorize_edit("note-uuid", _request(""))
+    assert result is not None
+    assert result.status_code == HTTPStatus.FORBIDDEN
+
+
+@patch("hyperscribe.scribe.api.session_view.Helper.editable_note", return_value=True)
+@patch("hyperscribe.scribe.api.session_view.Note")
+def test_authorize_edit_matching_provider(mock_note: MagicMock, editable: MagicMock) -> None:
+    mock_note.objects.select_related.return_value.get.return_value = _mock_note(42, "staff-1")
+
+    result = _authorize_edit("note-uuid", _request("staff-1"))
+    assert result is None
+    editable.assert_called_once_with(42)

--- a/tests/hyperscribe/scribe/application/test_transcript_app.py
+++ b/tests/hyperscribe/scribe/application/test_transcript_app.py
@@ -7,7 +7,7 @@ from canvas_generated.messages.events_pb2 import Event as EventRequest
 from canvas_sdk.events import Event
 from canvas_sdk.handlers.application import NoteApplication
 
-from hyperscribe.scribe.application.transcript_app import ScribeApp
+from hyperscribe.scribe.application.transcript_app import ScribeApp, _scribe_tab_has_content
 
 
 def test_class() -> None:
@@ -205,3 +205,164 @@ def test_handle(launch_modal_effect: object, mock_note: MagicMock) -> None:
         ),
         call().apply(),
     ]
+
+
+# --- _scribe_tab_has_content ---
+
+
+def _stub_transcript(items: list | None) -> MagicMock:
+    qs = MagicMock()
+    qs.first.return_value = items
+    chain = MagicMock()
+    chain.values_list.return_value = qs
+    transcript_cls = MagicMock()
+    transcript_cls.objects.filter.return_value = chain
+    return transcript_cls
+
+
+def _stub_summary(row: dict | None) -> MagicMock:
+    chain = MagicMock()
+    chain.first.return_value = row
+    values = MagicMock()
+    values.values.return_value = chain
+    summary_cls = MagicMock()
+    summary_cls.objects.filter.return_value = values
+    return summary_cls
+
+
+@patch("hyperscribe.scribe.application.transcript_app.ScribeSummary")
+@patch("hyperscribe.scribe.application.transcript_app.ScribeTranscript")
+def test_scribe_tab_has_content_no_rows(mock_transcript: MagicMock, mock_summary: MagicMock) -> None:
+    mock_transcript.objects.filter.return_value.values_list.return_value.first.return_value = None
+    mock_summary.objects.filter.return_value.values.return_value.first.return_value = None
+    assert _scribe_tab_has_content(99) is False
+
+
+@patch("hyperscribe.scribe.application.transcript_app.ScribeSummary")
+@patch("hyperscribe.scribe.application.transcript_app.ScribeTranscript")
+def test_scribe_tab_has_content_transcript_items(
+    mock_transcript: MagicMock, mock_summary: MagicMock
+) -> None:
+    mock_transcript.objects.filter.return_value.values_list.return_value.first.return_value = [
+        {"text": "Hello"}
+    ]
+    assert _scribe_tab_has_content(99) is True
+    mock_summary.objects.filter.assert_not_called()
+
+
+@patch("hyperscribe.scribe.application.transcript_app.ScribeSummary")
+@patch("hyperscribe.scribe.application.transcript_app.ScribeTranscript")
+def test_scribe_tab_has_content_summary_approved(
+    mock_transcript: MagicMock, mock_summary: MagicMock
+) -> None:
+    mock_transcript.objects.filter.return_value.values_list.return_value.first.return_value = []
+    mock_summary.objects.filter.return_value.values.return_value.first.return_value = {
+        "note_data": {},
+        "commands": [],
+        "approved": True,
+    }
+    assert _scribe_tab_has_content(99) is True
+
+
+@patch("hyperscribe.scribe.application.transcript_app.ScribeSummary")
+@patch("hyperscribe.scribe.application.transcript_app.ScribeTranscript")
+def test_scribe_tab_has_content_summary_commands(
+    mock_transcript: MagicMock, mock_summary: MagicMock
+) -> None:
+    mock_transcript.objects.filter.return_value.values_list.return_value.first.return_value = []
+    mock_summary.objects.filter.return_value.values.return_value.first.return_value = {
+        "note_data": {},
+        "commands": [{"command_type": "task", "display": ""}],
+        "approved": False,
+    }
+    assert _scribe_tab_has_content(99) is True
+
+
+@patch("hyperscribe.scribe.application.transcript_app.ScribeSummary")
+@patch("hyperscribe.scribe.application.transcript_app.ScribeTranscript")
+def test_scribe_tab_has_content_summary_text(
+    mock_transcript: MagicMock, mock_summary: MagicMock
+) -> None:
+    mock_transcript.objects.filter.return_value.values_list.return_value.first.return_value = []
+    mock_summary.objects.filter.return_value.values.return_value.first.return_value = {
+        "note_data": {"sections": [{"key": "cc", "title": "CC", "text": "Patient reports cough."}]},
+        "commands": [],
+        "approved": False,
+    }
+    assert _scribe_tab_has_content(99) is True
+
+
+@patch("hyperscribe.scribe.application.transcript_app.ScribeSummary")
+@patch("hyperscribe.scribe.application.transcript_app.ScribeTranscript")
+def test_scribe_tab_has_content_summary_blank(
+    mock_transcript: MagicMock, mock_summary: MagicMock
+) -> None:
+    """A ScribeSummary row exists from a manual-mode template flip, but the user
+    typed nothing and never clicked Approve."""
+    mock_transcript.objects.filter.return_value.values_list.return_value.first.return_value = []
+    mock_summary.objects.filter.return_value.values.return_value.first.return_value = {
+        "note_data": {"sections": [{"key": "cc", "title": "CC", "text": ""}]},
+        "commands": [],
+        "approved": False,
+    }
+    assert _scribe_tab_has_content(99) is False
+
+
+@patch("hyperscribe.scribe.application.transcript_app.ScribeSummary")
+@patch("hyperscribe.scribe.application.transcript_app.ScribeTranscript")
+def test_scribe_tab_has_content_whitespace_only(
+    mock_transcript: MagicMock, mock_summary: MagicMock
+) -> None:
+    mock_transcript.objects.filter.return_value.values_list.return_value.first.return_value = []
+    mock_summary.objects.filter.return_value.values.return_value.first.return_value = {
+        "note_data": {"sections": [{"key": "cc", "title": "CC", "text": "   \n  "}]},
+        "commands": [],
+        "approved": False,
+    }
+    assert _scribe_tab_has_content(99) is False
+
+
+# --- ScribeApp.open_by_default ---
+
+
+@patch("hyperscribe.scribe.application.transcript_app._scribe_tab_has_content")
+@patch("hyperscribe.scribe.application.transcript_app.Helper.editable_note")
+def test_open_by_default_editable_note(
+    mock_editable: MagicMock, mock_has_content: MagicMock
+) -> None:
+    mock_editable.return_value = True
+    mock_has_content.return_value = False  # irrelevant for editable
+    event = Event(EventRequest(context='{"note_id": 7}'))
+    tested = ScribeApp(event, {})
+    assert tested.open_by_default() is True
+
+
+@patch("hyperscribe.scribe.application.transcript_app._scribe_tab_has_content")
+@patch("hyperscribe.scribe.application.transcript_app.Helper.editable_note")
+def test_open_by_default_locked_with_content(
+    mock_editable: MagicMock, mock_has_content: MagicMock
+) -> None:
+    mock_editable.return_value = False
+    mock_has_content.return_value = True
+    event = Event(EventRequest(context='{"note_id": 7}'))
+    tested = ScribeApp(event, {})
+    assert tested.open_by_default() is True
+
+
+@patch("hyperscribe.scribe.application.transcript_app._scribe_tab_has_content")
+@patch("hyperscribe.scribe.application.transcript_app.Helper.editable_note")
+def test_open_by_default_locked_blank_defers_to_legacy(
+    mock_editable: MagicMock, mock_has_content: MagicMock
+) -> None:
+    mock_editable.return_value = False
+    mock_has_content.return_value = False
+    event = Event(EventRequest(context='{"note_id": 7}'))
+    tested = ScribeApp(event, {})
+    assert tested.open_by_default() is False
+    mock_has_content.assert_called_once_with(7)
+
+
+def test_open_by_default_no_note_id() -> None:
+    event = Event(EventRequest(context="{}"))
+    tested = ScribeApp(event, {})
+    assert tested.open_by_default() is True

--- a/uv.lock
+++ b/uv.lock
@@ -2,13 +2,6 @@ version = 1
 revision = 3
 requires-python = ">=3.11, <3.13"
 
-[options]
-exclude-newer = "2026-03-25T15:55:08.978231Z"
-exclude-newer-span = "P7D"
-
-[options.exclude-newer-package]
-canvas = { timestamp = "2026-04-01T15:55:07.978266Z", span = "PT1S" }
-
 [[package]]
 name = "annotated-doc"
 version = "0.0.4"


### PR DESCRIPTION
## Summary

Three buckets of work, shipped together:

**1. Read-only mode + locked-note handling** (the original `changes.md` ask)
- Only the note author (`note.provider.id == logged-in staff_id`) can edit the Scribe tab. Non-authors see a dimmed render with an info-icon banner and no edit / Accept-and-Sign affordances.
- Locked notes drop the lock-icon "Note Locked" placeholder; content is rendered in the same dimmed state with a padlock banner (no editing for anyone). Lock takes precedence over the non-author message.
- `ScribeApp.open_by_default` returns False when a note is locked **and** the Scribe tab has no meaningful content (manual-mode-aware: checks transcript items, summary commands, approved flag, and any non-empty section text). The tab is still in the bar — Canvas just defaults to the legacy note tab.
- Server-side `_authorize_edit` helper guards the six mutating endpoints (`/save-transcript`, `/save-summary`, `/generate-summary`, `/insert-commands`, `/insert-metadata`, `/sign-note`) with 400/403/404. `/insert-metadata` now requires `note_uuid` in the body.

**2. Transcript reliability & polish**
- Force-finalize partial entries on pause / finish so the "Listening" label never persists past live capture; safety net for whatever Nabla doesn't resolve in time.
- Stale-partial promotion: any partial that gets a later final placed after it is force-finalized so it stops rendering as "Listening".
- Monotonic timeline across pause/resume: track `sessionOffsetMs` recomputed on every reconnect; shift incoming `start_offset_ms` / `end_offset_ms` accordingly. Eliminates the bug where post-resume entries interleaved into pre-pause history because Nabla restarts offsets at zero.
- Empty `item_id` partials get a stable synthesized id (no data loss, no stacking).
- End-of-stream signal: stop audio capture and call `client.end()` *before* the speaker-attribution wait so Nabla flushes trailing speaker tags over the still-open WebSocket. `isResolved` check now mirrors the UI's Provider/Patient detection exactly.
- `SPEAKER_WAIT` audit event (reason / resolution / elapsed / unresolved counts) for tuning `FINISH_WAIT_MS` and `PAUSE_WAIT_MS` from real sessions.
- Suppress "Recording in progress" / "Paused" labels once `noteData` or `recording.finalized` is true; the panel header reads "Transcript" instead.
- Fold the "Finalizing transcript" wait into the existing generation progress banner as step 1 of 6 — no more dead time before the LLM kicks in.
- Auto-scroll the transcript to the latest entry while live (RAF-deferred, smooth animation, always pins during recording).

**3. Accept and Sign gating**
- Footer is only visible when **manual mode is active**, or when **AI mode has completed the full record → finish → generate flow** (`mode === 'ai' && recording.finalized && noteData`). Removes the `insertableCount > 0` clause that allowed the button to appear before the user committed to a flow.

## Tests

- New `tests/hyperscribe/scribe/api/test_session_view_auth.py` covering every branch of `_authorize_edit` (missing UUID, note-not-found, not-editable, no provider, different provider, missing staff_id, success).
- New tests in `test_transcript_app.py` for `_scribe_tab_has_content` (no rows, transcript items, approved, commands, section text, blank manual-mode opener, whitespace-only) and `ScribeApp.open_by_default` (editable / locked-with-content / locked-blank / no-note-id).
- Existing endpoint tests get an autouse fixture that bypasses `_authorize_edit`. Two `/insert-metadata` tests updated to pass `note_uuid` in their bodies.
- Backend suite: `uv run pytest tests/hyperscribe -q` → **1491 passed**.

## Test plan

- [ ] Open the Scribe tab as the note author on an editable note: full edit, no banner.
- [ ] Open as a different staffer on the same note: dimmed body, info-icon banner ("Read-only — only the note author can edit the Scribe tab"), no top-bar controls, no Accept and Sign.
- [ ] Lock the note (sign or amend-revert it): body still shows, dimmed, padlock banner ("This note is locked. To make changes, amend the note first.").
- [ ] Lock a never-used Scribe tab: tab still in the bar but Canvas opens the legacy note tab by default. Click into Scribe → empty + locked banner.
- [ ] Lock a note where Scribe was approved: Scribe tab opens by default with the post-approve view.
- [ ] AI flow: Start AI Scribe → speak → click Finish → progress banner shows "Finalizing transcript… (1/6)" through "Suggesting diagnoses… (6/6)" → Accept and Sign appears.
- [ ] Verify "Listening" never persists past Pause or Finish; verify post-resume content lands chronologically below pre-pause content; verify panel header says "Transcript" once `noteData` exists.
- [ ] Auto-scroll: while recording, transcript pins to the bottom even after speaker-attribution flips.
- [ ] Manual mode: click Manual → Accept and Sign appears immediately; AI top controls hidden.
- [ ] curl one of the gated endpoints from a non-author session → 403.

## QA item to confirm in deploy

- Canvas's NoteApplication framework, when no plugin tab returns `open_by_default=True`, falls through to the legacy Canvas note tab (vs. landing on a blank state). This is the assumption behind the locked-blank tab fallback. Easy to revert if not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)