### PR TITLE
Add /repair-mode endpoint for KOALA-5435

### DIFF
--- a/hyperscribe/scribe/api/session_view.py
+++ b/hyperscribe/scribe/api/session_view.py
@@ -516,6 +516,36 @@ class ScribeSessionView(StaffSessionAuthMixin, SimpleAPI):
             return [JSONResponse({"error": "Update failed"}, status_code=HTTPStatus.INTERNAL_SERVER_ERROR)]
         return [JSONResponse({"status": "ok"}, status_code=HTTPStatus.OK)]
 
+    @api.post("/repair-mode")
+    def post_repair_mode(self) -> list[Union[Response, Effect]]:
+        """Bulk-set mode='ai' on ScribeSummary rows where mode is empty.
+
+        This is a one-time repair endpoint for KOALA-5435. Sessions that
+        completed generate-summary before the mode-preservation fix have
+        mode='' which prevents the approve button from rendering.
+
+        Optional body: {"dry_run": true} to preview without writing.
+        """
+        try:
+            body: dict[str, Any] = json.loads(self.request.body) if self.request.body else {}
+        except (json.JSONDecodeError, ValueError):
+            body = {}
+        dry_run = body.get("dry_run", False)
+
+        qs = ScribeSummary.objects.filter(mode="")
+        count = qs.count()
+
+        if not dry_run and count > 0:
+            qs.update(mode="ai")
+            log.info(f"repair-mode: set mode='ai' on {count} ScribeSummary rows")
+
+        return [
+            JSONResponse(
+                {"status": "ok", "repaired": count, "dry_run": dry_run},
+                status_code=HTTPStatus.OK,
+            )
+        ]
+
     @api.get("/config")
     def get_config(self) -> list[Union[Response, Effect]]:
         try:


### PR DESCRIPTION
## Summary

- Adds a one-time `POST /repair-mode` endpoint that bulk-sets `mode='ai'` on all `ScribeSummary` rows where `mode` is empty string
- 1,282 records on Brigade have `mode=''` (343 unapproved with commands) — this prevents the approve button from rendering because the frontend checks `mode === 'ai'`
- Supports `{"dry_run": true}` to preview affected count without writing
- Protected by `StaffSessionAuthMixin` (requires authenticated staff session)
- Intended to be called once after deploy, then removed in a follow-up

## Usage

```bash
# Preview
curl -X POST https://brigade.canvasmedical.com/plugin/scribe-session/repair-mode \
  -H 'Content-Type: application/json' \
  -d '{"dry_run": true}'

# Execute
curl -X POST https://brigade.canvasmedical.com/plugin/scribe-session/repair-mode
```

## Context

`generate-summary` was overwriting `mode` to `''` on save ([KOALA-5435](https://canvasmedical.atlassian.net/browse/KOALA-5435)). The root cause fix is in PR #262 — this PR repairs the existing broken records.

## Test plan

- [ ] Deploy to a test instance, call with `dry_run: true`, verify count
- [ ] Call without dry_run, verify records updated
- [ ] Confirm approve button renders on previously-broken notes
- [ ] Remove endpoint in follow-up PR after repair is complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[KOALA-5435]: https://canvasmedical.atlassian.net/browse/KOALA-5435?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ