### PR TITLE
Default alert_facility to Yes at command-creation source

### DIFF
--- a/hyperscribe/scribe/commands/medication_statement.py
+++ b/hyperscribe/scribe/commands/medication_statement.py
@@ -46,6 +46,7 @@ class MedicationParser(CommandParser):
             data={
                 "medication_text": lines[0],
                 "fdb_code": _unstructured_coding(lines[0]),
+                "alert_facility": True,
             },
         )
 
@@ -57,6 +58,7 @@ class MedicationParser(CommandParser):
                 data={
                     "medication_text": line,
                     "fdb_code": _unstructured_coding(line),
+                    "alert_facility": True,
                 },
             )
             for line in _parse_medication_lines(text)

--- a/hyperscribe/scribe/recommendations/medication_statement.py
+++ b/hyperscribe/scribe/recommendations/medication_statement.py
@@ -103,6 +103,7 @@ class MedicationRecommender(BaseRecommender):
                         "medication_text": display,
                         "fdb_code": fdb_code,
                         "sig": med.sig,
+                        "alert_facility": True,
                     },
                     section_key="_recommended",
                 )

--- a/hyperscribe/scribe/static/summary.js
+++ b/hyperscribe/scribe/static/summary.js
@@ -902,7 +902,7 @@ export function Scribe({ noteId, patientId, staffId, staffName, providerName, pr
     setCommands(prev => [...prev, {
       command_type: 'medication_statement',
       display: '',
-      data: { medication_text: '', fdb_code: null, sig: '' },
+      data: { medication_text: '', fdb_code: null, sig: '', alert_facility: true },
       selected: true,
       section_key: '_objective_ad_hoc',
       already_documented: false,
@@ -995,7 +995,7 @@ export function Scribe({ noteId, patientId, staffId, staffName, providerName, pr
     setCommands(prev => [...prev, {
       command_type: 'stop_medication',
       display: '',
-      data: { medication_id: null, medication_name: '', rationale: '' },
+      data: { medication_id: null, medication_name: '', rationale: '', alert_facility: true },
       selected: true,
       section_key: '_objective_ad_hoc',
       already_documented: false,

--- a/tests/hyperscribe/scribe/commands/test_medication_statement.py
+++ b/tests/hyperscribe/scribe/commands/test_medication_statement.py
@@ -53,11 +53,13 @@ def test_extract_all_multiple() -> None:
     assert proposals[0].data == {
         "medication_text": "Lisinopril 10mg",
         "fdb_code": _unstructured_coding("Lisinopril 10mg"),
+        "alert_facility": True,
     }
     assert proposals[1].display == "Metformin 500mg"
     assert proposals[1].data == {
         "medication_text": "Metformin 500mg",
         "fdb_code": _unstructured_coding("Metformin 500mg"),
+        "alert_facility": True,
     }
 
 


### PR DESCRIPTION
## Summary

Default `alert_facility` to `true` for new `medication_statement` and `stop_medication` commands by stamping the field at the **5 emission sites** in the codebase. Every other piece of logic (backend `pending_metadata` Yes/No mapping, UI toggle predicates, toggle onClick semantics) is unchanged.

## Why this approach

The alternative — flipping read-side predicates to a tri-valued "missing means true" semantics — would have required touching 4 backend lines, 7 UI predicates, and the toggle's onClick logic, introducing a new mental model (missing ≠ false ≠ true). Stamping at the source keeps the model two-valued, with `data.alert_facility` always explicitly `true` or `false` from the moment a command is created onward. Existing pending_metadata logic (`bool(data.get("alert_facility"))` → `"Yes" if truthy else "No"`) just works.

## The 5 sites

| File | Function | Change |
|---|---|---|
| `hyperscribe/scribe/commands/medication_statement.py` | `MedicationParser.extract` | add `"alert_facility": True` to data dict |
| `hyperscribe/scribe/commands/medication_statement.py` | `MedicationParser.extract_all` | same |
| `hyperscribe/scribe/recommendations/medication_statement.py` | `MedicationRecommender.recommend` | same |
| `hyperscribe/scribe/static/summary.js` | `handleAddMedication` | add `alert_facility: true` to data |
| `hyperscribe/scribe/static/summary.js` | `handleAddStopMedication` | same |

`stop_medication` has no AI extractor (`StopMedicationParser.extract` returns `None`); it's only created via the UI add handler. `medication_statement` is created via extract / extract_all / recommender / UI add — all covered.

## Diff size

4 files changed, 7 insertions(+), 2 deletions(-). No predicate changes, no signature changes, no new abstractions.

## Test plan

- [x] `uv run pytest tests/` — full suite passes (2003)
- [x] `uv run mypy hyperscribe/` — clean (198 files)
- [ ] Manual sanity in test env with `AlertFacilityEnabled` set:
  - AI-extracted medication: badge shows by default in view mode; toggle ON by default in edit mode; `command_metadata.alert_facility="Yes"` after insert.
  - UI-added medication / stop_medication via "Add" button: same behavior.
  - AI-recommended medication: same behavior.
  - Toggle OFF + save → `"No"`. Toggle back ON + save → `"Yes"`.
- [ ] `AlertFacilityEnabled` unset → no metadata rows written (unchanged from PR #269).

## Risk

The only invariant introduced is "every new emission site for these two command types must stamp `alert_facility`". The 5 existing sites are easy to grep (`command_type=['"]medication_statement['"]` and `command_type=['"]stop_medication['"]`). If a future site is added without the stamp, that command writes `"No"` — same as the pre-#269 baseline, not a regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)