### PR TITLE
Allows generic locations to show up for all patients

### DIFF
--- a/hyperscribe/scribe/api/session_view.py
+++ b/hyperscribe/scribe/api/session_view.py
@@ -2400,7 +2400,7 @@ class ScribeSessionView(StaffSessionAuthMixin, SimpleAPI):
     @api.get("/search-imaging-centers")
     def get_search_imaging_centers(self) -> list[Union[Response, Effect]]:
         """Search for radiology imaging centers via the science service."""
-        from hyperscribe.scribe.contacts import resolve_zip_codes
+        from hyperscribe.scribe.contacts import resolve_zip_codes, search_imaging_centers
 
         query = self.request.query_params.get("query", "").strip()
         if not query:
@@ -2410,63 +2410,7 @@ class ScribeSessionView(StaffSessionAuthMixin, SimpleAPI):
         note_id = self.request.query_params.get("note_id", "").strip()
         zip_codes = resolve_zip_codes(patient_id, note_id)
 
-        base_params = f"?search={query}&job_title__icontains=radiology"
-        try:
-            # Try zip-filtered first for local results, fall back to unfiltered.
-            raw_results: list[dict] = []
-            if zip_codes:
-                params = base_params + f"&business_postal_code__in={','.join(zip_codes)}"
-                resp = science_http.get_json(f"/contacts/{params}")
-                raw_results = (resp.json() or {}).get("results", [])
-            if not raw_results:
-                resp = science_http.get_json(f"/contacts/{base_params}")
-                raw_results = (resp.json() or {}).get("results", [])
-        except Exception:
-            log.exception("Imaging center search failed")
-            return [JSONResponse({"results": []}, status_code=HTTPStatus.OK)]
-        results = []
-        for c in raw_results:
-            first = c.get("firstName", "")
-            last = c.get("lastName", "")
-            practice = c.get("practiceName", "")
-            specialty = c.get("specialty", "")
-            # Build display name matching Canvas convention.
-            parts = []
-            if first:
-                parts.append(first)
-            if last and last != first:
-                parts.append(last)
-            if practice and practice != first:
-                parts.append(f"({practice}),")
-            if specialty and specialty not in (first, last, practice):
-                parts.append(specialty)
-            name = " ".join(parts).strip()
-            # Build description with contact details.
-            desc_parts = []
-            phone = c.get("businessPhone")
-            fax = c.get("businessFax")
-            address = c.get("businessAddress")
-            if phone:
-                desc_parts.append(f"Phone: {phone}")
-            if fax:
-                desc_parts.append(f"Fax: {fax}")
-            if address:
-                desc_parts.append(f"Address: {address}")
-            results.append(
-                {
-                    "name": name,
-                    "description": " ".join(desc_parts),
-                    "data": {
-                        "first_name": first,
-                        "last_name": last,
-                        "specialty": specialty,
-                        "practice_name": practice,
-                        "business_fax": fax,
-                        "business_phone": phone,
-                        "business_address": address,
-                    },
-                }
-            )
+        results = search_imaging_centers(query, zip_codes or None)
         return [JSONResponse({"results": results}, status_code=HTTPStatus.OK)]
 
     @api.get("/search-refer-providers")

--- a/hyperscribe/scribe/api/session_view.py
+++ b/hyperscribe/scribe/api/session_view.py
@@ -82,6 +82,11 @@ from hyperscribe.scribe.recommendations.interactions import (
     check_recommendation_interactions,
     check_single_medication_interactions,
 )
+from hyperscribe.scribe.contacts import (
+    resolve_zip_codes,
+    search_imaging_centers,
+    search_refer_providers,
+)
 
 
 def _ensure_str(value: Any) -> str:
@@ -1102,8 +1107,6 @@ class ScribeSessionView(StaffSessionAuthMixin, SimpleAPI):
         api_key = self.secrets.get("AnthropicAPIKey", "")
         if api_key:
             try:
-                from hyperscribe.scribe.contacts import resolve_zip_codes
-
                 patient_id = str(data.get("patient_id", ""))
                 zip_codes = resolve_zip_codes(patient_id, note_id) or None
                 rec_proposals = recommend_commands(note, api_key, zip_codes=zip_codes, transcript=transcript)
@@ -1314,8 +1317,6 @@ class ScribeSessionView(StaffSessionAuthMixin, SimpleAPI):
                 )
             ]
         note = _parse_note(data.get("note", {}))
-        from hyperscribe.scribe.contacts import resolve_zip_codes
-
         patient_id = str(data.get("patient_id", ""))
         rec_note_id = str(data.get("note_id", ""))
         zip_codes = resolve_zip_codes(patient_id, rec_note_id) or None
@@ -2400,8 +2401,6 @@ class ScribeSessionView(StaffSessionAuthMixin, SimpleAPI):
     @api.get("/search-imaging-centers")
     def get_search_imaging_centers(self) -> list[Union[Response, Effect]]:
         """Search for radiology imaging centers via the science service."""
-        from hyperscribe.scribe.contacts import resolve_zip_codes, search_imaging_centers
-
         query = self.request.query_params.get("query", "").strip()
         if not query:
             return [JSONResponse({"results": []}, status_code=HTTPStatus.OK)]
@@ -2416,8 +2415,6 @@ class ScribeSessionView(StaffSessionAuthMixin, SimpleAPI):
     @api.get("/search-refer-providers")
     def get_search_refer_providers(self) -> list[Union[Response, Effect]]:
         """Search for providers to refer to via the science service."""
-        from hyperscribe.scribe.contacts import resolve_zip_codes, search_refer_providers
-
         query = self.request.query_params.get("query", "").strip()
         if not query:
             return [JSONResponse({"results": []}, status_code=HTTPStatus.OK)]

--- a/hyperscribe/scribe/api/session_view.py
+++ b/hyperscribe/scribe/api/session_view.py
@@ -5,6 +5,7 @@ import re
 from datetime import datetime, timezone
 from http import HTTPStatus
 from typing import Any, Union
+from urllib.parse import urlencode
 
 from canvas_sdk.v1.data.medication import Status
 from logger import log
@@ -2364,10 +2365,14 @@ class ScribeSessionView(StaffSessionAuthMixin, SimpleAPI):
         if not query:
             return [JSONResponse({"results": []}, status_code=HTTPStatus.OK)]
         try:
-            resp = science_http.get_json(f"/parse-templates/imaging-reports/?query={query}&limit=25")
+            params = urlencode({"query": query, "limit": "25"})
+            resp = science_http.get_json(f"/parse-templates/imaging-reports/?{params}")
             data = resp.json() or {}
-        except Exception:
-            log.exception("Imaging search failed")
+        except Exception as exc:
+            # Scrub query+URL from logs — the typed query may carry patient
+            # identifiers (HIPAA). Log only the exception class so ops sees
+            # the failure shape without the PHI-bearing context.
+            log.error("Imaging search failed: %s", type(exc).__name__)
             return [JSONResponse({"results": []}, status_code=HTTPStatus.OK)]
         results = []
         for r in data.get("results", []):

--- a/hyperscribe/scribe/contacts.py
+++ b/hyperscribe/scribe/contacts.py
@@ -76,42 +76,95 @@ def _is_generic(c: dict[str, Any]) -> bool:
     return (c.get("lastName") or "").strip() == _GENERIC_LAST_NAME
 
 
-def search_refer_providers(
+def _search_contacts(
     query: str,
-    zip_codes: list[str] | None = None,
+    zip_codes: list[str] | None,
+    extra_params: dict[str, str] | None,
+    log_label: str,
 ) -> list[dict[str, Any]]:
-    """Search the science-service contacts database and return formatted results.
+    """Shared science-service ``/contacts/`` search helper.
 
-    When zip codes are available, the search includes the generic postal code
-    '11111' alongside the patient's zip so that placeholder entries like
-    'Psychiatry TBD' always appear in results regardless of patient location.
+    When ``zip_codes`` is non-empty the request filters by
+    ``business_postal_code__in=<zips>,<_GENERIC_POSTAL_CODE>`` in a single API
+    call so generic/TBD placeholders appear alongside local results. Results
+    are sorted with non-generic contacts first (see ``_is_generic``).
+
+    When the zip-filtered call returns no rows the helper falls back to an
+    unfiltered call — preserving the prior behavior of both call sites.
+
+    ``extra_params`` lets callers tack on filters (e.g. ``job_title__icontains
+    =radiology`` for the imaging-center variant) without re-implementing the
+    rest of the pipeline. ``log_label`` shapes the exception log message so
+    failures are attributable to the calling endpoint.
     """
     if not query:
         return []
 
+    base_params: dict[str, str] = {"search": query}
+    if extra_params:
+        base_params.update(extra_params)
+
     try:
         if zip_codes:
-            # Include generic postal code so TBD/placeholder providers always
+            # Include generic postal code so TBD/placeholder contacts always
             # appear alongside local results — single API call.
             all_zips = list(dict.fromkeys(zip_codes + [_GENERIC_POSTAL_CODE]))
-            params = urlencode({"search": query, "business_postal_code__in": ",".join(all_zips)})
+            params = urlencode({**base_params, "business_postal_code__in": ",".join(all_zips)})
             resp = science_http.get_json(f"/contacts/?{params}")
             raw_results = (resp.json() or {}).get("results", [])
             if raw_results:
-                # Sort real providers before generic placeholders so callers
+                # Sort real contacts before generic placeholders so callers
                 # picking results[0] get a local match, not a TBD entry.
                 # Bool sort orders False<True, so non-generic comes first.
                 raw_results.sort(key=_is_generic)
                 return [_format_contact(c) for c in raw_results]
         # No zip codes, or zip-filtered returned nothing — fall back to unfiltered.
-        params = urlencode({"search": query})
+        params = urlencode(base_params)
         resp = science_http.get_json(f"/contacts/?{params}")
         raw_results = (resp.json() or {}).get("results", [])
     except Exception:
-        log.exception("Refer provider search failed")
+        log.exception(f"{log_label} failed")
         return []
 
     return [_format_contact(c) for c in raw_results]
+
+
+def search_refer_providers(
+    query: str,
+    zip_codes: list[str] | None = None,
+) -> list[dict[str, Any]]:
+    """Search the science-service contacts database for referral providers.
+
+    When zip codes are available, the search includes the generic postal code
+    '11111' alongside the patient's zip so that placeholder entries like
+    'Psychiatry TBD' always appear in results regardless of patient location.
+    """
+    return _search_contacts(
+        query=query,
+        zip_codes=zip_codes,
+        extra_params=None,
+        log_label="Refer provider search",
+    )
+
+
+def search_imaging_centers(
+    query: str,
+    zip_codes: list[str] | None = None,
+) -> list[dict[str, Any]]:
+    """Search the science-service contacts database for radiology imaging centers.
+
+    Same single-call + generic-postal-code semantics as
+    :func:`search_refer_providers`, plus a ``job_title__icontains=radiology``
+    filter to scope results to imaging providers. Closes the missing-generic
+    bug where TBD imaging centers ("Grove Diagnostic Imaging TBD Radiology")
+    disappeared for patients whose zip didn't match the placeholder's.
+    """
+    return _search_contacts(
+        query=query,
+        zip_codes=zip_codes,
+        extra_params={"job_title__icontains": "radiology"},
+        log_label="Imaging center search",
+    )
 
 
 def resolve_zip_codes(patient_id: str = "", note_id: str = "") -> list[str]:

--- a/hyperscribe/scribe/contacts.py
+++ b/hyperscribe/scribe/contacts.py
@@ -120,16 +120,17 @@ def _search_contacts(
             params = urlencode({**base_params, "business_postal_code__in": ",".join(all_zips)})
             resp = science_http.get_json(f"/contacts/?{params}")
             raw_results = (resp.json() or {}).get("results", [])
-            if raw_results:
-                # Sort real contacts before generic placeholders so callers
-                # picking results[0] get a local match, not a TBD entry.
-                # Bool sort orders False<True, so non-generic comes first.
-                raw_results.sort(key=_is_generic)
-                return [_format_contact(c) for c in raw_results]
-        # No zip codes, or zip-filtered returned nothing — fall back to unfiltered.
-        params = urlencode(base_params)
-        resp = science_http.get_json(f"/contacts/?{params}")
-        raw_results = (resp.json() or {}).get("results", [])
+            if not raw_results:
+                # Zip-filtered call returned nothing — fall back to unfiltered
+                # so a patient at a sparse zip still gets results.
+                params = urlencode(base_params)
+                resp = science_http.get_json(f"/contacts/?{params}")
+                raw_results = (resp.json() or {}).get("results", [])
+        else:
+            # No zip codes available — single unfiltered call.
+            params = urlencode(base_params)
+            resp = science_http.get_json(f"/contacts/?{params}")
+            raw_results = (resp.json() or {}).get("results", [])
     except Exception as exc:
         # HIPAA: the request URL contains the typed search query, which can
         # carry patient identifiers (provider types patient name as part of
@@ -139,6 +140,12 @@ def _search_contacts(
         log.error("%s failed: %s", log_label, type(exc).__name__)
         return []
 
+    # Sort real contacts before generic placeholders so callers picking
+    # results[0] (e.g. ReferRecommender) get a local match, not a TBD entry.
+    # Bool sort orders False<True, so non-generic comes first. Applied to
+    # BOTH the zip-filtered AND the unfiltered-fallback path so the
+    # local-first guarantee survives sparse-zip patients.
+    raw_results.sort(key=_is_generic)
     return [_format_contact(c) for c in raw_results]
 
 

--- a/hyperscribe/scribe/contacts.py
+++ b/hyperscribe/scribe/contacts.py
@@ -55,6 +55,25 @@ def _format_contact(c: dict[str, Any]) -> dict[str, Any]:
 
 
 _GENERIC_POSTAL_CODE = "11111"
+_GENERIC_LAST_NAME = "(TBD)"
+
+
+def _is_generic(c: dict[str, Any]) -> bool:
+    """Return True if a raw science-service contact is a generic/placeholder entry.
+
+    Science-service marks generic entries with ``last_name = "(TBD)"`` at import
+    time (see ``science/contacts/management/commands/import_contacts.py``). The
+    contact serializer does NOT include ``business_postal_code`` in its response
+    fields, so the only structural signal available client-side is ``lastName``.
+
+    We previously tried to detect generics by substring-matching the generic
+    postal code against ``businessAddress``. That gives false positives on real
+    addresses that happen to contain the digits (street numbers, ZIP+4, etc.),
+    so a real provider at e.g. ``"11111 Main St"`` would be sorted as generic
+    and bumped behind the placeholder. Matching ``lastName == "(TBD)"`` is
+    exact and tied to the import sentinel, not to display content.
+    """
+    return (c.get("lastName") or "").strip() == _GENERIC_LAST_NAME
 
 
 def search_refer_providers(
@@ -64,7 +83,7 @@ def search_refer_providers(
     """Search the science-service contacts database and return formatted results.
 
     When zip codes are available, the search includes the generic postal code
-    '1111' alongside the patient's zip so that placeholder entries like
+    '11111' alongside the patient's zip so that placeholder entries like
     'Psychiatry TBD' always appear in results regardless of patient location.
     """
     if not query:
@@ -81,7 +100,8 @@ def search_refer_providers(
             if raw_results:
                 # Sort real providers before generic placeholders so callers
                 # picking results[0] get a local match, not a TBD entry.
-                raw_results.sort(key=lambda c: _GENERIC_POSTAL_CODE in (c.get("businessAddress") or ""))
+                # Bool sort orders False<True, so non-generic comes first.
+                raw_results.sort(key=_is_generic)
                 return [_format_contact(c) for c in raw_results]
         # No zip codes, or zip-filtered returned nothing — fall back to unfiltered.
         params = urlencode({"search": query})

--- a/hyperscribe/scribe/contacts.py
+++ b/hyperscribe/scribe/contacts.py
@@ -160,24 +160,58 @@ def search_refer_providers(
     )
 
 
+# Imaging-adjacent specialty values from
+# ``science/contacts/models.py::Contact.SPECIALTY_CHOICES``. The science
+# FilterSet only exposes ``__icontains`` (no ``__in``/``__iregex``), so we
+# scope each call to one substring and merge results. "radiology" captures
+# both ``Radiology`` and ``Vascular & Interventional Radiology`` in one call;
+# ``Nuclear Medicine`` needs its own call. (``Radiation Oncology`` is treatment
+# rather than diagnostic imaging and is intentionally excluded — flag for
+# product confirmation if patients are missing therapy-providers from search.)
+_IMAGING_JOB_TITLE_FILTERS: tuple[str, ...] = ("radiology", "nuclear medicine")
+
+
 def search_imaging_centers(
     query: str,
     zip_codes: list[str] | None = None,
 ) -> list[dict[str, Any]]:
-    """Search the science-service contacts database for radiology imaging centers.
+    """Search the science-service contacts database for imaging providers.
 
     Same single-call + generic-postal-code semantics as
-    :func:`search_refer_providers`, plus a ``job_title__icontains=radiology``
-    filter to scope results to imaging providers. Closes the missing-generic
-    bug where TBD imaging centers ("Grove Diagnostic Imaging TBD Radiology")
-    disappeared for patients whose zip didn't match the placeholder's.
+    :func:`search_refer_providers`, but issues one call per imaging-adjacent
+    job_title filter (see ``_IMAGING_JOB_TITLE_FILTERS``) and merges results
+    de-duplicated by serialized content. This ensures Nuclear Medicine
+    providers — which "radiology" alone misses — surface for queries like
+    "PET scan", and also keeps the generic-TBD surfacing path
+    ("Grove Diagnostic Imaging TBD Radiology") intact across all imaging
+    specialties.
     """
-    return _search_contacts(
-        query=query,
-        zip_codes=zip_codes,
-        extra_params={"job_title__icontains": "radiology"},
-        log_label="Imaging center search",
-    )
+    merged: list[dict[str, Any]] = []
+    seen: set[tuple[str, ...]] = set()
+    for job_title_filter in _IMAGING_JOB_TITLE_FILTERS:
+        results = _search_contacts(
+            query=query,
+            zip_codes=zip_codes,
+            extra_params={"job_title__icontains": job_title_filter},
+            log_label=f"Imaging center search ({job_title_filter})",
+        )
+        for result in results:
+            data = result["data"]
+            # A contact has exactly one ``job_title`` value, so duplicates
+            # across two icontains buckets are rare in practice; key on a
+            # stable content tuple to be defensive against future overlaps.
+            key = (
+                data["first_name"],
+                data["last_name"],
+                data["practice_name"],
+                data["business_address"],
+                data["specialty"],
+            )
+            if key in seen:
+                continue
+            seen.add(key)
+            merged.append(result)
+    return merged
 
 
 def resolve_zip_codes(patient_id: str = "", note_id: str = "") -> list[str]:

--- a/hyperscribe/scribe/contacts.py
+++ b/hyperscribe/scribe/contacts.py
@@ -53,30 +53,53 @@ def _format_contact(c: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+_GENERIC_ADDRESS_MARKER = "1111"
+
+
+def _is_generic_contact(contact: dict[str, Any]) -> bool:
+    """Return True for generic/placeholder contacts (e.g. 'Psychiatry TBD') that should
+    always appear regardless of geo-filter."""
+    address = contact.get("businessAddress") or ""
+    return _GENERIC_ADDRESS_MARKER in address
+
+
 def search_refer_providers(
     query: str,
     zip_codes: list[str] | None = None,
 ) -> list[dict[str, Any]]:
-    """Search the science-service contacts database and return formatted results."""
+    """Search the science-service contacts database and return formatted results.
+
+    Generic contacts (address containing '1111') are always included alongside
+    geo-filtered results so providers can refer to specialty categories like
+    'Psychiatry TBD' regardless of patient location.
+    """
     if not query:
         return []
 
     try:
-        # Try zip-filtered first for local results, fall back to unfiltered.
+        local_results: list[dict[str, Any]] = []
         if zip_codes:
             params = f"?search={query}&business_postal_code__in={','.join(zip_codes)}"
             resp = science_http.get_json(f"/contacts/{params}")
-            raw_results = (resp.json() or {}).get("results", [])
-            if raw_results:
-                return [_format_contact(c) for c in raw_results]
+            local_results = (resp.json() or {}).get("results", [])
+
+        # Always run unfiltered search to pick up generic/TBD entries.
         params = f"?search={query}"
         resp = science_http.get_json(f"/contacts/{params}")
-        raw_results = (resp.json() or {}).get("results", [])
+        all_results = (resp.json() or {}).get("results", [])
     except Exception:
         log.exception("Refer provider search failed")
         return []
 
-    return [_format_contact(c) for c in raw_results]
+    if local_results:
+        # Merge: local geo-filtered results + any generic contacts from the
+        # unfiltered set that weren't already in the local results.
+        seen = {(c.get("firstName"), c.get("lastName"), c.get("specialty")) for c in local_results}
+        generic = [c for c in all_results if _is_generic_contact(c)
+                   and (c.get("firstName"), c.get("lastName"), c.get("specialty")) not in seen]
+        return [_format_contact(c) for c in local_results + generic]
+
+    return [_format_contact(c) for c in all_results]
 
 
 def resolve_zip_codes(patient_id: str = "", note_id: str = "") -> list[str]:

--- a/hyperscribe/scribe/contacts.py
+++ b/hyperscribe/scribe/contacts.py
@@ -55,6 +55,14 @@ def _format_contact(c: dict[str, Any]) -> dict[str, Any]:
 
 
 _GENERIC_POSTAL_CODE = "11111"
+# Fallback the science import-contacts management command writes when a
+# customer-supplied CSV row omits ``business_postal_code`` (see
+# ``science/contacts/management/commands/import_contacts.py`` —
+# ``row.get("business_postal_code") or "."``). Including "." in the zip
+# filter surfaces generic/TBD contacts that came in via that path; otherwise
+# they vanish for any patient whose own zip is not literally ".".
+_IMPORT_MISSING_POSTAL_CODE = "."
+_GENERIC_POSTAL_CODES = (_GENERIC_POSTAL_CODE, _IMPORT_MISSING_POSTAL_CODE)
 _GENERIC_LAST_NAME = "(TBD)"
 
 
@@ -106,9 +114,9 @@ def _search_contacts(
 
     try:
         if zip_codes:
-            # Include generic postal code so TBD/placeholder contacts always
-            # appear alongside local results — single API call.
-            all_zips = list(dict.fromkeys(zip_codes + [_GENERIC_POSTAL_CODE]))
+            # Include both generic postal codes so TBD/placeholder contacts
+            # always appear alongside local results — single API call.
+            all_zips = list(dict.fromkeys(zip_codes + list(_GENERIC_POSTAL_CODES)))
             params = urlencode({**base_params, "business_postal_code__in": ",".join(all_zips)})
             resp = science_http.get_json(f"/contacts/?{params}")
             raw_results = (resp.json() or {}).get("results", [])

--- a/hyperscribe/scribe/contacts.py
+++ b/hyperscribe/scribe/contacts.py
@@ -54,7 +54,7 @@ def _format_contact(c: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-_GENERIC_POSTAL_CODE = "1111"
+_GENERIC_POSTAL_CODE = "11111"
 
 
 def search_refer_providers(

--- a/hyperscribe/scribe/contacts.py
+++ b/hyperscribe/scribe/contacts.py
@@ -53,14 +53,7 @@ def _format_contact(c: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-_GENERIC_ADDRESS_MARKER = "1111"
-
-
-def _is_generic_contact(contact: dict[str, Any]) -> bool:
-    """Return True for generic/placeholder contacts (e.g. 'Psychiatry TBD') that should
-    always appear regardless of geo-filter."""
-    address = contact.get("businessAddress") or ""
-    return _GENERIC_ADDRESS_MARKER in address
+_GENERIC_POSTAL_CODE = "1111"
 
 
 def search_refer_providers(
@@ -69,37 +62,32 @@ def search_refer_providers(
 ) -> list[dict[str, Any]]:
     """Search the science-service contacts database and return formatted results.
 
-    Generic contacts (address containing '1111') are always included alongside
-    geo-filtered results so providers can refer to specialty categories like
-    'Psychiatry TBD' regardless of patient location.
+    When zip codes are available, the search includes the generic postal code
+    '1111' alongside the patient's zip so that placeholder entries like
+    'Psychiatry TBD' always appear in results regardless of patient location.
     """
     if not query:
         return []
 
     try:
-        local_results: list[dict[str, Any]] = []
         if zip_codes:
-            params = f"?search={query}&business_postal_code__in={','.join(zip_codes)}"
+            # Include generic postal code so TBD/placeholder providers always
+            # appear alongside local results — single API call.
+            all_zips = list(dict.fromkeys(zip_codes + [_GENERIC_POSTAL_CODE]))
+            params = f"?search={query}&business_postal_code__in={','.join(all_zips)}"
             resp = science_http.get_json(f"/contacts/{params}")
-            local_results = (resp.json() or {}).get("results", [])
-
-        # Always run unfiltered search to pick up generic/TBD entries.
+            raw_results = (resp.json() or {}).get("results", [])
+            if raw_results:
+                return [_format_contact(c) for c in raw_results]
+        # No zip codes, or zip-filtered returned nothing — fall back to unfiltered.
         params = f"?search={query}"
         resp = science_http.get_json(f"/contacts/{params}")
-        all_results = (resp.json() or {}).get("results", [])
+        raw_results = (resp.json() or {}).get("results", [])
     except Exception:
         log.exception("Refer provider search failed")
         return []
 
-    if local_results:
-        # Merge: local geo-filtered results + any generic contacts from the
-        # unfiltered set that weren't already in the local results.
-        seen = {(c.get("firstName"), c.get("lastName"), c.get("specialty")) for c in local_results}
-        generic = [c for c in all_results if _is_generic_contact(c)
-                   and (c.get("firstName"), c.get("lastName"), c.get("specialty")) not in seen]
-        return [_format_contact(c) for c in local_results + generic]
-
-    return [_format_contact(c) for c in all_results]
+    return [_format_contact(c) for c in raw_results]
 
 
 def resolve_zip_codes(patient_id: str = "", note_id: str = "") -> list[str]:

--- a/hyperscribe/scribe/contacts.py
+++ b/hyperscribe/scribe/contacts.py
@@ -130,8 +130,13 @@ def _search_contacts(
         params = urlencode(base_params)
         resp = science_http.get_json(f"/contacts/?{params}")
         raw_results = (resp.json() or {}).get("results", [])
-    except Exception:
-        log.exception(f"{log_label} failed")
+    except Exception as exc:
+        # HIPAA: the request URL contains the typed search query, which can
+        # carry patient identifiers (provider types patient name as part of
+        # refer search). Avoid log.exception/str(exc) — both leak the URL via
+        # the traceback or the HTTPError message format. Log only the
+        # exception class name.
+        log.error("%s failed: %s", log_label, type(exc).__name__)
         return []
 
     return [_format_contact(c) for c in raw_results]

--- a/hyperscribe/scribe/contacts.py
+++ b/hyperscribe/scribe/contacts.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from typing import Any
+from urllib.parse import urlencode
 
 from canvas_sdk.v1.data import Note
 from canvas_sdk.v1.data.patient import PatientAddress
@@ -74,14 +75,17 @@ def search_refer_providers(
             # Include generic postal code so TBD/placeholder providers always
             # appear alongside local results — single API call.
             all_zips = list(dict.fromkeys(zip_codes + [_GENERIC_POSTAL_CODE]))
-            params = f"?search={query}&business_postal_code__in={','.join(all_zips)}"
-            resp = science_http.get_json(f"/contacts/{params}")
+            params = urlencode({"search": query, "business_postal_code__in": ",".join(all_zips)})
+            resp = science_http.get_json(f"/contacts/?{params}")
             raw_results = (resp.json() or {}).get("results", [])
             if raw_results:
+                # Sort real providers before generic placeholders so callers
+                # picking results[0] get a local match, not a TBD entry.
+                raw_results.sort(key=lambda c: _GENERIC_POSTAL_CODE in (c.get("businessAddress") or ""))
                 return [_format_contact(c) for c in raw_results]
         # No zip codes, or zip-filtered returned nothing — fall back to unfiltered.
-        params = f"?search={query}"
-        resp = science_http.get_json(f"/contacts/{params}")
+        params = urlencode({"search": query})
+        resp = science_http.get_json(f"/contacts/?{params}")
         raw_results = (resp.json() or {}).get("results", [])
     except Exception:
         log.exception("Refer provider search failed")

--- a/tests/hyperscribe/scribe/api/test_session_view.py
+++ b/tests/hyperscribe/scribe/api/test_session_view.py
@@ -4548,3 +4548,43 @@ def test_delete_existing_commands_invalid_json() -> None:
 
     assert result[0].status_code == HTTPStatus.BAD_REQUEST
     assert "Invalid JSON" in json.loads(result[0].content)["error"]
+
+
+@patch("hyperscribe.scribe.api.session_view.science_http")
+def test_search_imaging_exception_log_does_not_leak_query_or_url(
+    mock_science_http: MagicMock, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A failed /search-imaging upstream call must not log the typed query
+    or the full request URL. The provider's query string can carry patient
+    identifiers (HIPAA); only the exception class name is allowed in the log."""
+    secret_query = "MaryJaneDoeSecretPatientName"
+    mock_science_http.get_json.side_effect = RuntimeError(
+        f"HTTPError 500 for url /parse-templates/imaging-reports/?query={secret_query}&limit=25"
+    )
+    view = _helper_instance()
+    view.request = SimpleNamespace(query_params={"query": secret_query})
+
+    with caplog.at_level("ERROR"):
+        result = view.get_search_imaging()
+
+    assert result[0].status_code == HTTPStatus.OK
+    assert json.loads(result[0].content) == {"results": []}
+    for record in caplog.records:
+        assert secret_query not in record.getMessage()
+        assert "/parse-templates/imaging-reports/" not in record.getMessage()
+        assert "query=" not in record.getMessage()
+    assert any("RuntimeError" in record.getMessage() for record in caplog.records)
+
+
+@patch("hyperscribe.scribe.api.session_view.science_http")
+def test_search_imaging_url_encodes_query(mock_science_http: MagicMock) -> None:
+    """Special characters in the typed imaging query must be URL-encoded so
+    the upstream science request stays well-formed (no & / = injection)."""
+    mock_science_http.get_json.return_value.json.return_value = {"results": []}
+    view = _helper_instance()
+    view.request = SimpleNamespace(query_params={"query": "MRI & CT"})
+
+    view.get_search_imaging()
+
+    called_url = mock_science_http.get_json.call_args[0][0]
+    assert "query=MRI+%26+CT" in called_url or "query=MRI%20%26%20CT" in called_url

--- a/tests/hyperscribe/scribe/api/test_session_view.py
+++ b/tests/hyperscribe/scribe/api/test_session_view.py
@@ -3086,7 +3086,7 @@ def test_get_ordering_providers_with_search_query(mock_staff_cls: MagicMock) -> 
 # --- /recommend-commands ---
 
 
-@patch("hyperscribe.scribe.contacts.resolve_zip_codes", return_value=[])
+@patch("hyperscribe.scribe.api.session_view.resolve_zip_codes", return_value=[])
 @patch("hyperscribe.scribe.api.session_view.recommend_commands")
 def test_recommend_commands_success(mock_recommend: MagicMock, _mock_zip: MagicMock) -> None:
     mock_recommend.return_value = [
@@ -3156,7 +3156,7 @@ def test_recommend_commands_invalid_json() -> None:
     assert "Invalid JSON" in json.loads(result[0].content)["error"]
 
 
-@patch("hyperscribe.scribe.contacts.resolve_zip_codes", return_value=[])
+@patch("hyperscribe.scribe.api.session_view.resolve_zip_codes", return_value=[])
 @patch("hyperscribe.scribe.api.session_view.recommend_commands")
 def test_recommend_commands_backend_error(mock_recommend: MagicMock, _mock_zip: MagicMock) -> None:
     mock_recommend.side_effect = Exception("LLM failure")
@@ -3171,7 +3171,7 @@ def test_recommend_commands_backend_error(mock_recommend: MagicMock, _mock_zip: 
     assert "failed" in data["error"].lower()
 
 
-@patch("hyperscribe.scribe.contacts.resolve_zip_codes", return_value=[])
+@patch("hyperscribe.scribe.api.session_view.resolve_zip_codes", return_value=[])
 @patch("hyperscribe.scribe.api.session_view.annotate_duplicates")
 @patch("hyperscribe.scribe.api.session_view.recommend_commands")
 def test_recommend_commands_with_note_uuid_triggers_annotation(
@@ -3203,7 +3203,7 @@ def test_recommend_commands_with_note_uuid_triggers_annotation(
     assert mock_annotate.call_args.args[1] == "note-uuid-456"
 
 
-@patch("hyperscribe.scribe.contacts.resolve_zip_codes", return_value=[])
+@patch("hyperscribe.scribe.api.session_view.resolve_zip_codes", return_value=[])
 @patch("hyperscribe.scribe.api.session_view.annotate_duplicates")
 @patch("hyperscribe.scribe.api.session_view.recommend_commands")
 def test_recommend_commands_without_note_uuid_calls_annotate_with_empty(
@@ -3259,7 +3259,7 @@ def test_get_summary_progress_not_found(mock_get_cache: MagicMock) -> None:
 # --- /generate-summary ---
 
 
-@patch("hyperscribe.scribe.contacts.resolve_zip_codes", return_value=[])
+@patch("hyperscribe.scribe.api.session_view.resolve_zip_codes", return_value=[])
 @patch("hyperscribe.scribe.api.session_view.annotate_duplicates")
 @patch("hyperscribe.scribe.api.session_view.suggest_diagnoses")
 @patch("hyperscribe.scribe.api.session_view.recommend_commands")
@@ -3341,7 +3341,7 @@ def test_generate_summary_success(
     mock_summary.objects.update_or_create.assert_called_once()
 
 
-@patch("hyperscribe.scribe.contacts.resolve_zip_codes", return_value=[])
+@patch("hyperscribe.scribe.api.session_view.resolve_zip_codes", return_value=[])
 @patch("hyperscribe.scribe.api.session_view.annotate_duplicates")
 @patch("hyperscribe.scribe.api.session_view.suggest_diagnoses")
 @patch("hyperscribe.scribe.api.session_view.recommend_commands")
@@ -3571,7 +3571,7 @@ def test_generate_summary_preserves_mode_and_template(
     assert defaults["selected_template_name"] == "Subsequent Visit"
 
 
-@patch("hyperscribe.scribe.contacts.resolve_zip_codes", return_value=[])
+@patch("hyperscribe.scribe.api.session_view.resolve_zip_codes", return_value=[])
 @patch("hyperscribe.scribe.api.session_view.annotate_duplicates")
 @patch("hyperscribe.scribe.api.session_view.suggest_diagnoses")
 @patch("hyperscribe.scribe.api.session_view.recommend_commands")
@@ -3653,7 +3653,7 @@ def test_generate_summary_preserves_mode_from_db_when_not_in_request(
     )
 
 
-@patch("hyperscribe.scribe.contacts.resolve_zip_codes", return_value=[])
+@patch("hyperscribe.scribe.api.session_view.resolve_zip_codes", return_value=[])
 @patch("hyperscribe.scribe.api.session_view.annotate_duplicates")
 @patch("hyperscribe.scribe.api.session_view.suggest_diagnoses")
 @patch("hyperscribe.scribe.api.session_view.recommend_commands")
@@ -3800,7 +3800,7 @@ def test_generate_summary_backend_error(
     assert "Note generation failed" in json.loads(result[0].content)["error"]
 
 
-@patch("hyperscribe.scribe.contacts.resolve_zip_codes", return_value=[])
+@patch("hyperscribe.scribe.api.session_view.resolve_zip_codes", return_value=[])
 @patch("hyperscribe.scribe.api.session_view.annotate_duplicates")
 @patch("hyperscribe.scribe.api.session_view.recommend_commands")
 @patch("hyperscribe.scribe.api.session_view.ScribeSummary")

--- a/tests/hyperscribe/scribe/test_contacts.py
+++ b/tests/hyperscribe/scribe/test_contacts.py
@@ -4,7 +4,6 @@ from unittest.mock import MagicMock, patch
 
 from hyperscribe.scribe.contacts import (
     _format_contact,
-    _is_generic_contact,
     search_refer_providers,
 )
 
@@ -31,16 +30,6 @@ _GENERIC_PSYCHIATRY_TBD = {
     "businessAddress": "1111",
 }
 
-_GENERIC_CARDIOLOGY_TBD = {
-    "firstName": "Cardiology",
-    "lastName": "TBD",
-    "practiceName": "",
-    "specialty": "Cardiology",
-    "businessPhone": "1111",
-    "businessFax": "",
-    "businessAddress": "1111",
-}
-
 _REMOTE_PSYCHIATRIST = {
     "firstName": "Bob",
     "lastName": "Jones",
@@ -50,25 +39,6 @@ _REMOTE_PSYCHIATRIST = {
     "businessFax": "",
     "businessAddress": "200 Wilshire Blvd, Los Angeles CA 90001",
 }
-
-
-# -- _is_generic_contact tests --
-
-
-def test_is_generic_contact_with_1111_address():
-    assert _is_generic_contact(_GENERIC_PSYCHIATRY_TBD) is True
-
-
-def test_is_generic_contact_with_normal_address():
-    assert _is_generic_contact(_LOCAL_PSYCHIATRIST) is False
-
-
-def test_is_generic_contact_with_empty_address():
-    assert _is_generic_contact({"businessAddress": ""}) is False
-
-
-def test_is_generic_contact_with_no_address_key():
-    assert _is_generic_contact({}) is False
 
 
 # -- _format_contact tests --
@@ -116,28 +86,29 @@ def test_search_no_zip_returns_all(mock_http):
 
 
 @patch("hyperscribe.scribe.contacts.science_http")
-def test_search_with_zip_merges_generic(mock_http):
-    """When zip-filtered results exist, generic contacts from the unfiltered
-    search should be merged in."""
-    mock_http.get_json.side_effect = [
-        _mock_science_response([_LOCAL_PSYCHIATRIST]),  # zip-filtered
-        _mock_science_response([_LOCAL_PSYCHIATRIST, _GENERIC_PSYCHIATRY_TBD, _REMOTE_PSYCHIATRIST]),  # unfiltered
-    ]
+def test_search_with_zip_includes_1111(mock_http):
+    """Zip-filtered search should include '1111' postal code to capture generics."""
+    mock_http.get_json.return_value = _mock_science_response(
+        [_LOCAL_PSYCHIATRIST, _GENERIC_PSYCHIATRY_TBD]
+    )
 
     results = search_refer_providers("psychiatry", zip_codes=["92591"])
 
-    assert len(results) == 2  # local + generic TBD (remote excluded)
+    assert len(results) == 2
+    # Verify the API was called with both the patient zip AND the generic postal code.
+    mock_http.get_json.assert_called_once_with(
+        "/contacts/?search=psychiatry&business_postal_code__in=92591,1111"
+    )
     names = [r["name"] for r in results]
     assert any("Jane Smith" in n for n in names)
     assert any("TBD" in n for n in names)
-    assert not any("Bob Jones" in n for n in names)
 
 
 @patch("hyperscribe.scribe.contacts.science_http")
-def test_search_with_zip_no_local_results_falls_back(mock_http):
-    """When zip-filtered returns empty, all unfiltered results are returned."""
+def test_search_with_zip_no_results_falls_back(mock_http):
+    """When zip-filtered returns empty, unfiltered search is used."""
     mock_http.get_json.side_effect = [
-        _mock_science_response([]),  # zip-filtered: nothing local
+        _mock_science_response([]),  # zip+1111 filtered: nothing
         _mock_science_response([_REMOTE_PSYCHIATRIST, _GENERIC_PSYCHIATRY_TBD]),  # unfiltered
     ]
 
@@ -147,39 +118,35 @@ def test_search_with_zip_no_local_results_falls_back(mock_http):
     names = [r["name"] for r in results]
     assert any("Bob Jones" in n for n in names)
     assert any("TBD" in n for n in names)
+    # Two calls: zip-filtered (empty), then unfiltered fallback
+    assert mock_http.get_json.call_count == 2
 
 
 @patch("hyperscribe.scribe.contacts.science_http")
-def test_search_with_zip_no_duplicates(mock_http):
-    """Generic contacts already in local results are not duplicated."""
-    mock_http.get_json.side_effect = [
-        _mock_science_response([_LOCAL_PSYCHIATRIST, _GENERIC_PSYCHIATRY_TBD]),  # zip-filtered includes generic
-        _mock_science_response([_GENERIC_PSYCHIATRY_TBD, _REMOTE_PSYCHIATRIST]),  # unfiltered
-    ]
+def test_search_with_zip_deduplicates_1111(mock_http):
+    """If zip_codes already contains '1111', it shouldn't appear twice."""
+    mock_http.get_json.return_value = _mock_science_response(
+        [_GENERIC_PSYCHIATRY_TBD]
+    )
 
-    results = search_refer_providers("psychiatry", zip_codes=["92591"])
+    results = search_refer_providers("psychiatry", zip_codes=["1111"])
 
-    # Local (Jane) + Generic TBD (already in local, not duped) = 2
-    assert len(results) == 2
-    tbd_count = sum(1 for r in results if "TBD" in r["name"])
-    assert tbd_count == 1
+    assert len(results) == 1
+    mock_http.get_json.assert_called_once_with(
+        "/contacts/?search=psychiatry&business_postal_code__in=1111"
+    )
 
 
 @patch("hyperscribe.scribe.contacts.science_http")
-def test_search_with_zip_multiple_generics(mock_http):
-    """Multiple generic contacts are all merged in."""
-    mock_http.get_json.side_effect = [
-        _mock_science_response([_LOCAL_PSYCHIATRIST]),  # zip-filtered
-        _mock_science_response([_GENERIC_PSYCHIATRY_TBD, _GENERIC_CARDIOLOGY_TBD, _REMOTE_PSYCHIATRIST]),  # unfiltered
-    ]
+def test_search_single_api_call_when_results_found(mock_http):
+    """When zip+1111 filter returns results, only one API call is made."""
+    mock_http.get_json.return_value = _mock_science_response(
+        [_LOCAL_PSYCHIATRIST, _GENERIC_PSYCHIATRY_TBD]
+    )
 
-    results = search_refer_providers("psych", zip_codes=["92591"])
+    search_refer_providers("psychiatry", zip_codes=["92591"])
 
-    assert len(results) == 3  # local + psych TBD + cardiology TBD
-    names = [r["name"] for r in results]
-    assert any("Jane Smith" in n for n in names)
-    assert any("Psychiatry" in n and "TBD" in n for n in names)
-    assert any("Cardiology" in n and "TBD" in n for n in names)
+    assert mock_http.get_json.call_count == 1
 
 
 @patch("hyperscribe.scribe.contacts.science_http")

--- a/tests/hyperscribe/scribe/test_contacts.py
+++ b/tests/hyperscribe/scribe/test_contacts.py
@@ -1,0 +1,191 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from hyperscribe.scribe.contacts import (
+    _format_contact,
+    _is_generic_contact,
+    search_refer_providers,
+)
+
+
+# -- Raw science-service contact fixtures --
+
+_LOCAL_PSYCHIATRIST = {
+    "firstName": "Jane",
+    "lastName": "Smith",
+    "practiceName": "Temecula Psych",
+    "specialty": "Psychiatry",
+    "businessPhone": "555-1234",
+    "businessFax": "555-5678",
+    "businessAddress": "100 Main St, Temecula CA 92591",
+}
+
+_GENERIC_PSYCHIATRY_TBD = {
+    "firstName": "Psychiatry",
+    "lastName": "TBD",
+    "practiceName": "",
+    "specialty": "Psychiatry",
+    "businessPhone": "1111",
+    "businessFax": "",
+    "businessAddress": "1111",
+}
+
+_GENERIC_CARDIOLOGY_TBD = {
+    "firstName": "Cardiology",
+    "lastName": "TBD",
+    "practiceName": "",
+    "specialty": "Cardiology",
+    "businessPhone": "1111",
+    "businessFax": "",
+    "businessAddress": "1111",
+}
+
+_REMOTE_PSYCHIATRIST = {
+    "firstName": "Bob",
+    "lastName": "Jones",
+    "practiceName": "LA Psych Group",
+    "specialty": "Psychiatry",
+    "businessPhone": "555-9999",
+    "businessFax": "",
+    "businessAddress": "200 Wilshire Blvd, Los Angeles CA 90001",
+}
+
+
+# -- _is_generic_contact tests --
+
+
+def test_is_generic_contact_with_1111_address():
+    assert _is_generic_contact(_GENERIC_PSYCHIATRY_TBD) is True
+
+
+def test_is_generic_contact_with_normal_address():
+    assert _is_generic_contact(_LOCAL_PSYCHIATRIST) is False
+
+
+def test_is_generic_contact_with_empty_address():
+    assert _is_generic_contact({"businessAddress": ""}) is False
+
+
+def test_is_generic_contact_with_no_address_key():
+    assert _is_generic_contact({}) is False
+
+
+# -- _format_contact tests --
+
+
+def test_format_contact_full():
+    result = _format_contact(_LOCAL_PSYCHIATRIST)
+    assert result["name"] == "Jane Smith (Temecula Psych), Psychiatry"
+    assert "Phone: 555-1234" in result["description"]
+    assert "Fax: 555-5678" in result["description"]
+    assert result["data"]["first_name"] == "Jane"
+    assert result["data"]["specialty"] == "Psychiatry"
+
+
+def test_format_contact_generic():
+    result = _format_contact(_GENERIC_PSYCHIATRY_TBD)
+    assert "Psychiatry" in result["name"]
+    assert "TBD" in result["name"]
+
+
+# -- search_refer_providers tests --
+
+
+def _mock_science_response(results):
+    """Create a mock response object with .json() returning the given results."""
+    mock = MagicMock()
+    mock.json.return_value = {"results": results}
+    return mock
+
+
+def test_search_empty_query():
+    assert search_refer_providers("") == []
+
+
+@patch("hyperscribe.scribe.contacts.science_http")
+def test_search_no_zip_returns_all(mock_http):
+    mock_http.get_json.return_value = _mock_science_response(
+        [_LOCAL_PSYCHIATRIST, _GENERIC_PSYCHIATRY_TBD]
+    )
+
+    results = search_refer_providers("psychiatry")
+
+    assert len(results) == 2
+    mock_http.get_json.assert_called_once_with("/contacts/?search=psychiatry")
+
+
+@patch("hyperscribe.scribe.contacts.science_http")
+def test_search_with_zip_merges_generic(mock_http):
+    """When zip-filtered results exist, generic contacts from the unfiltered
+    search should be merged in."""
+    mock_http.get_json.side_effect = [
+        _mock_science_response([_LOCAL_PSYCHIATRIST]),  # zip-filtered
+        _mock_science_response([_LOCAL_PSYCHIATRIST, _GENERIC_PSYCHIATRY_TBD, _REMOTE_PSYCHIATRIST]),  # unfiltered
+    ]
+
+    results = search_refer_providers("psychiatry", zip_codes=["92591"])
+
+    assert len(results) == 2  # local + generic TBD (remote excluded)
+    names = [r["name"] for r in results]
+    assert any("Jane Smith" in n for n in names)
+    assert any("TBD" in n for n in names)
+    assert not any("Bob Jones" in n for n in names)
+
+
+@patch("hyperscribe.scribe.contacts.science_http")
+def test_search_with_zip_no_local_results_falls_back(mock_http):
+    """When zip-filtered returns empty, all unfiltered results are returned."""
+    mock_http.get_json.side_effect = [
+        _mock_science_response([]),  # zip-filtered: nothing local
+        _mock_science_response([_REMOTE_PSYCHIATRIST, _GENERIC_PSYCHIATRY_TBD]),  # unfiltered
+    ]
+
+    results = search_refer_providers("psychiatry", zip_codes=["99999"])
+
+    assert len(results) == 2
+    names = [r["name"] for r in results]
+    assert any("Bob Jones" in n for n in names)
+    assert any("TBD" in n for n in names)
+
+
+@patch("hyperscribe.scribe.contacts.science_http")
+def test_search_with_zip_no_duplicates(mock_http):
+    """Generic contacts already in local results are not duplicated."""
+    mock_http.get_json.side_effect = [
+        _mock_science_response([_LOCAL_PSYCHIATRIST, _GENERIC_PSYCHIATRY_TBD]),  # zip-filtered includes generic
+        _mock_science_response([_GENERIC_PSYCHIATRY_TBD, _REMOTE_PSYCHIATRIST]),  # unfiltered
+    ]
+
+    results = search_refer_providers("psychiatry", zip_codes=["92591"])
+
+    # Local (Jane) + Generic TBD (already in local, not duped) = 2
+    assert len(results) == 2
+    tbd_count = sum(1 for r in results if "TBD" in r["name"])
+    assert tbd_count == 1
+
+
+@patch("hyperscribe.scribe.contacts.science_http")
+def test_search_with_zip_multiple_generics(mock_http):
+    """Multiple generic contacts are all merged in."""
+    mock_http.get_json.side_effect = [
+        _mock_science_response([_LOCAL_PSYCHIATRIST]),  # zip-filtered
+        _mock_science_response([_GENERIC_PSYCHIATRY_TBD, _GENERIC_CARDIOLOGY_TBD, _REMOTE_PSYCHIATRIST]),  # unfiltered
+    ]
+
+    results = search_refer_providers("psych", zip_codes=["92591"])
+
+    assert len(results) == 3  # local + psych TBD + cardiology TBD
+    names = [r["name"] for r in results]
+    assert any("Jane Smith" in n for n in names)
+    assert any("Psychiatry" in n and "TBD" in n for n in names)
+    assert any("Cardiology" in n and "TBD" in n for n in names)
+
+
+@patch("hyperscribe.scribe.contacts.science_http")
+def test_search_exception_returns_empty(mock_http):
+    mock_http.get_json.side_effect = Exception("Network error")
+
+    results = search_refer_providers("psychiatry", zip_codes=["92591"])
+
+    assert results == []

--- a/tests/hyperscribe/scribe/test_contacts.py
+++ b/tests/hyperscribe/scribe/test_contacts.py
@@ -265,8 +265,9 @@ _LOCAL_IMAGING_CENTER = {
     "businessAddress": "200 Center Dr, Temecula CA 92591",
 }
 
-# Mirrors the missing-center symptom from KOALA-5446 ("Grove Diagnostic Imaging
-# TBD Radiology"). Uses lastName="(TBD)" — the canonical generic sentinel.
+# Generic imaging-center placeholder ("Grove Diagnostic Imaging TBD Radiology")
+# using lastName="(TBD)" — the canonical sentinel science-service marks at
+# import time. Used to exercise the missing-imaging-center surfacing path.
 _GENERIC_IMAGING_TBD = {
     "firstName": "Grove Diagnostic Imaging",
     "lastName": "(TBD)",
@@ -287,10 +288,9 @@ def test_search_imaging_centers_empty_query() -> None:
 def test_search_imaging_centers_with_zip_includes_11111(mock_http: MagicMock) -> None:
     """Zip-filtered imaging-center search must include '11111' so TBD centers surface.
 
-    This is the missing-imaging-center bug described in KOALA-5446: the prior
-    implementation only filtered by the patient's zip, so generic TBD centers
-    (e.g. "Grove Diagnostic Imaging TBD Radiology") disappeared for patients
-    whose zip did not match the '11111' placeholder.
+    Without including the generic '11111' placeholder postal code alongside the
+    patient's zip, generic TBD imaging centers (e.g. "Grove Diagnostic Imaging
+    TBD Radiology") disappear for any patient whose zip does not match '11111'.
     """
     mock_http.get_json.return_value = _mock_science_response([_LOCAL_IMAGING_CENTER, _GENERIC_IMAGING_TBD])
 
@@ -401,9 +401,9 @@ def test_search_imaging_centers_tbd_visible_for_non_matching_zip(
 ) -> None:
     """A TBD imaging center must surface even when the patient's zip is different.
 
-    This is the regression case from KOALA-5446 — Brigade reported that TBD
-    centers disappeared for patients whose zip did not match the placeholder's.
-    Including '11111' in the zip filter restores that result.
+    Regression: TBD centers must remain visible for patients whose zip does not
+    match the placeholder's. Including '11111' in the zip filter restores that
+    result.
     """
     mock_http.get_json.return_value = _mock_science_response([_GENERIC_IMAGING_TBD])
 

--- a/tests/hyperscribe/scribe/test_contacts.py
+++ b/tests/hyperscribe/scribe/test_contacts.py
@@ -130,12 +130,38 @@ def test_search_empty_query():
 
 @patch("hyperscribe.scribe.contacts.science_http")
 def test_search_no_zip_returns_all(mock_http):
-    mock_http.get_json.return_value = _mock_science_response([_LOCAL_PSYCHIATRIST, _GENERIC_PSYCHIATRY_TBD])
+    """No zip codes provided → unfiltered call returns all results, sorted."""
+    mock_http.get_json.return_value = _mock_science_response([_GENERIC_PSYCHIATRY_TBD, _LOCAL_PSYCHIATRIST])
 
     results = search_refer_providers("psychiatry")
 
     assert len(results) == 2
+    # Sort must apply to the no-zip unfiltered path too — local before TBD even
+    # though TBD came first from science.
+    assert results[0]["data"]["last_name"] != "(TBD)"
+    assert results[1]["data"]["last_name"] == "(TBD)"
     mock_http.get_json.assert_called_once_with("/contacts/?search=psychiatry")
+
+
+@patch("hyperscribe.scribe.contacts.science_http")
+def test_search_fallback_unfiltered_still_sorts_local_first(mock_http: MagicMock) -> None:
+    """When zip-filtered call returns empty AND fallback unfiltered runs, the
+    sort must STILL apply so a TBD doesn't land in results[0] for a sparse-zip
+    patient. Regression for the UAT-discovered bug where sort was only applied
+    on the zip-filtered early-return path."""
+    # First call (zip-filtered) returns empty; second call (unfiltered) returns
+    # TBD first then local — the helper must reorder.
+    mock_http.get_json.side_effect = [
+        _mock_science_response([]),
+        _mock_science_response([_GENERIC_PSYCHIATRY_TBD, _LOCAL_PSYCHIATRIST]),
+    ]
+
+    results = search_refer_providers("psychiatry", zip_codes=["87101"])
+
+    assert len(results) == 2
+    assert results[0]["data"]["last_name"] != "(TBD)", "local must come before TBD on fallback path"
+    assert results[1]["data"]["last_name"] == "(TBD)"
+    assert mock_http.get_json.call_count == 2
 
 
 @patch("hyperscribe.scribe.contacts.science_http")

--- a/tests/hyperscribe/scribe/test_contacts.py
+++ b/tests/hyperscribe/scribe/test_contacts.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock, patch
 from hyperscribe.scribe.contacts import (
     _format_contact,
     _is_generic,
+    search_imaging_centers,
     search_refer_providers,
 )
 
@@ -248,5 +249,188 @@ def test_search_exception_returns_empty(mock_http):
     mock_http.get_json.side_effect = Exception("Network error")
 
     results = search_refer_providers("psychiatry", zip_codes=["92591"])
+
+    assert results == []
+
+
+# -- search_imaging_centers tests --
+
+_LOCAL_IMAGING_CENTER = {
+    "firstName": "",
+    "lastName": "",
+    "practiceName": "Temecula Radiology Group",
+    "specialty": "Radiology",
+    "businessPhone": "555-2222",
+    "businessFax": "555-3333",
+    "businessAddress": "200 Center Dr, Temecula CA 92591",
+}
+
+# Mirrors the missing-center symptom from KOALA-5446 ("Grove Diagnostic Imaging
+# TBD Radiology"). Uses lastName="(TBD)" — the canonical generic sentinel.
+_GENERIC_IMAGING_TBD = {
+    "firstName": "Grove Diagnostic Imaging",
+    "lastName": "(TBD)",
+    "practiceName": "",
+    "specialty": "Radiology",
+    "businessPhone": "",
+    "businessFax": "",
+    "businessAddress": "11111",
+}
+
+
+def test_search_imaging_centers_empty_query() -> None:
+    """Empty query short-circuits without an API call."""
+    assert search_imaging_centers("") == []
+
+
+@patch("hyperscribe.scribe.contacts.science_http")
+def test_search_imaging_centers_with_zip_includes_11111(mock_http: MagicMock) -> None:
+    """Zip-filtered imaging-center search must include '11111' so TBD centers surface.
+
+    This is the missing-imaging-center bug described in KOALA-5446: the prior
+    implementation only filtered by the patient's zip, so generic TBD centers
+    (e.g. "Grove Diagnostic Imaging TBD Radiology") disappeared for patients
+    whose zip did not match the '11111' placeholder.
+    """
+    mock_http.get_json.return_value = _mock_science_response([_LOCAL_IMAGING_CENTER, _GENERIC_IMAGING_TBD])
+
+    results = search_imaging_centers("radiology", zip_codes=["92591"])
+
+    assert len(results) == 2
+    call_url = mock_http.get_json.call_args[0][0]
+    assert "search=radiology" in call_url
+    assert "business_postal_code__in=" in call_url
+    assert "92591" in call_url
+    assert "11111" in call_url
+
+
+@patch("hyperscribe.scribe.contacts.science_http")
+def test_search_imaging_centers_preserves_radiology_filter(mock_http: MagicMock) -> None:
+    """The job_title__icontains=radiology filter must be sent on every call."""
+    mock_http.get_json.return_value = _mock_science_response([_LOCAL_IMAGING_CENTER])
+
+    search_imaging_centers("mri", zip_codes=["92591"])
+
+    call_url = mock_http.get_json.call_args[0][0]
+    # urlencode encodes the dunder filter key directly; just check the
+    # parameter and value appear (allowing either raw or percent-encoded).
+    assert "job_title__icontains" in call_url
+    assert "radiology" in call_url
+
+
+@patch("hyperscribe.scribe.contacts.science_http")
+def test_search_imaging_centers_radiology_filter_present_without_zip(
+    mock_http: MagicMock,
+) -> None:
+    """Even without a zip-filter, the radiology filter must scope unfiltered calls."""
+    mock_http.get_json.return_value = _mock_science_response([_LOCAL_IMAGING_CENTER])
+
+    search_imaging_centers("mri")
+
+    call_url = mock_http.get_json.call_args[0][0]
+    assert "job_title__icontains" in call_url
+    assert "radiology" in call_url
+
+
+@patch("hyperscribe.scribe.contacts.science_http")
+def test_search_imaging_centers_local_sorted_before_generic(
+    mock_http: MagicMock,
+) -> None:
+    """A local imaging center must appear before a TBD center."""
+    # Science service returns the TBD first to verify sort actually happens.
+    mock_http.get_json.return_value = _mock_science_response([_GENERIC_IMAGING_TBD, _LOCAL_IMAGING_CENTER])
+
+    results = search_imaging_centers("radiology", zip_codes=["92591"])
+
+    assert len(results) == 2
+    assert "Temecula Radiology Group" in results[0]["name"]
+    assert "TBD" in results[1]["name"]
+
+
+@patch("hyperscribe.scribe.contacts.science_http")
+def test_search_imaging_centers_url_encodes_query(mock_http: MagicMock) -> None:
+    """Query with special characters must be URL-encoded, not split on &."""
+    mock_http.get_json.return_value = _mock_science_response([])
+
+    search_imaging_centers("MRI & CT", zip_codes=["92591"])
+
+    call_url = mock_http.get_json.call_args[0][0]
+    # & must be encoded (%26), not act as a param separator.
+    assert "MRI" in call_url
+    assert "%26" in call_url
+
+
+@patch("hyperscribe.scribe.contacts.science_http")
+def test_search_imaging_centers_empty_zip_falls_through(mock_http: MagicMock) -> None:
+    """No zip_codes → unfiltered call (single API call), still with radiology filter."""
+    mock_http.get_json.return_value = _mock_science_response([_LOCAL_IMAGING_CENTER, _GENERIC_IMAGING_TBD])
+
+    results = search_imaging_centers("radiology", zip_codes=None)
+
+    assert len(results) == 2
+    assert mock_http.get_json.call_count == 1
+    call_url = mock_http.get_json.call_args[0][0]
+    # No postal_code filter on this path.
+    assert "business_postal_code__in" not in call_url
+
+
+@patch("hyperscribe.scribe.contacts.science_http")
+def test_search_imaging_centers_falls_back_when_zip_returns_empty(
+    mock_http: MagicMock,
+) -> None:
+    """When zip+11111 returns nothing, an unfiltered radiology call is retried.
+
+    Preserves the prior fallback semantics on the imaging-center endpoint:
+    if a patient's zip has no nearby center matching the query, surface the
+    generic + remote centers rather than returning an empty list.
+    """
+    mock_http.get_json.side_effect = [
+        _mock_science_response([]),  # zip+11111 filtered: nothing
+        _mock_science_response([_LOCAL_IMAGING_CENTER, _GENERIC_IMAGING_TBD]),  # unfiltered
+    ]
+
+    results = search_imaging_centers("radiology", zip_codes=["99999"])
+
+    assert len(results) == 2
+    assert mock_http.get_json.call_count == 2
+
+
+@patch("hyperscribe.scribe.contacts.science_http")
+def test_search_imaging_centers_tbd_visible_for_non_matching_zip(
+    mock_http: MagicMock,
+) -> None:
+    """A TBD imaging center must surface even when the patient's zip is different.
+
+    This is the regression case from KOALA-5446 — Brigade reported that TBD
+    centers disappeared for patients whose zip did not match the placeholder's.
+    Including '11111' in the zip filter restores that result.
+    """
+    mock_http.get_json.return_value = _mock_science_response([_GENERIC_IMAGING_TBD])
+
+    results = search_imaging_centers("radiology", zip_codes=["92591"])
+
+    assert len(results) == 1
+    assert "Grove Diagnostic Imaging" in results[0]["name"]
+    assert "TBD" in results[0]["name"]
+
+
+@patch("hyperscribe.scribe.contacts.science_http")
+def test_search_imaging_centers_single_call_when_results_found(
+    mock_http: MagicMock,
+) -> None:
+    """Single API call when zip+11111 returns results — no duplicate request."""
+    mock_http.get_json.return_value = _mock_science_response([_LOCAL_IMAGING_CENTER, _GENERIC_IMAGING_TBD])
+
+    search_imaging_centers("radiology", zip_codes=["92591"])
+
+    assert mock_http.get_json.call_count == 1
+
+
+@patch("hyperscribe.scribe.contacts.science_http")
+def test_search_imaging_centers_exception_returns_empty(mock_http: MagicMock) -> None:
+    """Network/API failure swallows the exception and returns an empty list."""
+    mock_http.get_json.side_effect = Exception("Network error")
+
+    results = search_imaging_centers("radiology", zip_codes=["92591"])
 
     assert results == []

--- a/tests/hyperscribe/scribe/test_contacts.py
+++ b/tests/hyperscribe/scribe/test_contacts.py
@@ -143,12 +143,39 @@ def test_search_with_zip_includes_11111(mock_http):
     results = search_refer_providers("psychiatry", zip_codes=["92591"])
 
     assert len(results) == 2
-    # Verify URL-encoded params with both patient zip and generic postal code.
+    # Verify URL-encoded params with both patient zip and generic postal codes.
     call_url = mock_http.get_json.call_args[0][0]
     assert "search=psychiatry" in call_url
     assert "business_postal_code__in=" in call_url
     assert "92591" in call_url
     assert "11111" in call_url
+    # Import script also writes "." for rows missing business_postal_code.
+    assert "%2C." in call_url or ",." in call_url
+
+
+# Generic TBD referral provider using "." as the import-script fallback for
+# customer-supplied CSV rows that omitted business_postal_code.
+_GENERIC_PSYCHIATRY_TBD_DOT = {
+    "firstName": "Psychiatry",
+    "lastName": "(TBD)",
+    "practiceName": "",
+    "specialty": "Psychiatry",
+    "businessPhone": "",
+    "businessFax": "",
+    "businessAddress": ".",
+}
+
+
+@patch("hyperscribe.scribe.contacts.science_http")
+def test_search_refer_providers_tbd_with_dot_postal_visible(mock_http: MagicMock) -> None:
+    """TBD referral providers imported with the "." fallback postal must surface."""
+    mock_http.get_json.return_value = _mock_science_response([_GENERIC_PSYCHIATRY_TBD_DOT])
+
+    results = search_refer_providers("psychiatry", zip_codes=["92591"])
+
+    assert len(results) == 1
+    assert "Psychiatry" in results[0]["name"]
+    assert "TBD" in results[0]["name"]
 
 
 @patch("hyperscribe.scribe.contacts.science_http")
@@ -302,6 +329,39 @@ def test_search_imaging_centers_with_zip_includes_11111(mock_http: MagicMock) ->
     assert "business_postal_code__in=" in call_url
     assert "92591" in call_url
     assert "11111" in call_url
+    # The import script also writes "." as the fallback for rows missing
+    # business_postal_code, so the filter must include it too.
+    assert "%2C." in call_url or ",." in call_url
+
+
+# Generic TBD imaging center using "." as the import-script fallback for a
+# customer-supplied CSV row that omitted business_postal_code.
+_GENERIC_IMAGING_TBD_DOT = {
+    "firstName": "Coastal Imaging",
+    "lastName": "(TBD)",
+    "practiceName": "",
+    "specialty": "Radiology",
+    "businessPhone": "",
+    "businessFax": "",
+    "businessAddress": ".",
+}
+
+
+@patch("hyperscribe.scribe.contacts.science_http")
+def test_search_imaging_centers_tbd_with_dot_postal_visible(mock_http: MagicMock) -> None:
+    """TBD imaging centers imported with the "." fallback postal must surface.
+
+    The science import command writes "." into business_postal_code when a
+    customer-supplied CSV row omits the column. Without "." in the zip filter,
+    those generic contacts vanish for any patient whose zip is not literally ".".
+    """
+    mock_http.get_json.return_value = _mock_science_response([_GENERIC_IMAGING_TBD_DOT])
+
+    results = search_imaging_centers("radiology", zip_codes=["92591"])
+
+    assert len(results) == 1
+    assert "Coastal Imaging" in results[0]["name"]
+    assert "TBD" in results[0]["name"]
 
 
 @patch("hyperscribe.scribe.contacts.science_http")

--- a/tests/hyperscribe/scribe/test_contacts.py
+++ b/tests/hyperscribe/scribe/test_contacts.py
@@ -397,31 +397,44 @@ def test_search_imaging_centers_tbd_with_dot_postal_visible(mock_http: MagicMock
 
 
 @patch("hyperscribe.scribe.contacts.science_http")
-def test_search_imaging_centers_preserves_radiology_filter(mock_http: MagicMock) -> None:
-    """The job_title__icontains=radiology filter must be sent on every call."""
+def test_search_imaging_centers_issues_one_call_per_specialty_filter(
+    mock_http: MagicMock,
+) -> None:
+    """One call per imaging-adjacent specialty: radiology + nuclear medicine.
+
+    The science FilterSet only exposes ``__icontains`` (no ``__in``/``__iregex``),
+    so we issue one call per imaging-adjacent value and merge. ``radiology``
+    catches both ``Radiology`` and ``Vascular & Interventional Radiology``;
+    ``nuclear medicine`` catches the Nuclear Medicine specialty.
+    """
     mock_http.get_json.return_value = _mock_science_response([_LOCAL_IMAGING_CENTER])
 
     search_imaging_centers("mri", zip_codes=["92591"])
 
-    call_url = mock_http.get_json.call_args[0][0]
-    # urlencode encodes the dunder filter key directly; just check the
-    # parameter and value appear (allowing either raw or percent-encoded).
-    assert "job_title__icontains" in call_url
-    assert "radiology" in call_url
+    # Two specialty filters → two API calls, each carrying its own filter value.
+    assert mock_http.get_json.call_count == 2
+    call_urls = [call.args[0] for call in mock_http.get_json.call_args_list]
+    for url in call_urls:
+        assert "job_title__icontains" in url
+    assert any("radiology" in url for url in call_urls)
+    assert any("nuclear" in url for url in call_urls)
 
 
 @patch("hyperscribe.scribe.contacts.science_http")
-def test_search_imaging_centers_radiology_filter_present_without_zip(
+def test_search_imaging_centers_specialty_filters_present_without_zip(
     mock_http: MagicMock,
 ) -> None:
-    """Even without a zip-filter, the radiology filter must scope unfiltered calls."""
+    """Even without a zip-filter, both specialty filters scope unfiltered calls."""
     mock_http.get_json.return_value = _mock_science_response([_LOCAL_IMAGING_CENTER])
 
     search_imaging_centers("mri")
 
-    call_url = mock_http.get_json.call_args[0][0]
-    assert "job_title__icontains" in call_url
-    assert "radiology" in call_url
+    assert mock_http.get_json.call_count == 2
+    call_urls = [call.args[0] for call in mock_http.get_json.call_args_list]
+    for url in call_urls:
+        assert "job_title__icontains" in url
+    assert any("radiology" in url for url in call_urls)
+    assert any("nuclear" in url for url in call_urls)
 
 
 @patch("hyperscribe.scribe.contacts.science_http")
@@ -454,37 +467,45 @@ def test_search_imaging_centers_url_encodes_query(mock_http: MagicMock) -> None:
 
 @patch("hyperscribe.scribe.contacts.science_http")
 def test_search_imaging_centers_empty_zip_falls_through(mock_http: MagicMock) -> None:
-    """No zip_codes → unfiltered call (single API call), still with radiology filter."""
+    """No zip_codes → one unfiltered call per specialty filter (two total)."""
     mock_http.get_json.return_value = _mock_science_response([_LOCAL_IMAGING_CENTER, _GENERIC_IMAGING_TBD])
 
     results = search_imaging_centers("radiology", zip_codes=None)
 
+    # Identical mock results from both specialty calls collapse to 2 after dedup.
     assert len(results) == 2
-    assert mock_http.get_json.call_count == 1
-    call_url = mock_http.get_json.call_args[0][0]
-    # No postal_code filter on this path.
-    assert "business_postal_code__in" not in call_url
+    # Two unfiltered calls — one per specialty filter, no postal_code filter on either.
+    assert mock_http.get_json.call_count == 2
+    for call in mock_http.get_json.call_args_list:
+        assert "business_postal_code__in" not in call.args[0]
 
 
 @patch("hyperscribe.scribe.contacts.science_http")
 def test_search_imaging_centers_falls_back_when_zip_returns_empty(
     mock_http: MagicMock,
 ) -> None:
-    """When zip+11111 returns nothing, an unfiltered radiology call is retried.
+    """When the zip-filtered call returns nothing, an unfiltered call is retried.
 
     Preserves the prior fallback semantics on the imaging-center endpoint:
     if a patient's zip has no nearby center matching the query, surface the
-    generic + remote centers rather than returning an empty list.
+    generic + remote centers rather than returning an empty list. With two
+    specialty filters and a fallback per filter, the worst case is 4 calls.
     """
     mock_http.get_json.side_effect = [
-        _mock_science_response([]),  # zip+11111 filtered: nothing
-        _mock_science_response([_LOCAL_IMAGING_CENTER, _GENERIC_IMAGING_TBD]),  # unfiltered
+        # radiology specialty: zip-filtered empty → fall back to unfiltered
+        _mock_science_response([]),
+        _mock_science_response([_LOCAL_IMAGING_CENTER, _GENERIC_IMAGING_TBD]),
+        # nuclear medicine specialty: zip-filtered empty → fall back to unfiltered
+        _mock_science_response([]),
+        _mock_science_response([_LOCAL_IMAGING_CENTER, _GENERIC_IMAGING_TBD]),
     ]
 
     results = search_imaging_centers("radiology", zip_codes=["99999"])
 
+    # Two specialty calls × (zip + fallback) = 4 calls. Dedup collapses
+    # repeated content from each specialty back to the original 2 contacts.
     assert len(results) == 2
-    assert mock_http.get_json.call_count == 2
+    assert mock_http.get_json.call_count == 4
 
 
 @patch("hyperscribe.scribe.contacts.science_http")
@@ -507,15 +528,16 @@ def test_search_imaging_centers_tbd_visible_for_non_matching_zip(
 
 
 @patch("hyperscribe.scribe.contacts.science_http")
-def test_search_imaging_centers_single_call_when_results_found(
+def test_search_imaging_centers_one_call_per_specialty_when_results_found(
     mock_http: MagicMock,
 ) -> None:
-    """Single API call when zip+11111 returns results — no duplicate request."""
+    """One zip-filtered call per specialty (no fallback) when each returns results."""
     mock_http.get_json.return_value = _mock_science_response([_LOCAL_IMAGING_CENTER, _GENERIC_IMAGING_TBD])
 
     search_imaging_centers("radiology", zip_codes=["92591"])
 
-    assert mock_http.get_json.call_count == 1
+    # Two specialty filters, each returns results → no fallback fires.
+    assert mock_http.get_json.call_count == 2
 
 
 @patch("hyperscribe.scribe.contacts.science_http")
@@ -526,3 +548,85 @@ def test_search_imaging_centers_exception_returns_empty(mock_http: MagicMock) ->
     results = search_imaging_centers("radiology", zip_codes=["92591"])
 
     assert results == []
+
+
+# A real Nuclear Medicine provider — the gap that motivated the
+# multi-specialty filter. The science FilterSet only supports __icontains,
+# and "radiology" alone does not match the "Nuclear Medicine" job_title.
+_NUCLEAR_MEDICINE_PROVIDER = {
+    "firstName": "Hans",
+    "lastName": "Geiger",
+    "practiceName": "Pacific Nuclear Imaging",
+    "specialty": "Nuclear Medicine",
+    "businessPhone": "555-7777",
+    "businessFax": "",
+    "businessAddress": "300 Atomic Way, Temecula CA 92591",
+}
+
+
+@patch("hyperscribe.scribe.contacts.science_http")
+def test_search_imaging_centers_finds_nuclear_medicine_specialty(
+    mock_http: MagicMock,
+) -> None:
+    """Nuclear Medicine providers must surface — they're invisible to "radiology" alone.
+
+    Closes the gap where a provider ordering a PET scan would not find Nuclear
+    Medicine specialists because the prior icontains=radiology filter excluded
+    them at the science-service layer.
+    """
+
+    def side_effect(url: str) -> MagicMock:
+        # Radiology bucket returns nothing for this query.
+        if "icontains=radiology" in url or "icontains=Radiology" in url:
+            return _mock_science_response([])
+        # Nuclear medicine bucket returns the actual provider.
+        return _mock_science_response([_NUCLEAR_MEDICINE_PROVIDER])
+
+    mock_http.get_json.side_effect = side_effect
+
+    results = search_imaging_centers("PET scan", zip_codes=["92591"])
+
+    assert len(results) == 1
+    assert "Hans" in results[0]["name"]
+    assert results[0]["data"]["specialty"] == "Nuclear Medicine"
+
+
+@patch("hyperscribe.scribe.contacts.science_http")
+def test_search_imaging_centers_merges_radiology_and_nuclear_medicine(
+    mock_http: MagicMock,
+) -> None:
+    """Both specialty buckets contribute to the merged result set."""
+
+    def side_effect(url: str) -> MagicMock:
+        if "radiology" in url.lower():
+            return _mock_science_response([_LOCAL_IMAGING_CENTER])
+        return _mock_science_response([_NUCLEAR_MEDICINE_PROVIDER])
+
+    mock_http.get_json.side_effect = side_effect
+
+    results = search_imaging_centers("imaging", zip_codes=["92591"])
+
+    names = [r["name"] for r in results]
+    assert any("Temecula Radiology Group" in n for n in names)
+    assert any("Hans" in n for n in names)
+    assert len(results) == 2
+
+
+@patch("hyperscribe.scribe.contacts.science_http")
+def test_search_imaging_centers_dedupes_overlap_between_buckets(
+    mock_http: MagicMock,
+) -> None:
+    """A contact returned by both specialty buckets is deduped, not duplicated.
+
+    In practice each contact has exactly one job_title and the two icontains
+    buckets are disjoint, but defensive dedup matters: if a future science-service
+    behavior (e.g. a synthetic "Radiology / Nuclear Medicine" specialty) returns
+    the same contact under both queries, we must not surface it twice.
+    """
+    # Both calls return the same single contact.
+    mock_http.get_json.return_value = _mock_science_response([_LOCAL_IMAGING_CENTER])
+
+    results = search_imaging_centers("radiology", zip_codes=["92591"])
+
+    assert len(results) == 1
+    assert "Temecula Radiology Group" in results[0]["name"]

--- a/tests/hyperscribe/scribe/test_contacts.py
+++ b/tests/hyperscribe/scribe/test_contacts.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock, patch
 
 from hyperscribe.scribe.contacts import (
     _format_contact,
+    _is_generic,
     search_refer_providers,
 )
 
@@ -20,12 +21,15 @@ _LOCAL_PSYCHIATRIST = {
     "businessAddress": "100 Main St, Temecula CA 92591",
 }
 
+# Mirrors how science-service marks generic contacts at import time:
+# `last_name = "(TBD)"` with parentheses. The serializer omits
+# `business_postal_code` from the response, so it's not present here.
 _GENERIC_PSYCHIATRY_TBD = {
     "firstName": "Psychiatry",
-    "lastName": "TBD",
+    "lastName": "(TBD)",
     "practiceName": "",
     "specialty": "Psychiatry",
-    "businessPhone": "11111",
+    "businessPhone": "",
     "businessFax": "",
     "businessAddress": "11111",
 }
@@ -38,6 +42,18 @@ _REMOTE_PSYCHIATRIST = {
     "businessPhone": "555-9999",
     "businessFax": "",
     "businessAddress": "200 Wilshire Blvd, Los Angeles CA 90001",
+}
+
+# Real provider whose street address starts with "11111" — would have been
+# misclassified as generic under the old substring-match sort key.
+_LOCAL_PROVIDER_AT_11111_MAIN = {
+    "firstName": "Alice",
+    "lastName": "Cooper",
+    "practiceName": "11111 Main Medical",
+    "specialty": "Psychiatry",
+    "businessPhone": "555-1111",
+    "businessFax": "",
+    "businessAddress": "11111 Main St, Temecula CA 92591",
 }
 
 
@@ -53,10 +69,45 @@ def test_format_contact_full():
     assert result["data"]["specialty"] == "Psychiatry"
 
 
-def test_format_contact_generic():
+def test_format_contact_generic() -> None:
+    """Generic TBD entries should still produce a recognizable display name."""
     result = _format_contact(_GENERIC_PSYCHIATRY_TBD)
     assert "Psychiatry" in result["name"]
     assert "TBD" in result["name"]
+
+
+# -- _is_generic tests --
+
+
+def test_is_generic_recognizes_tbd_lastname() -> None:
+    """`lastName == "(TBD)"` is the canonical sentinel science-service uses."""
+    assert _is_generic(_GENERIC_PSYCHIATRY_TBD) is True
+
+
+def test_is_generic_rejects_real_provider_with_11111_in_address() -> None:
+    """A real provider at "11111 Main St" must NOT be classified as generic.
+
+    Closes the substring false-positive: the prior sort key (`"11111" in
+    businessAddress`) flagged this entry as generic and demoted it.
+    """
+    assert _is_generic(_LOCAL_PROVIDER_AT_11111_MAIN) is False
+
+
+def test_is_generic_rejects_normal_provider() -> None:
+    """A normal local provider is not generic."""
+    assert _is_generic(_LOCAL_PSYCHIATRIST) is False
+
+
+def test_is_generic_handles_missing_lastname() -> None:
+    """Contacts with missing or null lastName must not crash and are non-generic."""
+    assert _is_generic({"firstName": "Smith"}) is False
+    assert _is_generic({"lastName": None}) is False
+    assert _is_generic({"lastName": ""}) is False
+
+
+def test_is_generic_strips_whitespace() -> None:
+    """Leading/trailing whitespace around "(TBD)" must still resolve as generic."""
+    assert _is_generic({"lastName": " (TBD) "}) is True
 
 
 # -- search_refer_providers tests --
@@ -100,7 +151,7 @@ def test_search_with_zip_includes_11111(mock_http):
 
 
 @patch("hyperscribe.scribe.contacts.science_http")
-def test_search_with_zip_local_providers_sorted_first(mock_http):
+def test_search_with_zip_local_providers_sorted_first(mock_http: MagicMock) -> None:
     """Local providers should appear before generic TBD entries in results."""
     # Science service returns generic before local
     mock_http.get_json.return_value = _mock_science_response([_GENERIC_PSYCHIATRY_TBD, _LOCAL_PSYCHIATRIST])
@@ -110,6 +161,33 @@ def test_search_with_zip_local_providers_sorted_first(mock_http):
     assert len(results) == 2
     # results[0] should be the real local provider, not the TBD
     assert "Jane Smith" in results[0]["name"]
+    assert "TBD" in results[1]["name"]
+
+
+@patch("hyperscribe.scribe.contacts.science_http")
+def test_sort_local_before_generic_handles_real_address_containing_11111(
+    mock_http: MagicMock,
+) -> None:
+    """A real provider at '11111 Main St' must still sort before a TBD entry.
+
+    Regression for the substring-match false positive: the old sort key
+    treated "11111" appearing anywhere in businessAddress as generic, so
+    a real provider at a street number starting with 11111 was demoted
+    behind the placeholder. The structural `lastName == "(TBD)"` check
+    avoids that conflation.
+    """
+    # Science service returns the TBD first; the real "11111 Main St" provider
+    # second. Under the old sort key the real provider would have been sorted
+    # AFTER the TBD (both treated as generic). Under the new key only the
+    # actual TBD is generic, so it gets demoted as expected.
+    mock_http.get_json.return_value = _mock_science_response([_GENERIC_PSYCHIATRY_TBD, _LOCAL_PROVIDER_AT_11111_MAIN])
+
+    results = search_refer_providers("psychiatry", zip_codes=["92591"])
+
+    assert len(results) == 2
+    assert "Alice Cooper" in results[0]["name"], (
+        "Real provider with '11111' in street address must sort before TBD placeholder"
+    )
     assert "TBD" in results[1]["name"]
 
 

--- a/tests/hyperscribe/scribe/test_contacts.py
+++ b/tests/hyperscribe/scribe/test_contacts.py
@@ -25,9 +25,9 @@ _GENERIC_PSYCHIATRY_TBD = {
     "lastName": "TBD",
     "practiceName": "",
     "specialty": "Psychiatry",
-    "businessPhone": "1111",
+    "businessPhone": "11111",
     "businessFax": "",
-    "businessAddress": "1111",
+    "businessAddress": "11111",
 }
 
 _REMOTE_PSYCHIATRIST = {
@@ -88,8 +88,8 @@ def test_search_no_zip_returns_all(mock_http):
 
 
 @patch("hyperscribe.scribe.contacts.science_http")
-def test_search_with_zip_includes_1111(mock_http):
-    """Zip-filtered search should include '1111' postal code to capture generics."""
+def test_search_with_zip_includes_11111(mock_http):
+    """Zip-filtered search should include '11111' postal code to capture generics."""
     mock_http.get_json.return_value = _mock_science_response(
         [_LOCAL_PSYCHIATRIST, _GENERIC_PSYCHIATRY_TBD]
     )
@@ -102,7 +102,7 @@ def test_search_with_zip_includes_1111(mock_http):
     assert "search=psychiatry" in call_url
     assert "business_postal_code__in=" in call_url
     assert "92591" in call_url
-    assert "1111" in call_url
+    assert "11111" in call_url
 
 
 @patch("hyperscribe.scribe.contacts.science_http")
@@ -125,7 +125,7 @@ def test_search_with_zip_local_providers_sorted_first(mock_http):
 def test_search_with_zip_no_results_falls_back(mock_http):
     """When zip-filtered returns empty, unfiltered search is used."""
     mock_http.get_json.side_effect = [
-        _mock_science_response([]),  # zip+1111 filtered: nothing
+        _mock_science_response([]),  # zip+11111 filtered: nothing
         _mock_science_response([_REMOTE_PSYCHIATRIST, _GENERIC_PSYCHIATRY_TBD]),  # unfiltered
     ]
 
@@ -139,23 +139,23 @@ def test_search_with_zip_no_results_falls_back(mock_http):
 
 
 @patch("hyperscribe.scribe.contacts.science_http")
-def test_search_with_zip_deduplicates_1111(mock_http):
-    """If zip_codes already contains '1111', it shouldn't appear twice."""
+def test_search_with_zip_deduplicates_11111(mock_http):
+    """If zip_codes already contains '11111', it shouldn't appear twice."""
     mock_http.get_json.return_value = _mock_science_response(
         [_GENERIC_PSYCHIATRY_TBD]
     )
 
-    results = search_refer_providers("psychiatry", zip_codes=["1111"])
+    results = search_refer_providers("psychiatry", zip_codes=["11111"])
 
     assert len(results) == 1
     call_url = mock_http.get_json.call_args[0][0]
-    # 1111 should only appear once in the URL
-    assert call_url.count("1111") == 1
+    # 11111 should only appear once in the URL
+    assert call_url.count("11111") == 1
 
 
 @patch("hyperscribe.scribe.contacts.science_http")
 def test_search_single_api_call_when_results_found(mock_http):
-    """When zip+1111 filter returns results, only one API call is made."""
+    """When zip+11111 filter returns results, only one API call is made."""
     mock_http.get_json.return_value = _mock_science_response(
         [_LOCAL_PSYCHIATRIST, _GENERIC_PSYCHIATRY_TBD]
     )

--- a/tests/hyperscribe/scribe/test_contacts.py
+++ b/tests/hyperscribe/scribe/test_contacts.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+import logging
 from unittest.mock import MagicMock, patch
+
+import pytest
 
 from hyperscribe.scribe.contacts import (
     _format_contact,
@@ -278,6 +281,35 @@ def test_search_exception_returns_empty(mock_http):
     results = search_refer_providers("psychiatry", zip_codes=["92591"])
 
     assert results == []
+
+
+@patch("hyperscribe.scribe.contacts.science_http")
+def test_search_exception_log_does_not_leak_query_or_url(
+    mock_http: MagicMock, caplog: pytest.LogCaptureFixture
+) -> None:
+    """HIPAA: the search query and request URL must NOT appear in failure logs.
+
+    Patient identifiers ride in the typed search query (e.g. provider types a
+    patient name when searching referrals). HTTPError messages embed the full
+    URL — including the query string — so log.exception / str(exc) would leak
+    it. The handler must log only the exception class name.
+    """
+    # Simulate the worst case: an HTTPError-style message that embeds the URL.
+    sensitive_query = "PATIENTLASTNAME"
+    mock_http.get_json.side_effect = RuntimeError(
+        f"500 Server Error: Internal Server Error for url: https://science.example/contacts/?search={sensitive_query}"
+    )
+
+    with caplog.at_level(logging.ERROR, logger="plugin_runner_logger"):
+        results = search_refer_providers(sensitive_query, zip_codes=["92591"])
+
+    assert results == []
+    combined = " ".join(rec.getMessage() for rec in caplog.records)
+    assert sensitive_query not in combined, "search query (a potential PHI carrier) must not appear in error logs"
+    assert "?search=" not in combined, "request URL substring must not appear in error logs"
+    assert "/contacts/" not in combined, "request path must not appear in error logs"
+    # Sanity: we should still record the exception class for diagnostics.
+    assert any("RuntimeError" in rec.getMessage() for rec in caplog.records)
 
 
 # -- search_imaging_centers tests --

--- a/tests/hyperscribe/scribe/test_contacts.py
+++ b/tests/hyperscribe/scribe/test_contacts.py
@@ -82,7 +82,9 @@ def test_search_no_zip_returns_all(mock_http):
     results = search_refer_providers("psychiatry")
 
     assert len(results) == 2
-    mock_http.get_json.assert_called_once_with("/contacts/?search=psychiatry")
+    mock_http.get_json.assert_called_once_with(
+        "/contacts/?search=psychiatry"
+    )
 
 
 @patch("hyperscribe.scribe.contacts.science_http")
@@ -95,13 +97,28 @@ def test_search_with_zip_includes_1111(mock_http):
     results = search_refer_providers("psychiatry", zip_codes=["92591"])
 
     assert len(results) == 2
-    # Verify the API was called with both the patient zip AND the generic postal code.
-    mock_http.get_json.assert_called_once_with(
-        "/contacts/?search=psychiatry&business_postal_code__in=92591,1111"
+    # Verify URL-encoded params with both patient zip and generic postal code.
+    call_url = mock_http.get_json.call_args[0][0]
+    assert "search=psychiatry" in call_url
+    assert "business_postal_code__in=" in call_url
+    assert "92591" in call_url
+    assert "1111" in call_url
+
+
+@patch("hyperscribe.scribe.contacts.science_http")
+def test_search_with_zip_local_providers_sorted_first(mock_http):
+    """Local providers should appear before generic TBD entries in results."""
+    # Science service returns generic before local
+    mock_http.get_json.return_value = _mock_science_response(
+        [_GENERIC_PSYCHIATRY_TBD, _LOCAL_PSYCHIATRIST]
     )
-    names = [r["name"] for r in results]
-    assert any("Jane Smith" in n for n in names)
-    assert any("TBD" in n for n in names)
+
+    results = search_refer_providers("psychiatry", zip_codes=["92591"])
+
+    assert len(results) == 2
+    # results[0] should be the real local provider, not the TBD
+    assert "Jane Smith" in results[0]["name"]
+    assert "TBD" in results[1]["name"]
 
 
 @patch("hyperscribe.scribe.contacts.science_http")
@@ -118,7 +135,6 @@ def test_search_with_zip_no_results_falls_back(mock_http):
     names = [r["name"] for r in results]
     assert any("Bob Jones" in n for n in names)
     assert any("TBD" in n for n in names)
-    # Two calls: zip-filtered (empty), then unfiltered fallback
     assert mock_http.get_json.call_count == 2
 
 
@@ -132,9 +148,9 @@ def test_search_with_zip_deduplicates_1111(mock_http):
     results = search_refer_providers("psychiatry", zip_codes=["1111"])
 
     assert len(results) == 1
-    mock_http.get_json.assert_called_once_with(
-        "/contacts/?search=psychiatry&business_postal_code__in=1111"
-    )
+    call_url = mock_http.get_json.call_args[0][0]
+    # 1111 should only appear once in the URL
+    assert call_url.count("1111") == 1
 
 
 @patch("hyperscribe.scribe.contacts.science_http")
@@ -147,6 +163,18 @@ def test_search_single_api_call_when_results_found(mock_http):
     search_refer_providers("psychiatry", zip_codes=["92591"])
 
     assert mock_http.get_json.call_count == 1
+
+
+@patch("hyperscribe.scribe.contacts.science_http")
+def test_search_url_encodes_query(mock_http):
+    """Query with special characters should be URL-encoded."""
+    mock_http.get_json.return_value = _mock_science_response([])
+
+    search_refer_providers("ENT & Allergy", zip_codes=["92591"])
+
+    call_url = mock_http.get_json.call_args[0][0]
+    # & should be encoded, not treated as a param separator
+    assert "ENT+%26+Allergy" in call_url or "ENT+%26" in call_url
 
 
 @patch("hyperscribe.scribe.contacts.science_http")

--- a/tests/hyperscribe/scribe/test_contacts.py
+++ b/tests/hyperscribe/scribe/test_contacts.py
@@ -75,24 +75,18 @@ def test_search_empty_query():
 
 @patch("hyperscribe.scribe.contacts.science_http")
 def test_search_no_zip_returns_all(mock_http):
-    mock_http.get_json.return_value = _mock_science_response(
-        [_LOCAL_PSYCHIATRIST, _GENERIC_PSYCHIATRY_TBD]
-    )
+    mock_http.get_json.return_value = _mock_science_response([_LOCAL_PSYCHIATRIST, _GENERIC_PSYCHIATRY_TBD])
 
     results = search_refer_providers("psychiatry")
 
     assert len(results) == 2
-    mock_http.get_json.assert_called_once_with(
-        "/contacts/?search=psychiatry"
-    )
+    mock_http.get_json.assert_called_once_with("/contacts/?search=psychiatry")
 
 
 @patch("hyperscribe.scribe.contacts.science_http")
 def test_search_with_zip_includes_11111(mock_http):
     """Zip-filtered search should include '11111' postal code to capture generics."""
-    mock_http.get_json.return_value = _mock_science_response(
-        [_LOCAL_PSYCHIATRIST, _GENERIC_PSYCHIATRY_TBD]
-    )
+    mock_http.get_json.return_value = _mock_science_response([_LOCAL_PSYCHIATRIST, _GENERIC_PSYCHIATRY_TBD])
 
     results = search_refer_providers("psychiatry", zip_codes=["92591"])
 
@@ -109,9 +103,7 @@ def test_search_with_zip_includes_11111(mock_http):
 def test_search_with_zip_local_providers_sorted_first(mock_http):
     """Local providers should appear before generic TBD entries in results."""
     # Science service returns generic before local
-    mock_http.get_json.return_value = _mock_science_response(
-        [_GENERIC_PSYCHIATRY_TBD, _LOCAL_PSYCHIATRIST]
-    )
+    mock_http.get_json.return_value = _mock_science_response([_GENERIC_PSYCHIATRY_TBD, _LOCAL_PSYCHIATRIST])
 
     results = search_refer_providers("psychiatry", zip_codes=["92591"])
 
@@ -141,9 +133,7 @@ def test_search_with_zip_no_results_falls_back(mock_http):
 @patch("hyperscribe.scribe.contacts.science_http")
 def test_search_with_zip_deduplicates_11111(mock_http):
     """If zip_codes already contains '11111', it shouldn't appear twice."""
-    mock_http.get_json.return_value = _mock_science_response(
-        [_GENERIC_PSYCHIATRY_TBD]
-    )
+    mock_http.get_json.return_value = _mock_science_response([_GENERIC_PSYCHIATRY_TBD])
 
     results = search_refer_providers("psychiatry", zip_codes=["11111"])
 
@@ -156,9 +146,7 @@ def test_search_with_zip_deduplicates_11111(mock_http):
 @patch("hyperscribe.scribe.contacts.science_http")
 def test_search_single_api_call_when_results_found(mock_http):
     """When zip+11111 filter returns results, only one API call is made."""
-    mock_http.get_json.return_value = _mock_science_response(
-        [_LOCAL_PSYCHIATRIST, _GENERIC_PSYCHIATRY_TBD]
-    )
+    mock_http.get_json.return_value = _mock_science_response([_LOCAL_PSYCHIATRIST, _GENERIC_PSYCHIATRY_TBD])
 
     search_refer_providers("psychiatry", zip_codes=["92591"])
 


### PR DESCRIPTION
[KOALA-5446](https://canvasmedical.atlassian.net/browse/KOALA-5446)

Providers wanted to be able to select the generic 11111 locations for referrals (e.g. "generic psychiatry"), but the location filtered these out on the scribe tab - this adds them back!

[KOALA-5446]: https://canvasmedical.atlassian.net/browse/KOALA-5446?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ