### PR TITLE
Add Image Results custom command and fix narrative HTML rendering

### DIFF
--- a/hyperscribe/CANVAS_MANIFEST.json
+++ b/hyperscribe/CANVAS_MANIFEST.json
@@ -214,6 +214,12 @@
         "label": "Lab Results",
         "schema_key": "labResult",
         "section": "objective"
+      },
+      {
+        "name": "ImageResults",
+        "label": "Image Results",
+        "schema_key": "imageResult",
+        "section": "objective"
       }
     ],
     "content": [],

--- a/hyperscribe/scribe/commands/builder.py
+++ b/hyperscribe/scribe/commands/builder.py
@@ -17,6 +17,7 @@ from hyperscribe.scribe.commands.diagnose import DiagnoseParser
 from hyperscribe.scribe.commands.family_history import FamilyHistoryParser
 from hyperscribe.scribe.commands.history_review import HistoryReviewParser
 from hyperscribe.scribe.commands.hpi import HpiParser
+from hyperscribe.scribe.commands.image_results import ImageResultsParser
 from hyperscribe.scribe.commands.imaging_order import ImagingOrderParser
 from hyperscribe.scribe.commands.lab_order import LabOrderParser
 from hyperscribe.scribe.commands.lab_results import LabResultsParser
@@ -49,6 +50,7 @@ _BUILDERS: dict[str, CommandParser] = {
     "history_review": HistoryReviewParser(),
     "hpi": HpiParser(),
     "imaging_order": ImagingOrderParser(),
+    "imaging_results": ImageResultsParser(),
     "lab_order": LabOrderParser(),
     "lab_results": LabResultsParser(),
     "medicalHistory": MedicalHistoryParser(),

--- a/hyperscribe/scribe/commands/extractor.py
+++ b/hyperscribe/scribe/commands/extractor.py
@@ -183,6 +183,23 @@ def _extract_lab_results(note: ClinicalNote) -> CommandProposal | None:
     )
 
 
+def _extract_image_results(note: ClinicalNote) -> CommandProposal | None:
+    """Extract imaging_results section into an Image Results command."""
+    image_section = next(
+        (s for s in note.sections if s.key.lower() == "imaging_results" and s.text.strip()),
+        None,
+    )
+    if image_section is None:
+        return None
+    text = image_section.text.strip()
+    return CommandProposal(
+        command_type="imaging_results",
+        display=text,
+        data={"narrative": text},
+        section_key="imaging_results",
+    )
+
+
 def extract_commands(note: ClinicalNote) -> list[CommandProposal]:
     """Map ClinicalNote sections to CommandProposal list (deterministic, no LLM)."""
     proposals: list[CommandProposal] = []
@@ -216,5 +233,9 @@ def extract_commands(note: ClinicalNote) -> list[CommandProposal]:
     lab_proposal = _extract_lab_results(note)
     if lab_proposal is not None:
         proposals.append(lab_proposal)
+
+    image_proposal = _extract_image_results(note)
+    if image_proposal is not None:
+        proposals.append(image_proposal)
 
     return proposals

--- a/hyperscribe/scribe/commands/image_results.py
+++ b/hyperscribe/scribe/commands/image_results.py
@@ -15,7 +15,7 @@ def _to_ascii_html(text: str) -> str:
 
 
 def _narrative_to_html(text: str) -> str:
-    """Convert lab results narrative text into structured HTML.
+    """Convert image results narrative text into structured HTML.
 
     Lines starting with ``- `` become bullet items in a ``<ul>``. Consecutive
     non-bullet lines collapse into a single ``<p>`` with ``<br>`` between
@@ -45,8 +45,8 @@ def _narrative_to_html(text: str) -> str:
     return "".join(parts)
 
 
-class LabResultsParser(CommandParser):
-    command_type = "lab_results"
+class ImageResultsParser(CommandParser):
+    command_type = "imaging_results"
     data_field = "narrative"
 
     def extract(self, text: str) -> None:
@@ -56,7 +56,7 @@ class LabResultsParser(CommandParser):
         narrative = str(data.get("narrative", ""))
         html = _narrative_to_html(narrative) if narrative else ""
         return CustomCommand(
-            schema_key="labResult",
+            schema_key="imageResult",
             content=html,
             note_uuid=note_uuid,
             command_uuid=command_uuid,

--- a/hyperscribe/scribe/commands/image_results.py
+++ b/hyperscribe/scribe/commands/image_results.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import html
 import re
 from typing import Any
 
@@ -10,8 +11,17 @@ from hyperscribe.scribe.commands.base import CommandParser
 
 
 def _to_ascii_html(text: str) -> str:
-    """Convert non-ASCII characters to HTML entities so they survive JSON serialization."""
-    return "".join(c if ord(c) < 128 else f"&#{ord(c)};" for c in text)
+    """Escape HTML metacharacters and convert non-ASCII to numeric entities.
+
+    The result is shipped as ``CustomCommand.content`` and rendered as HTML
+    by the chart, so ``<``, ``>``, ``&``, ``"``, ``'`` must be entity-escaped
+    to prevent both garbled markup from benign clinical text (``K+ <3.0``)
+    and script injection from untrusted transcript/textarea input.
+    """
+    return "".join(
+        c if ord(c) < 128 else f"&#{ord(c)};"
+        for c in html.escape(text, quote=True)
+    )
 
 
 def _narrative_to_html(text: str) -> str:

--- a/hyperscribe/scribe/commands/lab_results.py
+++ b/hyperscribe/scribe/commands/lab_results.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import html
 import re
 from typing import Any
 
@@ -10,8 +11,17 @@ from hyperscribe.scribe.commands.base import CommandParser
 
 
 def _to_ascii_html(text: str) -> str:
-    """Convert non-ASCII characters to HTML entities so they survive JSON serialization."""
-    return "".join(c if ord(c) < 128 else f"&#{ord(c)};" for c in text)
+    """Escape HTML metacharacters and convert non-ASCII to numeric entities.
+
+    The result is shipped as ``CustomCommand.content`` and rendered as HTML
+    by the chart, so ``<``, ``>``, ``&``, ``"``, ``'`` must be entity-escaped
+    to prevent both garbled markup from benign clinical text (``K+ <3.0``)
+    and script injection from untrusted transcript/textarea input.
+    """
+    return "".join(
+        c if ord(c) < 128 else f"&#{ord(c)};"
+        for c in html.escape(text, quote=True)
+    )
 
 
 def _narrative_to_html(text: str) -> str:

--- a/hyperscribe/scribe/static/command-row.js
+++ b/hyperscribe/scribe/static/command-row.js
@@ -12,6 +12,7 @@ const DATA_FIELD = {
   hpi: 'narrative',
   plan: 'narrative',
   lab_results: 'narrative',
+  imaging_results: 'narrative',
 };
 
 export function CommandRow({ command, commandIndex, onEdit, onDelete, readOnly, onEditingChange }) {

--- a/hyperscribe/scribe/static/soap-group.js
+++ b/hyperscribe/scribe/static/soap-group.js
@@ -223,7 +223,7 @@ function RemovalRow({ command, commandIndex, onEdit, onDelete, readOnly, patient
   `;
 }
 
-const NARRATIVE_SECTIONS = new Set(['chief_complaint', 'history_of_present_illness', 'plan', 'assessment_and_plan', 'appointments', 'lab_results']);
+const NARRATIVE_SECTIONS = new Set(['chief_complaint', 'history_of_present_illness', 'plan', 'assessment_and_plan', 'appointments', 'lab_results', 'imaging_results']);
 const PLAN_SECTIONS = new Set(['plan', 'assessment_and_plan']);
 const ORDER_TYPES = new Set(['prescribe', 'refill', 'adjust_prescription', 'lab_order', 'imaging_order', 'refer']);
 const HISTORY_TYPES = new Set(['familyHistory', 'medicalHistory', 'surgicalHistory']);

--- a/hyperscribe/scribe/static/summary.js
+++ b/hyperscribe/scribe/static/summary.js
@@ -1468,6 +1468,7 @@ export function Scribe({ noteId, patientId, staffId, staffName, providerName, pr
     ['past_surgical_history', { key: 'past_surgical_history', title: 'Past Surgical History', text: '' }],
     ['family_history', { key: 'family_history', title: 'Family History', text: '' }],
     ['lab_results', { key: 'lab_results', title: 'Lab Results', text: '' }],
+    ['imaging_results', { key: 'imaging_results', title: 'Imaging Results', text: '' }],
     ['physical_exam', { key: 'physical_exam', title: 'Physical Exam', text: '' }],
   ]);
   const effectiveSections = (() => {

--- a/tests/hyperscribe/scribe/commands/test_image_results.py
+++ b/tests/hyperscribe/scribe/commands/test_image_results.py
@@ -1,0 +1,129 @@
+from unittest.mock import patch
+
+from hyperscribe.scribe.backend.models import ClinicalNote, NoteSection
+from hyperscribe.scribe.commands.builder import _BUILDERS
+from hyperscribe.scribe.commands.extractor import extract_commands
+from hyperscribe.scribe.commands.image_results import (
+    ImageResultsParser,
+    _narrative_to_html,
+)
+
+
+def test_parser_registered_under_imaging_results_key() -> None:
+    parser = _BUILDERS["imaging_results"]
+    assert isinstance(parser, ImageResultsParser)
+    assert parser.command_type == "imaging_results"
+    assert parser.data_field == "narrative"
+
+
+def test_extract_imaging_results_section_to_proposal() -> None:
+    note = ClinicalNote(
+        title="Note",
+        sections=[
+            NoteSection(
+                key="imaging_results",
+                title="Imaging Results",
+                text="- Chest X-ray: clear lungs.\n- Knee MRI: small effusion.",
+            )
+        ],
+    )
+    proposals = extract_commands(note)
+    assert len(proposals) == 1
+    assert proposals[0].command_type == "imaging_results"
+    assert proposals[0].section_key == "imaging_results"
+    assert proposals[0].data == {
+        "narrative": "- Chest X-ray: clear lungs.\n- Knee MRI: small effusion.",
+    }
+
+
+def test_extract_empty_imaging_results_section_yields_no_proposal() -> None:
+    note = ClinicalNote(
+        title="Note",
+        sections=[NoteSection(key="imaging_results", title="Imaging Results", text="   ")],
+    )
+    assert extract_commands(note) == []
+
+
+def test_narrative_to_html_bulletizes_dash_separated_items() -> None:
+    html = _narrative_to_html("- Chest X-ray: clear.\n- Knee MRI: small effusion.")
+    assert html == "<ul><li>Chest X-ray: clear.</li><li>Knee MRI: small effusion.</li></ul>"
+
+
+def test_narrative_to_html_wraps_plain_text_in_paragraph() -> None:
+    assert _narrative_to_html("Findings unremarkable.") == "<p>Findings unremarkable.</p>"
+
+
+def test_narrative_to_html_returns_empty_string_for_blank_input() -> None:
+    assert _narrative_to_html("   ") == ""
+    assert _narrative_to_html("") == ""
+    assert _narrative_to_html("\n\n  \n") == ""
+
+
+def test_narrative_to_html_free_text_after_bullets_does_not_collapse() -> None:
+    text = (
+        "- Hemoglobin A1c: 6.9%\n"
+        "- Platelets: 240 x10/uL\n"
+        "new line 1\n"
+        "new line 2.\n"
+        "new line 3\n"
+        "\n"
+        "new line 4 with an extra blank line above."
+    )
+    assert _narrative_to_html(text) == (
+        "<ul><li>Hemoglobin A1c: 6.9%</li><li>Platelets: 240 x10/uL</li></ul>"
+        "<p>new line 1<br>new line 2.<br>new line 3</p>"
+        "<p>new line 4 with an extra blank line above.</p>"
+    )
+
+
+def test_narrative_to_html_blank_line_starts_new_paragraph() -> None:
+    assert _narrative_to_html("First paragraph.\n\nSecond paragraph.") == (
+        "<p>First paragraph.</p><p>Second paragraph.</p>"
+    )
+
+
+def test_narrative_to_html_hard_line_break_within_paragraph() -> None:
+    assert _narrative_to_html("Line A\nLine B") == "<p>Line A<br>Line B</p>"
+
+
+def test_narrative_to_html_bullets_can_resume_after_paragraph() -> None:
+    text = "- first\n\nintroductory text\n\n- second\n- third"
+    assert _narrative_to_html(text) == (
+        "<ul><li>first</li></ul>"
+        "<p>introductory text</p>"
+        "<ul><li>second</li><li>third</li></ul>"
+    )
+
+
+def test_narrative_to_html_escapes_non_ascii() -> None:
+    html = _narrative_to_html("Café reading 98° normal")
+    assert "&#233;" in html  # é
+    assert "&#176;" in html  # °
+
+
+def test_build_creates_custom_command_with_image_result_schema_key() -> None:
+    parser = ImageResultsParser()
+    with patch("hyperscribe.scribe.commands.image_results.CustomCommand") as mock_cc:
+        parser.build(
+            data={"narrative": "- MRI brain: no acute findings."},
+            note_uuid="note-uuid",
+            command_uuid="cmd-uuid",
+        )
+    mock_cc.assert_called_once_with(
+        schema_key="imageResult",
+        content="<ul><li>MRI brain: no acute findings.</li></ul>",
+        note_uuid="note-uuid",
+        command_uuid="cmd-uuid",
+    )
+
+
+def test_build_with_empty_narrative_passes_empty_content() -> None:
+    parser = ImageResultsParser()
+    with patch("hyperscribe.scribe.commands.image_results.CustomCommand") as mock_cc:
+        parser.build(data={}, note_uuid="note-uuid", command_uuid="cmd-uuid")
+    mock_cc.assert_called_once_with(
+        schema_key="imageResult",
+        content="",
+        note_uuid="note-uuid",
+        command_uuid="cmd-uuid",
+    )

--- a/tests/hyperscribe/scribe/commands/test_image_results.py
+++ b/tests/hyperscribe/scribe/commands/test_image_results.py
@@ -127,3 +127,30 @@ def test_build_with_empty_narrative_passes_empty_content() -> None:
         note_uuid="note-uuid",
         command_uuid="cmd-uuid",
     )
+
+
+def test_narrative_to_html_escapes_less_than_in_clinical_text() -> None:
+    # K+ <3.0 used to render as malformed markup; now becomes &lt;.
+    assert _narrative_to_html("- K+ <3.0 mmol/L") == "<ul><li>K+ &lt;3.0 mmol/L</li></ul>"
+
+
+def test_narrative_to_html_escapes_greater_than_in_clinical_text() -> None:
+    assert _narrative_to_html("- BP > 140/90") == "<ul><li>BP &gt; 140/90</li></ul>"
+
+
+def test_narrative_to_html_escapes_ampersand() -> None:
+    assert _narrative_to_html("Q&A about results") == "<p>Q&amp;A about results</p>"
+
+
+def test_narrative_to_html_escapes_script_tag_injection() -> None:
+    out = _narrative_to_html("<script>alert(1)</script>")
+    assert "<script>" not in out
+    assert "&lt;script&gt;alert(1)&lt;/script&gt;" in out
+
+
+def test_narrative_to_html_handles_combined_non_ascii_and_metacharacter() -> None:
+    out = _narrative_to_html("Café reading 98° was <2 mmHg")
+    assert "&#233;" in out  # é
+    assert "&#176;" in out  # °
+    assert "&lt;2" in out
+    assert "<2" not in out


### PR DESCRIPTION
https://canvasmedical.atlassian.net/browse/KOALA-5461

## Summary
- New `ImageResultsParser` + `ImageResults` custom command (`schema_key: imageResult`) that mirrors `LabResultsParser` end-to-end — extractor picks up Nabla's `imaging_results` section, builder originates the custom command, manifest declares it under the `objective` section.
- Scribe SPA wired up so Image Results renders as an editable narrative `CommandRow` next to Lab Results: added `imaging_results` to `DATA_FIELD` (`command-row.js`), `NARRATIVE_SECTIONS` (`soap-group.js`), and `ENSURE_KEYS` (`summary.js`).
- Fixed a rendering bug shared by Lab Results and Image Results: `_narrative_to_html` only split on `- ` and never converted `\n`, so free text typed between/after bullets was glued onto the previous `<li>` and embedded newlines collapsed to spaces in the chart-rendered view. The helper now splits on blank lines for paragraph breaks, groups bullet runs into `<ul>`, and joins non-bullet runs into a `<p>` with `<br>` separators.

## Test plan
- [x] `uv run pytest tests/hyperscribe/scribe/commands/test_image_results.py tests/hyperscribe/scribe/commands/test_builder.py tests/hyperscribe/scribe/commands/test_extractor.py` → 63/63 pass
- [x] Deploy and exercise with the bundled transcript fixture (`.cpa-workflow-artifacts/imaging_results_transcript.json` — vitals + lab review + 3 imaging studies); confirm:
  - [x] `imaging_results` proposal appears in the OBJECTIVE group under "Imaging Results"
  - [x] Narrative is editable inline (same UX as Lab Results)
  - [x] Saving inserts a `CustomCommand(schema_key="imageResult")` on the note
  - [x] Rendered HTML preserves bullet lists AND free-text line breaks AND blank-line paragraph gaps for both Lab Results and Image Results

🤖 Generated with [Claude Code](https://claude.com/claude-code)