### PR TITLE
Attach alert_facility metadata before commit (gated by AlertFacilityEnabled)

### DIFF
--- a/hyperscribe/scribe/api/session_view.py
+++ b/hyperscribe/scribe/api/session_view.py
@@ -1115,7 +1115,8 @@ class ScribeSessionView(StaffSessionAuthMixin, SimpleAPI):
                     status_code=HTTPStatus.BAD_REQUEST,
                 )
             ]
-        effects, metadata_pending, attempted = build_effects(commands, note_uuid)
+        feature_flags = {"AlertFacilityEnabled": bool(self.secrets.get("AlertFacilityEnabled"))}
+        effects, metadata_pending, attempted = build_effects(commands, note_uuid, feature_flags)
         audit_event(
             note_uuid,
             "INSERT_COMMANDS",

--- a/hyperscribe/scribe/commands/base.py
+++ b/hyperscribe/scribe/commands/base.py
@@ -79,8 +79,13 @@ class CommandParser(ABC):
         except Exception:
             return []
 
-    def pending_metadata(self, command: _BaseCommand, proposal: dict[str, Any] | None = None) -> dict[str, Any] | None:
-        """Return metadata to upsert in phase 2, or None. Override per command type."""
+    def pending_metadata(
+        self,
+        command: _BaseCommand,
+        proposal: dict[str, Any] | None = None,
+        feature_flags: dict[str, bool] | None = None,
+    ) -> dict[str, Any] | None:
+        """Return metadata to upsert, or None. Override per command type."""
         return None
 
     def build_stub(self, command_uuid: str, note_uuid: str) -> _BaseCommand:

--- a/hyperscribe/scribe/commands/builder.py
+++ b/hyperscribe/scribe/commands/builder.py
@@ -4,7 +4,6 @@ import json
 import uuid
 from typing import Any
 
-from canvas_generated.messages.effects_pb2 import Effect as _RawEffect
 from canvas_sdk.commands.base import _BaseCommand
 from canvas_sdk.effects import Effect
 from canvas_sdk.v1.data.note import Note
@@ -108,13 +107,18 @@ def validate_proposals(proposals: list[dict[str, Any]]) -> list[dict[str, Any]]:
 
 def _build_unvalidated_metadata_effect(
     command: _BaseCommand, key: str, value: str
-) -> _RawEffect:
+) -> Effect:
     """Construct UPSERT_COMMAND_METADATA directly. The SDK helper
     validates Command.objects.filter(...).exists() at Python build time,
     which fails before originate has been applied. Canvas processes effects
     sequentially, so originate (STAGED) -> metadata (apply-time check passes)
-    -> commit (COMMITTED with metadata attached) all in one response."""
-    return _RawEffect(
+    -> commit (COMMITTED with metadata attached) all in one response.
+
+    Note: `Effect` is imported from `canvas_sdk.effects` (which re-exports the
+    protobuf class) rather than the raw `canvas_generated.messages.effects_pb2`
+    path, because the plugin-runner sandbox allowlists the former but not the
+    latter."""
+    return Effect(
         type="UPSERT_COMMAND_METADATA",
         payload=json.dumps(
             {

--- a/hyperscribe/scribe/commands/builder.py
+++ b/hyperscribe/scribe/commands/builder.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+import json
 import uuid
 from typing import Any
 
+from canvas_generated.messages.effects_pb2 import Effect as _RawEffect
 from canvas_sdk.commands.base import _BaseCommand
 from canvas_sdk.effects import Effect
 from canvas_sdk.v1.data.note import Note
@@ -104,18 +106,52 @@ def validate_proposals(proposals: list[dict[str, Any]]) -> list[dict[str, Any]]:
     return validation_errors
 
 
+def _build_unvalidated_metadata_effect(
+    command: _BaseCommand, key: str, value: str
+) -> _RawEffect:
+    """Construct UPSERT_COMMAND_METADATA directly. The SDK helper
+    validates Command.objects.filter(...).exists() at Python build time,
+    which fails before originate has been applied. Canvas processes effects
+    sequentially, so originate (STAGED) -> metadata (apply-time check passes)
+    -> commit (COMMITTED with metadata attached) all in one response."""
+    return _RawEffect(
+        type="UPSERT_COMMAND_METADATA",
+        payload=json.dumps(
+            {
+                "data": {
+                    "schema_key": command.Meta.key,
+                    "command_id": str(command.command_uuid),
+                    "key": key,
+                    "value": value,
+                },
+            }
+        ),
+    )
+
+
 def build_effects(
-    proposals: list[dict[str, Any]], note_uuid: str
+    proposals: list[dict[str, Any]],
+    note_uuid: str,
+    feature_flags: dict[str, bool] | None = None,
 ) -> tuple[list[Effect], list[dict[str, Any]], list[dict[str, Any]]]:
     """Convert selected command proposals into Canvas SDK Effects.
 
     Each command is originated individually so a single failure doesn't
-    take down unrelated commands. Post-originate effects (commit/review)
-    follow immediately since Canvas processes effects sequentially.
+    take down unrelated commands. Effect order in the returned list is:
 
-    Returns (effects, metadata_pending, attempted) where:
-    - metadata_pending: items needing a second request for metadata upsert
-    - attempted: list of {command_uuid, command_type, display} for verification
+        originate_A, originate_B, ...,
+        metadata_A, metadata_B, ...,    # only when pending_metadata is non-empty
+        commit_A,   commit_B,   ...,
+
+    Canvas processes effects sequentially, so by the time a metadata effect
+    runs the corresponding originate effect has populated the Command row
+    in the DB; by the time the commit effect runs, the metadata row is
+    already attached to the (still STAGED) command.
+
+    Returns (effects, metadata_pending, attempted). `metadata_pending` is
+    always empty now (metadata is emitted inline); kept in the signature so
+    the legacy `/insert-metadata` pathway continues to be a no-op without
+    requiring a separate route change.
     """
     built: list[tuple[CommandParser, _BaseCommand, dict[str, Any]]] = []
     for proposal in proposals:
@@ -133,13 +169,14 @@ def build_effects(
         effects.append(command.originate())
 
     for builder, command, proposal in built:
-        effects.extend(builder.post_originate_effects(command, proposal))
+        meta = builder.pending_metadata(command, proposal, feature_flags)
+        if not meta:
+            continue
+        for key, value in (meta.get("metadata") or {}).items():
+            effects.append(_build_unvalidated_metadata_effect(command, key, value))
 
-    metadata_pending: list[dict[str, Any]] = []
     for builder, command, proposal in built:
-        meta = builder.pending_metadata(command, proposal)
-        if meta:
-            metadata_pending.append(meta)
+        effects.extend(builder.post_originate_effects(command, proposal))
 
     attempted = [
         {
@@ -150,7 +187,7 @@ def build_effects(
         for builder, command, proposal in built
     ]
 
-    return effects, metadata_pending, attempted
+    return effects, [], attempted
 
 
 def build_metadata_effects(pending: list[dict[str, Any]]) -> list[Effect]:

--- a/hyperscribe/scribe/commands/medication_statement.py
+++ b/hyperscribe/scribe/commands/medication_statement.py
@@ -116,15 +116,21 @@ class MedicationParser(CommandParser):
             command_uuid=command_uuid,
         )
 
-    def pending_metadata(self, command: _BaseCommand, proposal: dict[str, Any] | None = None) -> dict[str, Any] | None:
-        if proposal and proposal.get("data", {}).get("alert_facility"):
-            return {
-                "command_uuid": command.command_uuid,
-                "command_type": self.command_type,
-                "note_uuid": command.note_uuid,
-                "metadata": {"alert_facility": "true"},
-            }
-        return None
+    def pending_metadata(
+        self,
+        command: _BaseCommand,
+        proposal: dict[str, Any] | None = None,
+        feature_flags: dict[str, bool] | None = None,
+    ) -> dict[str, Any] | None:
+        if not (feature_flags or {}).get("AlertFacilityEnabled"):
+            return None
+        truthy = bool(proposal and proposal.get("data", {}).get("alert_facility"))
+        return {
+            "command_uuid": command.command_uuid,
+            "command_type": self.command_type,
+            "note_uuid": command.note_uuid,
+            "metadata": {"alert_facility": "Yes" if truthy else "No"},
+        }
 
     def build_stub(self, command_uuid: str, note_uuid: str) -> _BaseCommand:
         return MedicationStatementCommand(command_uuid=command_uuid, note_uuid=note_uuid)

--- a/hyperscribe/scribe/commands/stop_medication.py
+++ b/hyperscribe/scribe/commands/stop_medication.py
@@ -31,15 +31,21 @@ class StopMedicationParser(CommandParser):
             command_uuid=command_uuid,
         )
 
-    def pending_metadata(self, command: _BaseCommand, proposal: dict[str, Any] | None = None) -> dict[str, Any] | None:
-        if proposal and proposal.get("data", {}).get("alert_facility"):
-            return {
-                "command_uuid": command.command_uuid,
-                "command_type": self.command_type,
-                "note_uuid": command.note_uuid,
-                "metadata": {"alert_facility": "true"},
-            }
-        return None
+    def pending_metadata(
+        self,
+        command: _BaseCommand,
+        proposal: dict[str, Any] | None = None,
+        feature_flags: dict[str, bool] | None = None,
+    ) -> dict[str, Any] | None:
+        if not (feature_flags or {}).get("AlertFacilityEnabled"):
+            return None
+        truthy = bool(proposal and proposal.get("data", {}).get("alert_facility"))
+        return {
+            "command_uuid": command.command_uuid,
+            "command_type": self.command_type,
+            "note_uuid": command.note_uuid,
+            "metadata": {"alert_facility": "Yes" if truthy else "No"},
+        }
 
     def build_stub(self, command_uuid: str, note_uuid: str) -> _BaseCommand:
         return StopMedicationCommand(command_uuid=command_uuid, note_uuid=note_uuid)

--- a/tests/hyperscribe/scribe/api/test_session_view.py
+++ b/tests/hyperscribe/scribe/api/test_session_view.py
@@ -734,7 +734,7 @@ def test_insert_commands_success(mock_build: MagicMock) -> None:
     assert len(result) == 3  # JSONResponse + 2 effects
     assert result[1] is mock_effect_1
     assert result[2] is mock_effect_2
-    mock_build.assert_called_once_with(commands, "note-uuid-123")
+    mock_build.assert_called_once_with(commands, "note-uuid-123", {"AlertFacilityEnabled": False})
 
 
 @patch("hyperscribe.scribe.api.session_view.build_effects")

--- a/tests/hyperscribe/scribe/commands/test_builder.py
+++ b/tests/hyperscribe/scribe/commands/test_builder.py
@@ -1,5 +1,8 @@
+import json
 from typing import Any
 from unittest.mock import MagicMock, patch
+
+from canvas_generated.messages.effects_pb2 import EffectType
 
 from hyperscribe.scribe.commands.builder import build_effects, build_metadata_effects, validate_proposals
 
@@ -120,8 +123,81 @@ def test_build_effects_empty_list() -> None:
     assert attempted == []
 
 
-def test_build_effects_medication_with_alert_facility() -> None:
-    """Medication statement with alert_facility produces metadata_pending."""
+def test_build_effects_medication_with_alert_facility_emits_yes_inline() -> None:
+    """Flag on + alert_facility True: originate, UPSERT_COMMAND_METADATA="Yes" inline, commit.
+
+    Pins the exact protobuf payload so any SDK schema change for
+    UPSERT_COMMAND_METADATA breaks CI rather than silently diverging.
+    """
+    proposals: list[dict[str, Any]] = [
+        {
+            "command_type": "medication_statement",
+            "data": {"medication_text": "Lisinopril 10mg", "alert_facility": True},
+        },
+    ]
+    with patch("hyperscribe.scribe.commands.medication_statement.MedicationStatementCommand") as mock_med:
+        inst = MagicMock()
+        inst.originate.return_value = "med_originate"
+        inst.commit.return_value = "med_commit"
+        inst.command_uuid = "d6a96b19-a087-458a-9619-b46537a8c121"
+        inst.note_uuid = "5899e7bf-5ecb-4399-aceb-0e233bd4a8f0"
+        inst.Meta.key = "medicationStatement"
+        mock_med.return_value = inst
+
+        effects, metadata_pending, attempted = build_effects(
+            proposals,
+            "5899e7bf-5ecb-4399-aceb-0e233bd4a8f0",
+            feature_flags={"AlertFacilityEnabled": True},
+        )
+
+    assert len(effects) == 3
+    assert effects[0] == "med_originate"
+    assert effects[2] == "med_commit"
+    meta_effect = effects[1]
+    assert EffectType.Name(meta_effect.type) == "UPSERT_COMMAND_METADATA"
+    assert json.loads(meta_effect.payload) == {
+        "data": {
+            "schema_key": "medicationStatement",
+            "command_id": "d6a96b19-a087-458a-9619-b46537a8c121",
+            "key": "alert_facility",
+            "value": "Yes",
+        },
+    }
+    assert metadata_pending == []
+    assert len(attempted) == 1
+    assert attempted[0]["command_type"] == "medication_statement"
+
+
+def test_build_effects_medication_alert_facility_false_writes_no_inline() -> None:
+    """Flag on + alert_facility falsy: still emits inline metadata, value="No"."""
+    proposals: list[dict[str, Any]] = [
+        {
+            "command_type": "medication_statement",
+            "data": {"medication_text": "Lisinopril 10mg"},
+        },
+    ]
+    with patch("hyperscribe.scribe.commands.medication_statement.MedicationStatementCommand") as mock_med:
+        inst = MagicMock()
+        inst.originate.return_value = "med_originate"
+        inst.commit.return_value = "med_commit"
+        inst.command_uuid = "d6a96b19-a087-458a-9619-b46537a8c121"
+        inst.note_uuid = "5899e7bf-5ecb-4399-aceb-0e233bd4a8f0"
+        inst.Meta.key = "medicationStatement"
+        mock_med.return_value = inst
+
+        effects, metadata_pending, attempted = build_effects(
+            proposals,
+            "5899e7bf-5ecb-4399-aceb-0e233bd4a8f0",
+            feature_flags={"AlertFacilityEnabled": True},
+        )
+
+    assert len(effects) == 3
+    assert json.loads(effects[1].payload)["data"]["value"] == "No"
+    assert metadata_pending == []
+
+
+def test_build_effects_medication_alert_facility_flag_off_no_metadata() -> None:
+    """Flag off: no metadata effect emitted, just originate + commit."""
     proposals: list[dict[str, Any]] = [
         {
             "command_type": "medication_statement",
@@ -136,37 +212,14 @@ def test_build_effects_medication_with_alert_facility() -> None:
         inst.note_uuid = "5899e7bf-5ecb-4399-aceb-0e233bd4a8f0"
         mock_med.return_value = inst
 
-        effects, metadata_pending, attempted = build_effects(proposals, "5899e7bf-5ecb-4399-aceb-0e233bd4a8f0")
+        effects, metadata_pending, attempted = build_effects(
+            proposals,
+            "5899e7bf-5ecb-4399-aceb-0e233bd4a8f0",
+            feature_flags={"AlertFacilityEnabled": False},
+        )
 
-    assert len(effects) == 2  # 1 originate + 1 commit
-    assert effects[0] == "med_originate"
-    assert len(metadata_pending) == 1
-    assert metadata_pending[0]["command_uuid"] == "d6a96b19-a087-458a-9619-b46537a8c121"
-    assert metadata_pending[0]["command_type"] == "medication_statement"
-    assert metadata_pending[0]["metadata"] == {"alert_facility": "true"}
-    assert len(attempted) == 1
-    assert attempted[0]["command_type"] == "medication_statement"
-
-
-def test_build_effects_medication_without_alert_facility() -> None:
-    """Medication statement without alert_facility produces no metadata_pending."""
-    proposals: list[dict[str, Any]] = [
-        {
-            "command_type": "medication_statement",
-            "data": {"medication_text": "Lisinopril 10mg"},
-        },
-    ]
-    with patch("hyperscribe.scribe.commands.medication_statement.MedicationStatementCommand") as mock_med:
-        inst = MagicMock()
-        inst.originate.return_value = "med_originate"
-        inst.commit.return_value = "med_commit"
-        inst.command_uuid = "d6a96b19-a087-458a-9619-b46537a8c121"
-        inst.note_uuid = "5899e7bf-5ecb-4399-aceb-0e233bd4a8f0"
-        mock_med.return_value = inst
-
-        effects, metadata_pending, attempted = build_effects(proposals, "5899e7bf-5ecb-4399-aceb-0e233bd4a8f0")
-
-    assert len(effects) == 2  # 1 originate + 1 commit
+    assert len(effects) == 2
+    assert effects == ["med_originate", "med_commit"]
     assert metadata_pending == []
 
 

--- a/tests/hyperscribe/scribe/commands/test_medication_statement.py
+++ b/tests/hyperscribe/scribe/commands/test_medication_statement.py
@@ -240,3 +240,45 @@ def test_annotate_duplicates_no_patient(
     ]
     MedicationParser().annotate_duplicates(proposals, mock_note)
     assert proposals[0].already_documented is False
+
+
+def _make_med_command() -> MagicMock:
+    cmd = MagicMock()
+    cmd.command_uuid = "00000000-0000-0000-0000-000000000001"
+    cmd.note_uuid = "00000000-0000-0000-0000-000000000aaa"
+    return cmd
+
+
+def test_pending_metadata_flag_off_returns_none() -> None:
+    cmd = _make_med_command()
+    proposal = {"data": {"alert_facility": True}}
+    assert MedicationParser().pending_metadata(cmd, proposal, feature_flags={}) is None
+    assert MedicationParser().pending_metadata(cmd, proposal, feature_flags=None) is None
+    assert (
+        MedicationParser().pending_metadata(cmd, proposal, feature_flags={"AlertFacilityEnabled": False})
+        is None
+    )
+
+
+def test_pending_metadata_flag_on_alert_truthy_returns_yes() -> None:
+    cmd = _make_med_command()
+    proposal = {"data": {"alert_facility": True}}
+    result = MedicationParser().pending_metadata(cmd, proposal, feature_flags={"AlertFacilityEnabled": True})
+    assert result == {
+        "command_uuid": cmd.command_uuid,
+        "command_type": "medication_statement",
+        "note_uuid": cmd.note_uuid,
+        "metadata": {"alert_facility": "Yes"},
+    }
+
+
+def test_pending_metadata_flag_on_alert_falsy_defaults_to_no() -> None:
+    cmd = _make_med_command()
+    for proposal in (
+        {"data": {"alert_facility": False}},
+        {"data": {}},
+        None,
+    ):
+        result = MedicationParser().pending_metadata(cmd, proposal, feature_flags={"AlertFacilityEnabled": True})
+        assert result is not None
+        assert result["metadata"] == {"alert_facility": "No"}

--- a/tests/hyperscribe/scribe/commands/test_stop_medication.py
+++ b/tests/hyperscribe/scribe/commands/test_stop_medication.py
@@ -48,3 +48,49 @@ def test_command_type() -> None:
 
 def test_data_field_is_none() -> None:
     assert StopMedicationParser().data_field is None
+
+
+def _make_stop_command() -> MagicMock:
+    cmd = MagicMock()
+    cmd.command_uuid = "00000000-0000-0000-0000-0000000000b1"
+    cmd.note_uuid = "00000000-0000-0000-0000-0000000000bb"
+    return cmd
+
+
+def test_pending_metadata_flag_off_returns_none() -> None:
+    cmd = _make_stop_command()
+    proposal = {"data": {"alert_facility": True}}
+    assert StopMedicationParser().pending_metadata(cmd, proposal, feature_flags={}) is None
+    assert StopMedicationParser().pending_metadata(cmd, proposal, feature_flags=None) is None
+    assert (
+        StopMedicationParser().pending_metadata(cmd, proposal, feature_flags={"AlertFacilityEnabled": False})
+        is None
+    )
+
+
+def test_pending_metadata_flag_on_alert_truthy_returns_yes() -> None:
+    cmd = _make_stop_command()
+    proposal = {"data": {"alert_facility": True}}
+    result = StopMedicationParser().pending_metadata(
+        cmd, proposal, feature_flags={"AlertFacilityEnabled": True}
+    )
+    assert result == {
+        "command_uuid": cmd.command_uuid,
+        "command_type": "stop_medication",
+        "note_uuid": cmd.note_uuid,
+        "metadata": {"alert_facility": "Yes"},
+    }
+
+
+def test_pending_metadata_flag_on_alert_falsy_defaults_to_no() -> None:
+    cmd = _make_stop_command()
+    for proposal in (
+        {"data": {"alert_facility": False}},
+        {"data": {}},
+        None,
+    ):
+        result = StopMedicationParser().pending_metadata(
+            cmd, proposal, feature_flags={"AlertFacilityEnabled": True}
+        )
+        assert result is not None
+        assert result["metadata"] == {"alert_facility": "No"}


### PR DESCRIPTION
## Summary

Minimal surgical change off `feat/canvas-scribe` to store `alert_facility` metadata on `medication_statement` and `stop_medication` commands, attached to the command **before** the commit effect transitions it from STAGED → COMMITTED.

- **Format**: `alert_facility="Yes"` (when the UI toggle is on) or `"No"` (default when the feature flag is on but the toggle is off). Matches the `alert_facility_fields` plugin contract.
- **Server-side gate**: backend reads the `AlertFacilityEnabled` plugin secret. When unset → **zero** metadata effects emitted. When set → emit `"Yes"`/`"No"` on every medication_statement / stop_medication.
- **Timing**: metadata effect is inserted into the returned effect list between originate and commit. Canvas's sequential effect processor applies originate first (row appears as STAGED), then the metadata (apply-time SDK check passes), then commit (transitions to COMMITTED with metadata attached). All in a single round-trip.
- **SDK bypass**: `command.upsert_metadata(...)` runs a synchronous `Command.objects.filter(...).exists()` check at python-build time, which always fails before originate has been applied. The fix constructs `UPSERT_COMMAND_METADATA` as a raw protobuf Effect directly. A test pins the exact payload shape (effect type + JSON keys) so any future SDK schema change for that effect breaks CI rather than silently diverging in production.

## What this diff does NOT touch

- **Zero frontend changes**: no JS / CSS / static assets modified. The frontend already sends `data.alert_facility: true/false` and gates UI on the flag — both work unchanged.
- **No new constants** in `hyperscribe/libraries/constants.py`. The literals appear in 2 parsers and 1 test pin; centralising them would add diff without type safety.
- **No removal of `build_metadata_effects` / `/insert-metadata`**: kept byte-for-byte from baseline. `build_effects` now always returns an empty `metadata_pending`, so the legacy two-phase path becomes a no-op for alert_facility but is still available for any other future use.
- **No new audit events** in `session_view.py`. The existing `INSERT_COMMANDS` event already captures what matters.
- **No manifest change**. `AlertFacilityEnabled` plugin secret already exists in baseline.

## Files modified

| File | Purpose |
|---|---|
| `hyperscribe/scribe/commands/base.py` | Add `feature_flags` kwarg to default `pending_metadata` signature |
| `hyperscribe/scribe/commands/medication_statement.py` | Update `pending_metadata` to gate on flag and emit Yes/No |
| `hyperscribe/scribe/commands/stop_medication.py` | Same |
| `hyperscribe/scribe/commands/builder.py` | Add `_build_unvalidated_metadata_effect` helper; emit metadata inline between originate and commit |
| `hyperscribe/scribe/api/session_view.py` | One line: build `feature_flags` from `self.secrets` and pass to `build_effects` |
| Tests | Pinning the payload shape + flag on/off + Yes/No defaults for both command types |

`git diff --stat origin/feat/canvas-scribe..HEAD`: 9 files changed, 242 insertions(+), 46 deletions(-)

## Test plan

- [x] `uv run pytest tests/` — all 2003 tests pass
- [x] `uv run mypy hyperscribe/` — clean (198 files)
- [x] Manual sanity in test environment:
  - With `AlertFacilityEnabled` unset → insert a medication command, confirm no `alert_facility` row exists in the Canvas `command_metadata` table for that command.
  - With `AlertFacilityEnabled` set → insert two medication commands (one toggle on, one off). Both have an `alert_facility` row, values `"Yes"` and `"No"` respectively. Same for stop_medication.
  - Confirm metadata is attached on the same response as the commit (no second-phase round-trip; visible immediately on first read).
  - Confirm no other command type writes an `alert_facility` row.

## Risk

The raw protobuf bypass deliberately skips one SDK build-time validator. The dedicated test pins the exact payload shape (effect type literal + JSON schema), so a future SDK breaking change for `UPSERT_COMMAND_METADATA` produces a clean CI failure rather than silent divergence. No native SDK alternative exists for attaching metadata before commit within a single effect-handler response.

🤖 Generated with [Claude Code](https://claude.com/claude-code)