### PR TITLE
scribe: surface vitals validation errors instead of generic insert-commands 500

### DIFF
--- a/hyperscribe/scribe/api/session_view.py
+++ b/hyperscribe/scribe/api/session_view.py
@@ -215,9 +215,7 @@ def _save_summary(note_id: str, payload: dict[str, Any]) -> None:
 
 def _infer_mode_for_heal(note_dbid: int, has_user_content: bool) -> str:
     """Pick the user's mode from session artifacts. '' means no signal — don't heal."""
-    events = (
-        ScribeAuditLog.objects.filter(note_id=note_dbid).values_list("events", flat=True).first()
-    ) or []
+    events = (ScribeAuditLog.objects.filter(note_id=note_dbid).values_list("events", flat=True).first()) or []
     last_start = ""
     for event in events:
         event_type = event.get("type") if isinstance(event, dict) else None
@@ -245,10 +243,7 @@ def _has_user_authored_content(row: dict[str, Any]) -> bool:
     if row["note_data"]:
         return True
     commands = row["commands"] or []
-    return any(
-        isinstance(cmd, dict) and not cmd.get("_template_inserted")
-        for cmd in commands
-    )
+    return any(isinstance(cmd, dict) and not cmd.get("_template_inserted") for cmd in commands)
 
 
 def _load_summary(note_id: str) -> dict[str, Any] | None:
@@ -1161,7 +1156,19 @@ class ScribeSessionView(StaffSessionAuthMixin, SimpleAPI):
                 )
             ]
         feature_flags = {"AlertFacilityEnabled": bool(self.secrets.get("AlertFacilityEnabled"))}
-        effects, metadata_pending, attempted = build_effects(commands, note_uuid, feature_flags)
+        effects, metadata_pending, attempted, build_errors = build_effects(commands, note_uuid, feature_flags)
+        if build_errors:
+            audit_event(
+                note_uuid,
+                "VALIDATION_FAILED",
+                {"errors": build_errors, "source": "build"},
+            )
+            return [
+                JSONResponse(
+                    {"error": "Validation failed", "validation_errors": build_errors},
+                    status_code=HTTPStatus.BAD_REQUEST,
+                )
+            ]
         audit_event(
             note_uuid,
             "INSERT_COMMANDS",

--- a/hyperscribe/scribe/application/transcript_app.py
+++ b/hyperscribe/scribe/application/transcript_app.py
@@ -62,11 +62,7 @@ def _scribe_tab_has_content(note_dbid: int) -> bool:
     if items:
         return True
 
-    summary = (
-        ScribeSummary.objects.filter(note_id=note_dbid)
-        .values("note_data", "commands", "approved")
-        .first()
-    )
+    summary = ScribeSummary.objects.filter(note_id=note_dbid).values("note_data", "commands", "approved").first()
     if not summary:
         return False
     if summary["approved"] or summary["commands"]:

--- a/hyperscribe/scribe/commands/builder.py
+++ b/hyperscribe/scribe/commands/builder.py
@@ -7,6 +7,7 @@ from typing import Any
 from canvas_sdk.commands.base import _BaseCommand
 from canvas_sdk.effects import Effect
 from canvas_sdk.v1.data.note import Note
+from pydantic import ValidationError
 
 from hyperscribe.scribe.backend.models import CommandProposal
 from hyperscribe.scribe.commands.adjust_prescription import AdjustPrescriptionParser
@@ -105,9 +106,7 @@ def validate_proposals(proposals: list[dict[str, Any]]) -> list[dict[str, Any]]:
     return validation_errors
 
 
-def _build_unvalidated_metadata_effect(
-    command: _BaseCommand, key: str, value: str
-) -> Effect:
+def _build_unvalidated_metadata_effect(command: _BaseCommand, key: str, value: str) -> Effect:
     """Construct UPSERT_COMMAND_METADATA directly. The SDK helper
     validates Command.objects.filter(...).exists() at Python build time,
     which fails before originate has been applied. Canvas processes effects
@@ -133,11 +132,21 @@ def _build_unvalidated_metadata_effect(
     )
 
 
+def _format_pydantic_errors(exc: ValidationError) -> list[str]:
+    """Render pydantic errors as actionable one-liners for the provider UI."""
+    messages: list[str] = []
+    for err in exc.errors():
+        loc = ".".join(str(part) for part in err.get("loc", ())) or "value"
+        msg = err.get("msg", "Invalid value")
+        messages.append(f"{loc}: {msg} (got {err['input']!r})")
+    return messages
+
+
 def build_effects(
     proposals: list[dict[str, Any]],
     note_uuid: str,
     feature_flags: dict[str, bool] | None = None,
-) -> tuple[list[Effect], list[dict[str, Any]], list[dict[str, Any]]]:
+) -> tuple[list[Effect], list[dict[str, Any]], list[dict[str, Any]], list[dict[str, Any]]]:
     """Convert selected command proposals into Canvas SDK Effects.
 
     Each command is originated individually so a single failure doesn't
@@ -152,21 +161,44 @@ def build_effects(
     in the DB; by the time the commit effect runs, the metadata row is
     already attached to the (still STAGED) command.
 
-    Returns (effects, metadata_pending, attempted). `metadata_pending` is
-    always empty now (metadata is emitted inline); kept in the signature so
-    the legacy `/insert-metadata` pathway continues to be a no-op without
-    requiring a separate route change.
+    Returns (effects, metadata_pending, attempted, build_errors). When a
+    proposal fails SDK construction (e.g. a vital outside its pydantic range),
+    that single command is skipped and a structured error in the same shape as
+    ``validate_proposals`` is appended to ``build_errors``; sibling commands
+    still produce effects. ``metadata_pending`` is always empty now (metadata
+    is emitted inline); kept in the signature so the legacy ``/insert-metadata``
+    pathway continues to be a no-op without requiring a separate route change.
     """
     built: list[tuple[CommandParser, _BaseCommand, dict[str, Any]]] = []
+    build_errors: list[dict[str, Any]] = []
     for proposal in proposals:
         builder = _BUILDERS.get(proposal.get("command_type", ""))
         if builder is None:
             continue
-        command = builder.build(proposal.get("data", {}), note_uuid, str(uuid.uuid4()))
+        try:
+            command = builder.build(proposal.get("data", {}), note_uuid, str(uuid.uuid4()))
+        except ValidationError as exc:
+            build_errors.append(
+                {
+                    "command_type": proposal.get("command_type", ""),
+                    "display": (proposal.get("display") or "")[:80],
+                    "errors": _format_pydantic_errors(exc),
+                }
+            )
+            continue
+        except ValueError as exc:
+            build_errors.append(
+                {
+                    "command_type": proposal.get("command_type", ""),
+                    "display": (proposal.get("display") or "")[:80],
+                    "errors": [str(exc)],
+                }
+            )
+            continue
         built.append((builder, command, proposal))
 
     if not built:
-        return [], [], []
+        return [], [], [], build_errors
 
     effects: list[Effect] = []
     for _, command, _ in built:
@@ -191,7 +223,7 @@ def build_effects(
         for builder, command, proposal in built
     ]
 
-    return effects, [], attempted
+    return effects, [], attempted, build_errors
 
 
 def build_metadata_effects(pending: list[dict[str, Any]]) -> list[Effect]:

--- a/hyperscribe/scribe/commands/builder.py
+++ b/hyperscribe/scribe/commands/builder.py
@@ -133,13 +133,79 @@ def _build_unvalidated_metadata_effect(command: _BaseCommand, key: str, value: s
 
 
 def _format_pydantic_errors(exc: ValidationError) -> list[str]:
-    """Render pydantic errors as actionable one-liners for the provider UI."""
+    """Render pydantic errors as actionable one-liners for the provider UI.
+
+    The rendered message names the failing field and states the constraint in plain
+    English. Raw ``input`` values are **never** echoed except when they are explicit
+    PHI-safe scalars (``int``/``float``/``bool``/``None``); any other type — string,
+    list, dict, model — is omitted entirely. This matters because ``build_errors``
+    is persisted to the ``VALIDATION_FAILED`` audit log by ``session_view`` and
+    returned in the HTTP response body, both of which are HIPAA-sensitive sinks
+    when the LLM emits free-text content into a numeric/enum field.
+    """
     messages: list[str] = []
     for err in exc.errors():
+        # INVARIANT: ``loc`` parts are developer-defined field names from the scribe
+        # SDK command models, not LLM/user input — safe to render in clinician-facing
+        # error UI and to persist to the VALIDATION_FAILED audit log. Pydantic
+        # surfaces dict keys into ``loc`` for ``dict[K, V]``-typed fields; do NOT add
+        # ``dict[str, X]``-typed fields to scribe command models without sanitizing,
+        # or the LLM-supplied keys will leak into ``loc`` and through this renderer.
         loc = ".".join(str(part) for part in err.get("loc", ())) or "value"
-        msg = err.get("msg", "Invalid value")
-        messages.append(f"{loc}: {msg} (got {err['input']!r})")
+        err_type = err.get("type", "")
+        ctx = err.get("ctx", {}) or {}
+        input_value = err.get("input")
+        if err_type == "greater_than_equal" and "ge" in ctx:
+            messages.append(f"{loc} must be greater than or equal to {ctx['ge']} ({_render_input(input_value)})")
+        elif err_type == "less_than_equal" and "le" in ctx:
+            messages.append(f"{loc} must be less than or equal to {ctx['le']} ({_render_input(input_value)})")
+        elif err_type == "greater_than" and "gt" in ctx:
+            messages.append(f"{loc} must be greater than {ctx['gt']} ({_render_input(input_value)})")
+        elif err_type == "less_than" and "lt" in ctx:
+            messages.append(f"{loc} must be less than {ctx['lt']} ({_render_input(input_value)})")
+        elif err_type == "string_too_long" and "max_length" in ctx:
+            messages.append(f"{loc} must be at most {ctx['max_length']} characters")
+        elif err_type == "string_too_short" and "min_length" in ctx:
+            messages.append(f"{loc} must be at least {ctx['min_length']} characters")
+        elif err_type == "missing":
+            messages.append(f"{loc} is required")
+        elif err_type in ("value_error", "assertion_error"):
+            # Latent defense: custom ``@field_validator`` decorators (none today in
+            # ``hyperscribe/scribe/commands/``) raise ``ValueError(f"... {x} ...")``,
+            # and Pydantic embeds the raw input into ``msg`` for these types — a PHI
+            # vector via the ``else:`` fallback. Surface only the field name.
+            messages.append(f"{loc}: invalid value")
+        else:
+            # Fallback for unmapped pydantic types (int_type/int_parsing/bool_type/
+            # etc.). Keep the pydantic message but only echo input when it's a
+            # PHI-safe scalar; otherwise omit entirely.
+            msg = err.get("msg", "Invalid value")
+            if isinstance(input_value, (int, float, bool)) or input_value is None:
+                messages.append(f"{loc}: {msg} (currently {input_value!r})")
+            else:
+                messages.append(f"{loc}: {msg}")
     return messages
+
+
+def _render_input(value: Any) -> str:
+    """Render an ``input`` value for inclusion in an error message.
+
+    For the if/elif branches above, the constraint is on a numeric field and the
+    value is expected to be a number — but the LLM can emit free text into a
+    numeric field, in which case the value is unsafe to echo (PHI risk). Anything
+    that isn't an explicit PHI-safe scalar collapses to ``"currently invalid"``.
+    """
+    if isinstance(value, (int, float, bool)) or value is None:
+        return f"currently {value}"
+    return "currently invalid"
+
+
+# Friendly command-type labels used as the ``display`` prefix on build_errors,
+# so the UI renders e.g. "Vitals: pulse must be greater than or equal to 30
+# (currently 8)" instead of dumping the raw input free-text as the prefix.
+_BUILD_ERROR_LABELS: dict[str, str] = {
+    "vitals": "Vitals",
+}
 
 
 def build_effects(
@@ -172,26 +238,45 @@ def build_effects(
     built: list[tuple[CommandParser, _BaseCommand, dict[str, Any]]] = []
     build_errors: list[dict[str, Any]] = []
     for proposal in proposals:
-        builder = _BUILDERS.get(proposal.get("command_type", ""))
+        command_type = proposal.get("command_type", "")
+        builder = _BUILDERS.get(command_type)
         if builder is None:
             continue
+        # Resolve the user-facing label once per proposal. The LLM-supplied
+        # ``display`` is untrusted free text and may contain PHI when the model
+        # echoes raw field content; prefer the friendly label from
+        # ``_BUILD_ERROR_LABELS`` for any command type we render error UI for.
+        display = _BUILD_ERROR_LABELS.get(command_type) or (proposal.get("display") or "")[:80]
         try:
             command = builder.build(proposal.get("data", {}), note_uuid, str(uuid.uuid4()))
         except ValidationError as exc:
             build_errors.append(
                 {
-                    "command_type": proposal.get("command_type", ""),
-                    "display": (proposal.get("display") or "")[:80],
+                    "command_type": command_type,
+                    "display": display,
                     "errors": _format_pydantic_errors(exc),
                 }
             )
             continue
-        except ValueError as exc:
+        except ValueError:
+            # Non-pydantic value coercion error. Today the only path that lands
+            # here is the enum coercion in vitals.py:70 for an LLM-supplied
+            # free-text ``blood_pressure_position_and_site``. We deliberately do
+            # NOT include ``str(exc)`` because Python's standard enum
+            # ``ValueError`` embeds the raw input verbatim ("'<raw>' is not a
+            # valid <EnumName>"), and that string is persisted to the
+            # VALIDATION_FAILED audit log by session_view — a HIPAA leak sink
+            # when the raw input is free-text PHI. But we DO surface the field
+            # name (developer-defined, PHI-safe) so the clinician sees which
+            # field is wrong and can re-prompt; a bare generic message is
+            # unactionable. If another command type starts raising plain
+            # ``ValueError`` from ``build()``, this hardcoded field name will
+            # become misleading — add a per-command-type lookup at that point.
             build_errors.append(
                 {
-                    "command_type": proposal.get("command_type", ""),
-                    "display": (proposal.get("display") or "")[:80],
-                    "errors": [str(exc)],
+                    "command_type": command_type,
+                    "display": display,
+                    "errors": ["blood_pressure_position_and_site: invalid value"],
                 }
             )
             continue

--- a/hyperscribe/scribe/commands/image_results.py
+++ b/hyperscribe/scribe/commands/image_results.py
@@ -18,10 +18,7 @@ def _to_ascii_html(text: str) -> str:
     to prevent both garbled markup from benign clinical text (``K+ <3.0``)
     and script injection from untrusted transcript/textarea input.
     """
-    return "".join(
-        c if ord(c) < 128 else f"&#{ord(c)};"
-        for c in html.escape(text, quote=True)
-    )
+    return "".join(c if ord(c) < 128 else f"&#{ord(c)};" for c in html.escape(text, quote=True))
 
 
 def _narrative_to_html(text: str) -> str:
@@ -43,9 +40,7 @@ def _narrative_to_html(text: str) -> str:
                 while i < len(lines) and lines[i].startswith("- "):
                     bullets.append(lines[i][2:].strip())
                     i += 1
-                parts.append(
-                    "<ul>" + "".join(f"<li>{_to_ascii_html(b)}</li>" for b in bullets) + "</ul>"
-                )
+                parts.append("<ul>" + "".join(f"<li>{_to_ascii_html(b)}</li>" for b in bullets) + "</ul>")
             else:
                 paragraph: list[str] = []
                 while i < len(lines) and not lines[i].startswith("- "):

--- a/hyperscribe/scribe/commands/lab_results.py
+++ b/hyperscribe/scribe/commands/lab_results.py
@@ -18,10 +18,7 @@ def _to_ascii_html(text: str) -> str:
     to prevent both garbled markup from benign clinical text (``K+ <3.0``)
     and script injection from untrusted transcript/textarea input.
     """
-    return "".join(
-        c if ord(c) < 128 else f"&#{ord(c)};"
-        for c in html.escape(text, quote=True)
-    )
+    return "".join(c if ord(c) < 128 else f"&#{ord(c)};" for c in html.escape(text, quote=True))
 
 
 def _narrative_to_html(text: str) -> str:
@@ -43,9 +40,7 @@ def _narrative_to_html(text: str) -> str:
                 while i < len(lines) and lines[i].startswith("- "):
                     bullets.append(lines[i][2:].strip())
                     i += 1
-                parts.append(
-                    "<ul>" + "".join(f"<li>{_to_ascii_html(b)}</li>" for b in bullets) + "</ul>"
-                )
+                parts.append("<ul>" + "".join(f"<li>{_to_ascii_html(b)}</li>" for b in bullets) + "</ul>")
             else:
                 paragraph: list[str] = []
                 while i < len(lines) and not lines[i].startswith("- "):

--- a/tests/hyperscribe/scribe/api/test_session_view.py
+++ b/tests/hyperscribe/scribe/api/test_session_view.py
@@ -610,18 +610,14 @@ def test_save_summary_defaults(mock_note: MagicMock, mock_summary: MagicMock) ->
 
 @patch("hyperscribe.scribe.api.session_view.ScribeSummary")
 @patch("hyperscribe.scribe.api.session_view.Note")
-def test_save_summary_omits_mode_and_template_when_absent(
-    mock_note: MagicMock, mock_summary: MagicMock
-) -> None:
+def test_save_summary_omits_mode_and_template_when_absent(mock_note: MagicMock, mock_summary: MagicMock) -> None:
     """Autosave paths that don't send mode / selected_template_name must not
     overwrite those columns — update_or_create only touches keys present in
     defaults, so omitting them preserves the existing DB values."""
     mock_note.objects.values_list.return_value.get.return_value = 42
 
     view = _helper_instance()
-    view.request = SimpleNamespace(
-        body=json.dumps({"note_id": "42", "note": {}, "commands": [], "approved": False})
-    )
+    view.request = SimpleNamespace(body=json.dumps({"note_id": "42", "note": {}, "commands": [], "approved": False}))
     result = view.post_save_summary()
 
     assert result[0].status_code == HTTPStatus.OK
@@ -632,9 +628,7 @@ def test_save_summary_omits_mode_and_template_when_absent(
 
 @patch("hyperscribe.scribe.api.session_view.ScribeSummary")
 @patch("hyperscribe.scribe.api.session_view.Note")
-def test_save_summary_clears_template_when_explicitly_null(
-    mock_note: MagicMock, mock_summary: MagicMock
-) -> None:
+def test_save_summary_clears_template_when_explicitly_null(mock_note: MagicMock, mock_summary: MagicMock) -> None:
     """Deselecting the visit template sends `selected_template_name: null`,
     which must clear the DB column (write '') rather than be silently dropped."""
     mock_note.objects.values_list.return_value.get.return_value = 42
@@ -660,17 +654,13 @@ def test_save_summary_clears_template_when_explicitly_null(
 
 @patch("hyperscribe.scribe.api.session_view.ScribeSummary")
 @patch("hyperscribe.scribe.api.session_view.Note")
-def test_save_summary_clears_mode_when_explicitly_null(
-    mock_note: MagicMock, mock_summary: MagicMock
-) -> None:
+def test_save_summary_clears_mode_when_explicitly_null(mock_note: MagicMock, mock_summary: MagicMock) -> None:
     """Symmetric to template deselect: explicit `mode: null` clears the column."""
     mock_note.objects.values_list.return_value.get.return_value = 42
 
     view = _helper_instance()
     view.request = SimpleNamespace(
-        body=json.dumps(
-            {"note_id": "42", "note": {}, "commands": [], "approved": False, "mode": None}
-        )
+        body=json.dumps({"note_id": "42", "note": {}, "commands": [], "approved": False, "mode": None})
     )
     result = view.post_save_summary()
 
@@ -1073,7 +1063,7 @@ def test_insert_commands_success(mock_build: MagicMock) -> None:
         {"command_uuid": "u1", "command_type": "hpi", "display": "Back pain"},
         {"command_uuid": "u2", "command_type": "plan", "display": "Start naproxen"},
     ]
-    mock_build.return_value = ([mock_effect_1, mock_effect_2], [], attempted)
+    mock_build.return_value = ([mock_effect_1, mock_effect_2], [], attempted, [])
 
     view = _helper_instance()
     commands = [
@@ -1109,6 +1099,7 @@ def test_insert_commands_with_metadata_pending(mock_build: MagicMock) -> None:
         [mock_effect],
         pending,
         [{"command_uuid": "uuid-1", "command_type": "medication_statement", "display": "Test"}],
+        [],
     )
 
     view = _helper_instance()
@@ -1125,7 +1116,7 @@ def test_insert_commands_with_metadata_pending(mock_build: MagicMock) -> None:
 
 @patch("hyperscribe.scribe.api.session_view.build_effects")
 def test_insert_commands_empty(mock_build: MagicMock) -> None:
-    mock_build.return_value = ([], [], [])
+    mock_build.return_value = ([], [], [], [])
 
     view = _helper_instance()
     view.request = SimpleNamespace(body=json.dumps({"note_uuid": "note-uuid-123", "commands": []}))
@@ -1154,6 +1145,30 @@ def test_insert_commands_invalid_json() -> None:
 
     assert result[0].status_code == HTTPStatus.BAD_REQUEST
     assert "Invalid JSON" in json.loads(result[0].content)["error"]
+
+
+@patch("hyperscribe.scribe.api.session_view.audit_event")
+def test_insert_commands_build_validation_error_returns_400(mock_audit: MagicMock) -> None:
+    """Regression for KOALA-5476: pydantic ValidationError during build() returns 400 with
+    a structured ``validation_errors`` payload rather than crashing the whole batch with a 500."""
+    view = _helper_instance()
+    commands = [
+        {"command_type": "vitals", "data": {"pulse": 8}, "display": "HR 8"},
+    ]
+    view.request = SimpleNamespace(body=json.dumps({"note_uuid": "note-uuid-123", "commands": commands}))
+    result = view.post_insert_commands()
+
+    assert len(result) == 1
+    assert result[0].status_code == HTTPStatus.BAD_REQUEST
+    body = json.loads(result[0].content)
+    assert body["error"] == "Validation failed"
+    assert len(body["validation_errors"]) == 1
+    err = body["validation_errors"][0]
+    assert err["command_type"] == "vitals"
+    assert err["display"] == "HR 8"
+    assert any("pulse" in msg for msg in err["errors"])
+    mock_audit.assert_called_once()
+    assert mock_audit.call_args.args[1] == "VALIDATION_FAILED"
 
 
 # --- /insert-metadata ---
@@ -1476,10 +1491,7 @@ def test_get_ordering_providers_returns_all_results(mock_staff_cls: MagicMock) -
     which silently dropped real prescribers (e.g. anyone with a last name past
     "Cu...") on customers with larger staff rosters.
     """
-    staff_objects = [
-        SimpleNamespace(id=f"key-{i}", credentialed_name=f"Provider {i:03d} MD")
-        for i in range(75)
-    ]
+    staff_objects = [SimpleNamespace(id=f"key-{i}", credentialed_name=f"Provider {i:03d} MD") for i in range(75)]
     ordered_qs = MagicMock(spec=QuerySet)
     ordered_qs.__iter__.return_value = iter(staff_objects)
     distinct_qs = MagicMock(spec=QuerySet)
@@ -1825,12 +1837,14 @@ def test_generate_summary_preserves_mode_and_template(
     view = _helper_instance()
     view.secrets["AnthropicAPIKey"] = "test-key"
     view.request = SimpleNamespace(
-        body=json.dumps({
-            "note_id": "55",
-            "note_uuid": "55",
-            "mode": "ai",
-            "selected_template_name": "Subsequent Visit",
-        })
+        body=json.dumps(
+            {
+                "note_id": "55",
+                "note_uuid": "55",
+                "mode": "ai",
+                "selected_template_name": "Subsequent Visit",
+            }
+        )
     )
     result = view.post_generate_summary()
 
@@ -1902,10 +1916,12 @@ def test_generate_summary_preserves_mode_from_db_when_not_in_request(
     view.secrets["AnthropicAPIKey"] = "test-key"
     # Frontend request does NOT include mode or selected_template_name.
     view.request = SimpleNamespace(
-        body=json.dumps({
-            "note_id": "55",
-            "note_uuid": "55",
-        })
+        body=json.dumps(
+            {
+                "note_id": "55",
+                "note_uuid": "55",
+            }
+        )
     )
     result = view.post_generate_summary()
 
@@ -1990,9 +2006,7 @@ def test_generate_summary_does_not_clobber_concurrent_save_on_cas_miss(
     view = _helper_instance()
     view.secrets["AnthropicAPIKey"] = "test-key"
     # Frontend doesn't include mode in the generate-summary request body.
-    view.request = SimpleNamespace(
-        body=json.dumps({"note_id": "55", "note_uuid": "55"})
-    )
+    view.request = SimpleNamespace(body=json.dumps({"note_id": "55", "note_uuid": "55"}))
     result = view.post_generate_summary()
 
     assert result[0].status_code == HTTPStatus.OK

--- a/tests/hyperscribe/scribe/api/test_session_view.py
+++ b/tests/hyperscribe/scribe/api/test_session_view.py
@@ -1150,7 +1150,11 @@ def test_insert_commands_invalid_json() -> None:
 @patch("hyperscribe.scribe.api.session_view.audit_event")
 def test_insert_commands_build_validation_error_returns_400(mock_audit: MagicMock) -> None:
     """Regression for KOALA-5476: pydantic ValidationError during build() returns 400 with
-    a structured ``validation_errors`` payload rather than crashing the whole batch with a 500."""
+    a structured ``validation_errors`` payload rather than crashing the whole batch with a 500.
+
+    Per UAT feedback on PR #273, the response surfaces a friendly command-name label
+    in ``display`` and a plain-English error sentence in ``errors`` (no raw input
+    dictionary, no Pydantic-internal wording)."""
     view = _helper_instance()
     commands = [
         {"command_type": "vitals", "data": {"pulse": 8}, "display": "HR 8"},
@@ -1165,8 +1169,8 @@ def test_insert_commands_build_validation_error_returns_400(mock_audit: MagicMoc
     assert len(body["validation_errors"]) == 1
     err = body["validation_errors"][0]
     assert err["command_type"] == "vitals"
-    assert err["display"] == "HR 8"
-    assert any("pulse" in msg for msg in err["errors"])
+    assert err["display"] == "Vitals"
+    assert err["errors"] == ["pulse must be greater than or equal to 30 (currently 8)"]
     mock_audit.assert_called_once()
     assert mock_audit.call_args.args[1] == "VALIDATION_FAILED"
 

--- a/tests/hyperscribe/scribe/application/test_transcript_app.py
+++ b/tests/hyperscribe/scribe/application/test_transcript_app.py
@@ -240,21 +240,15 @@ def test_scribe_tab_has_content_no_rows(mock_transcript: MagicMock, mock_summary
 
 @patch("hyperscribe.scribe.application.transcript_app.ScribeSummary")
 @patch("hyperscribe.scribe.application.transcript_app.ScribeTranscript")
-def test_scribe_tab_has_content_transcript_items(
-    mock_transcript: MagicMock, mock_summary: MagicMock
-) -> None:
-    mock_transcript.objects.filter.return_value.values_list.return_value.first.return_value = [
-        {"text": "Hello"}
-    ]
+def test_scribe_tab_has_content_transcript_items(mock_transcript: MagicMock, mock_summary: MagicMock) -> None:
+    mock_transcript.objects.filter.return_value.values_list.return_value.first.return_value = [{"text": "Hello"}]
     assert _scribe_tab_has_content(99) is True
     mock_summary.objects.filter.assert_not_called()
 
 
 @patch("hyperscribe.scribe.application.transcript_app.ScribeSummary")
 @patch("hyperscribe.scribe.application.transcript_app.ScribeTranscript")
-def test_scribe_tab_has_content_summary_approved(
-    mock_transcript: MagicMock, mock_summary: MagicMock
-) -> None:
+def test_scribe_tab_has_content_summary_approved(mock_transcript: MagicMock, mock_summary: MagicMock) -> None:
     mock_transcript.objects.filter.return_value.values_list.return_value.first.return_value = []
     mock_summary.objects.filter.return_value.values.return_value.first.return_value = {
         "note_data": {},
@@ -266,9 +260,7 @@ def test_scribe_tab_has_content_summary_approved(
 
 @patch("hyperscribe.scribe.application.transcript_app.ScribeSummary")
 @patch("hyperscribe.scribe.application.transcript_app.ScribeTranscript")
-def test_scribe_tab_has_content_summary_commands(
-    mock_transcript: MagicMock, mock_summary: MagicMock
-) -> None:
+def test_scribe_tab_has_content_summary_commands(mock_transcript: MagicMock, mock_summary: MagicMock) -> None:
     mock_transcript.objects.filter.return_value.values_list.return_value.first.return_value = []
     mock_summary.objects.filter.return_value.values.return_value.first.return_value = {
         "note_data": {},
@@ -280,9 +272,7 @@ def test_scribe_tab_has_content_summary_commands(
 
 @patch("hyperscribe.scribe.application.transcript_app.ScribeSummary")
 @patch("hyperscribe.scribe.application.transcript_app.ScribeTranscript")
-def test_scribe_tab_has_content_summary_text(
-    mock_transcript: MagicMock, mock_summary: MagicMock
-) -> None:
+def test_scribe_tab_has_content_summary_text(mock_transcript: MagicMock, mock_summary: MagicMock) -> None:
     mock_transcript.objects.filter.return_value.values_list.return_value.first.return_value = []
     mock_summary.objects.filter.return_value.values.return_value.first.return_value = {
         "note_data": {"sections": [{"key": "cc", "title": "CC", "text": "Patient reports cough."}]},
@@ -294,9 +284,7 @@ def test_scribe_tab_has_content_summary_text(
 
 @patch("hyperscribe.scribe.application.transcript_app.ScribeSummary")
 @patch("hyperscribe.scribe.application.transcript_app.ScribeTranscript")
-def test_scribe_tab_has_content_summary_blank(
-    mock_transcript: MagicMock, mock_summary: MagicMock
-) -> None:
+def test_scribe_tab_has_content_summary_blank(mock_transcript: MagicMock, mock_summary: MagicMock) -> None:
     """A ScribeSummary row exists from a manual-mode template flip, but the user
     typed nothing and never clicked Approve."""
     mock_transcript.objects.filter.return_value.values_list.return_value.first.return_value = []
@@ -310,9 +298,7 @@ def test_scribe_tab_has_content_summary_blank(
 
 @patch("hyperscribe.scribe.application.transcript_app.ScribeSummary")
 @patch("hyperscribe.scribe.application.transcript_app.ScribeTranscript")
-def test_scribe_tab_has_content_whitespace_only(
-    mock_transcript: MagicMock, mock_summary: MagicMock
-) -> None:
+def test_scribe_tab_has_content_whitespace_only(mock_transcript: MagicMock, mock_summary: MagicMock) -> None:
     mock_transcript.objects.filter.return_value.values_list.return_value.first.return_value = []
     mock_summary.objects.filter.return_value.values.return_value.first.return_value = {
         "note_data": {"sections": [{"key": "cc", "title": "CC", "text": "   \n  "}]},
@@ -327,9 +313,7 @@ def test_scribe_tab_has_content_whitespace_only(
 
 @patch("hyperscribe.scribe.application.transcript_app._scribe_tab_has_content")
 @patch("hyperscribe.scribe.application.transcript_app.Helper.editable_note")
-def test_open_by_default_editable_note(
-    mock_editable: MagicMock, mock_has_content: MagicMock
-) -> None:
+def test_open_by_default_editable_note(mock_editable: MagicMock, mock_has_content: MagicMock) -> None:
     mock_editable.return_value = True
     mock_has_content.return_value = False  # irrelevant for editable
     event = Event(EventRequest(context='{"note_id": 7}'))
@@ -339,9 +323,7 @@ def test_open_by_default_editable_note(
 
 @patch("hyperscribe.scribe.application.transcript_app._scribe_tab_has_content")
 @patch("hyperscribe.scribe.application.transcript_app.Helper.editable_note")
-def test_open_by_default_locked_with_content(
-    mock_editable: MagicMock, mock_has_content: MagicMock
-) -> None:
+def test_open_by_default_locked_with_content(mock_editable: MagicMock, mock_has_content: MagicMock) -> None:
     mock_editable.return_value = False
     mock_has_content.return_value = True
     event = Event(EventRequest(context='{"note_id": 7}'))
@@ -351,9 +333,7 @@ def test_open_by_default_locked_with_content(
 
 @patch("hyperscribe.scribe.application.transcript_app._scribe_tab_has_content")
 @patch("hyperscribe.scribe.application.transcript_app.Helper.editable_note")
-def test_open_by_default_locked_blank_defers_to_legacy(
-    mock_editable: MagicMock, mock_has_content: MagicMock
-) -> None:
+def test_open_by_default_locked_blank_defers_to_legacy(mock_editable: MagicMock, mock_has_content: MagicMock) -> None:
     mock_editable.return_value = False
     mock_has_content.return_value = False
     event = Event(EventRequest(context='{"note_id": 7}'))

--- a/tests/hyperscribe/scribe/clients/nabla/test_backend.py
+++ b/tests/hyperscribe/scribe/clients/nabla/test_backend.py
@@ -126,9 +126,7 @@ def test_generate_note_physical_exam_excludes_vitals() -> None:
 
     payload = mock_rest_client.generate_note.call_args.args[0]
     pe_entries = [
-        entry
-        for entry in payload["note_sections_customization"]
-        if entry.get("section_key") == "PHYSICAL_EXAM"
+        entry for entry in payload["note_sections_customization"] if entry.get("section_key") == "PHYSICAL_EXAM"
     ]
     assert len(pe_entries) == 1, "expected exactly one PHYSICAL_EXAM customization entry"
     pe_entry = pe_entries[0]
@@ -139,10 +137,16 @@ def test_generate_note_physical_exam_excludes_vitals() -> None:
     # The four vital signs called out in the requirement, each in long form and
     # in its common abbreviation/synonym, so the prompt blocks paraphrased leaks.
     required_terms = (
-        "heart rate", "pulse", "hr",
-        "blood pressure", "bp",
-        "oxygen saturation", "spo2",
-        "breaths per minute", "respiratory rate", "rr",
+        "heart rate",
+        "pulse",
+        "hr",
+        "blood pressure",
+        "bp",
+        "oxygen saturation",
+        "spo2",
+        "breaths per minute",
+        "respiratory rate",
+        "rr",
     )
     for term in required_terms:
         assert term in instruction_lower, f"missing exclusion term {term!r}"

--- a/tests/hyperscribe/scribe/commands/test_builder.py
+++ b/tests/hyperscribe/scribe/commands/test_builder.py
@@ -82,7 +82,9 @@ def test_build_effects_routes_all_types() -> None:
             inst.note_uuid = "5899e7bf-5ecb-4399-aceb-0e233bd4a8f0"
             mock.return_value = inst
 
-        effects, metadata_pending, attempted = build_effects(proposals, "5899e7bf-5ecb-4399-aceb-0e233bd4a8f0")
+        effects, metadata_pending, attempted, build_errors = build_effects(
+            proposals, "5899e7bf-5ecb-4399-aceb-0e233bd4a8f0"
+        )
 
     # 14 originates + 13 commits + 1 review (prescription)
     assert len(effects) == 28
@@ -110,14 +112,14 @@ def test_build_effects_routes_all_types() -> None:
 
 def test_build_effects_unknown_type_skipped() -> None:
     proposals: list[dict[str, Any]] = [{"command_type": "unknown_type", "data": {"foo": "bar"}}]
-    effects, metadata_pending, attempted = build_effects(proposals, "note-uuid")
+    effects, metadata_pending, attempted, build_errors = build_effects(proposals, "note-uuid")
     assert effects == []
     assert metadata_pending == []
     assert attempted == []
 
 
 def test_build_effects_empty_list() -> None:
-    effects, metadata_pending, attempted = build_effects([], "note-uuid")
+    effects, metadata_pending, attempted, build_errors = build_effects([], "note-uuid")
     assert effects == []
     assert metadata_pending == []
     assert attempted == []
@@ -144,7 +146,7 @@ def test_build_effects_medication_with_alert_facility_emits_yes_inline() -> None
         inst.Meta.key = "medicationStatement"
         mock_med.return_value = inst
 
-        effects, metadata_pending, attempted = build_effects(
+        effects, metadata_pending, attempted, build_errors = build_effects(
             proposals,
             "5899e7bf-5ecb-4399-aceb-0e233bd4a8f0",
             feature_flags={"AlertFacilityEnabled": True},
@@ -185,7 +187,7 @@ def test_build_effects_medication_alert_facility_false_writes_no_inline() -> Non
         inst.Meta.key = "medicationStatement"
         mock_med.return_value = inst
 
-        effects, metadata_pending, attempted = build_effects(
+        effects, metadata_pending, attempted, build_errors = build_effects(
             proposals,
             "5899e7bf-5ecb-4399-aceb-0e233bd4a8f0",
             feature_flags={"AlertFacilityEnabled": True},
@@ -212,7 +214,7 @@ def test_build_effects_medication_alert_facility_flag_off_no_metadata() -> None:
         inst.note_uuid = "5899e7bf-5ecb-4399-aceb-0e233bd4a8f0"
         mock_med.return_value = inst
 
-        effects, metadata_pending, attempted = build_effects(
+        effects, metadata_pending, attempted, build_errors = build_effects(
             proposals,
             "5899e7bf-5ecb-4399-aceb-0e233bd4a8f0",
             feature_flags={"AlertFacilityEnabled": False},
@@ -399,3 +401,61 @@ def test_validate_proposals_refill_and_adjust() -> None:
     ]
     errors = validate_proposals(proposals)
     assert len(errors) == 2
+
+
+def test_build_effects_vitals_out_of_range_returns_build_error() -> None:
+    """Pydantic ValidationError from the SDK is caught and surfaced as a structured per-command error.
+
+    Regression for KOALA-5476: previously, a single out-of-range vital made the entire
+    insert-commands batch crash with a generic 500.
+    """
+    proposals: list[dict[str, Any]] = [
+        {"command_type": "vitals", "data": {"pulse": 8}, "display": "HR 8"},
+    ]
+    effects, metadata_pending, attempted, build_errors = build_effects(proposals, "note-uuid")
+    assert effects == []
+    assert metadata_pending == []
+    assert attempted == []
+    assert len(build_errors) == 1
+    err = build_errors[0]
+    assert err["command_type"] == "vitals"
+    assert err["display"] == "HR 8"
+    assert any("pulse" in msg for msg in err["errors"])
+    assert any("8" in msg for msg in err["errors"])
+
+
+def test_build_effects_one_invalid_does_not_block_others() -> None:
+    """A bad vitals proposal does not prevent other commands from being originated."""
+    proposals: list[dict[str, Any]] = [
+        {"command_type": "vitals", "data": {"pulse": 8}, "display": "HR 8"},
+        {"command_type": "rfv", "data": {"comment": "Headache"}, "display": "Headache"},
+    ]
+    with patch("hyperscribe.scribe.commands.rfv.ReasonForVisitCommand") as mock_rfv:
+        inst = MagicMock()
+        inst.originate.return_value = "rfv_originate"
+        inst.commit.return_value = "rfv_commit"
+        inst.command_uuid = "rfv-uuid"
+        mock_rfv.return_value = inst
+        effects, metadata_pending, attempted, build_errors = build_effects(proposals, "note-uuid")
+    assert effects == ["rfv_originate", "rfv_commit"]
+    assert len(attempted) == 1
+    assert attempted[0]["command_type"] == "rfv"
+    assert len(build_errors) == 1
+    assert build_errors[0]["command_type"] == "vitals"
+
+
+def test_build_effects_vitals_invalid_enum_returns_build_error() -> None:
+    """ValueError raised by enum coercion in build() is also caught and surfaced."""
+    proposals: list[dict[str, Any]] = [
+        {
+            "command_type": "vitals",
+            "data": {"blood_pressure_position_and_site": 999},
+            "display": "BP bad site",
+        },
+    ]
+    effects, metadata_pending, attempted, build_errors = build_effects(proposals, "note-uuid")
+    assert effects == []
+    assert attempted == []
+    assert len(build_errors) == 1
+    assert build_errors[0]["command_type"] == "vitals"
+    assert build_errors[0]["display"] == "BP bad site"

--- a/tests/hyperscribe/scribe/commands/test_builder.py
+++ b/tests/hyperscribe/scribe/commands/test_builder.py
@@ -1,10 +1,72 @@
 import json
 from typing import Any
+
+import pytest
 from unittest.mock import MagicMock, patch
 
 from canvas_generated.messages.effects_pb2 import EffectType
+from pydantic import BaseModel, Field, ValidationError
 
-from hyperscribe.scribe.commands.builder import build_effects, build_metadata_effects, validate_proposals
+from hyperscribe.scribe.commands.builder import (
+    _format_pydantic_errors,
+    build_effects,
+    build_metadata_effects,
+    validate_proposals,
+)
+
+
+def _make_constrained_int_model(
+    ge: int | None = None,
+    le: int | None = None,
+    gt: int | None = None,
+    lt: int | None = None,
+) -> type[BaseModel]:
+    """Build a tiny Pydantic v2 model with the requested numeric constraint on ``value``.
+
+    Used by the type-string guard test to exercise each branch of
+    ``_format_pydantic_errors`` against a real ValidationError, not a synthesized dict.
+    """
+    field_kwargs: dict[str, Any] = {}
+    if ge is not None:
+        field_kwargs["ge"] = ge
+    if le is not None:
+        field_kwargs["le"] = le
+    if gt is not None:
+        field_kwargs["gt"] = gt
+    if lt is not None:
+        field_kwargs["lt"] = lt
+
+    class _NumModel(BaseModel):
+        value: int = Field(**field_kwargs)
+
+    return _NumModel
+
+
+def _make_constrained_str_model(
+    min_length: int | None = None,
+    max_length: int | None = None,
+) -> type[BaseModel]:
+    """Build a Pydantic v2 model with a string-length constraint on ``value``."""
+    field_kwargs: dict[str, Any] = {}
+    if min_length is not None:
+        field_kwargs["min_length"] = min_length
+    if max_length is not None:
+        field_kwargs["max_length"] = max_length
+
+    class _StrModel(BaseModel):
+        value: str = Field(**field_kwargs)
+
+    return _StrModel
+
+
+def _make_required_field_model() -> type[BaseModel]:
+    """Build a Pydantic v2 model with a required field (no default) to trigger
+    ``type=missing``."""
+
+    class _ReqModel(BaseModel):
+        value: int
+
+    return _ReqModel
 
 
 def test_build_effects_routes_all_types() -> None:
@@ -408,6 +470,11 @@ def test_build_effects_vitals_out_of_range_returns_build_error() -> None:
 
     Regression for KOALA-5476: previously, a single out-of-range vital made the entire
     insert-commands batch crash with a generic 500.
+
+    Per UAT feedback on PR #273, the error message must be a concise plain-English
+    sentence (no raw input dump, no Pydantic-internal phrasing). The display label
+    is set to the friendly command name ("Vitals") so the rendered output reads
+    "Vitals: pulse must be greater than or equal to 30 (currently 8)".
     """
     proposals: list[dict[str, Any]] = [
         {"command_type": "vitals", "data": {"pulse": 8}, "display": "HR 8"},
@@ -419,9 +486,85 @@ def test_build_effects_vitals_out_of_range_returns_build_error() -> None:
     assert len(build_errors) == 1
     err = build_errors[0]
     assert err["command_type"] == "vitals"
-    assert err["display"] == "HR 8"
-    assert any("pulse" in msg for msg in err["errors"])
-    assert any("8" in msg for msg in err["errors"])
+    assert err["display"] == "Vitals"
+    assert err["errors"] == ["pulse must be greater than or equal to 30 (currently 8)"]
+
+
+def test_build_effects_vitals_too_low_message_format() -> None:
+    """A too-low vital value renders as ``<field> must be greater than or equal to <min> (currently <value>)``."""
+    proposals: list[dict[str, Any]] = [
+        {
+            "command_type": "vitals",
+            "data": {"blood_pressure_systole": 5},
+            "display": "BP 5/?",
+        },
+    ]
+    _, _, _, build_errors = build_effects(proposals, "note-uuid")
+    assert build_errors[0]["display"] == "Vitals"
+    assert build_errors[0]["errors"] == [
+        "blood_pressure_systole must be greater than or equal to 30 (currently 5)",
+    ]
+
+
+def test_build_effects_vitals_too_high_message_format() -> None:
+    """A too-high vital value renders as ``<field> must be less than or equal to <max> (currently <value>)``."""
+    proposals: list[dict[str, Any]] = [
+        {
+            "command_type": "vitals",
+            "data": {"blood_pressure_systole": 999},
+            "display": "BP 999/?",
+        },
+    ]
+    _, _, _, build_errors = build_effects(proposals, "note-uuid")
+    assert build_errors[0]["display"] == "Vitals"
+    assert build_errors[0]["errors"] == [
+        "blood_pressure_systole must be less than or equal to 305 (currently 999)",
+    ]
+
+
+def test_build_effects_vitals_multiple_invalid_fields_each_render_one_line() -> None:
+    """When multiple vital fields fail validation, each error renders on its own line.
+
+    Mirrors what the UI does (one ``<li>`` per error). The display label stays "Vitals";
+    each error is the field-specific sentence with no raw input dictionary in it.
+    """
+    proposals: list[dict[str, Any]] = [
+        {
+            "command_type": "vitals",
+            "data": {"blood_pressure_systole": 5, "pulse": 8},
+            "display": "BP 5/?, HR 8",
+        },
+    ]
+    _, _, _, build_errors = build_effects(proposals, "note-uuid")
+    err = build_errors[0]
+    assert err["display"] == "Vitals"
+    assert set(err["errors"]) == {
+        "blood_pressure_systole must be greater than or equal to 30 (currently 5)",
+        "pulse must be greater than or equal to 30 (currently 8)",
+    }
+    # No raw input dictionary or Pydantic-internal phrasing leaks into the message.
+    for msg in err["errors"]:
+        assert "Input should be" not in msg
+        assert "(got " not in msg
+
+
+def test_build_effects_vitals_string_too_long_does_not_leak_input() -> None:
+    """For string-length violations, the message names the field and limit but never includes
+    the raw input string (which could carry free-text PHI in the note field)."""
+    long_note = "x" * 200
+    proposals: list[dict[str, Any]] = [
+        {
+            "command_type": "vitals",
+            "data": {"pulse": 80, "note": long_note},
+            "display": "HR 80, long note",
+        },
+    ]
+    _, _, _, build_errors = build_effects(proposals, "note-uuid")
+    err = build_errors[0]
+    assert err["display"] == "Vitals"
+    assert err["errors"] == ["note must be at most 150 characters"]
+    for msg in err["errors"]:
+        assert long_note not in msg
 
 
 def test_build_effects_one_invalid_does_not_block_others() -> None:
@@ -445,7 +588,12 @@ def test_build_effects_one_invalid_does_not_block_others() -> None:
 
 
 def test_build_effects_vitals_invalid_enum_returns_build_error() -> None:
-    """ValueError raised by enum coercion in build() is also caught and surfaced."""
+    """ValueError raised by enum coercion in build() is also caught and surfaced.
+
+    The display label uses the friendly command name ("Vitals"), matching the
+    ValidationError branch — the LLM-supplied ``display`` field is untrusted
+    free text and must not leak into the response payload.
+    """
     proposals: list[dict[str, Any]] = [
         {
             "command_type": "vitals",
@@ -458,4 +606,184 @@ def test_build_effects_vitals_invalid_enum_returns_build_error() -> None:
     assert attempted == []
     assert len(build_errors) == 1
     assert build_errors[0]["command_type"] == "vitals"
-    assert build_errors[0]["display"] == "BP bad site"
+    assert build_errors[0]["display"] == "Vitals"
+
+
+def test_build_effects_vitals_int_type_does_not_leak_input() -> None:
+    """A non-numeric pulse hits the ``else:`` fallback in ``_format_pydantic_errors``.
+
+    The fallback path historically echoed ``input_value`` verbatim into the rendered
+    message, which would leak any LLM-supplied free text (potentially PHI) into both
+    the HTTP response and the persisted ``VALIDATION_FAILED`` audit log.
+
+    The PHI marker MUST NOT appear anywhere in the rendered error string.
+    """
+    phi_marker = "PHI_PLACEHOLDER_xyz"
+    proposals: list[dict[str, Any]] = [
+        {
+            "command_type": "vitals",
+            "data": {"pulse": phi_marker},
+            "display": "HR free text",
+        },
+    ]
+    _, _, _, build_errors = build_effects(proposals, "note-uuid")
+    assert len(build_errors) == 1
+    assert build_errors[0]["command_type"] == "vitals"
+    assert build_errors[0]["display"] == "Vitals"
+    rendered = " ".join(build_errors[0]["errors"])
+    assert phi_marker not in rendered, f"PHI marker leaked into error message: {rendered!r}"
+
+
+def test_build_effects_vitals_enum_value_error_does_not_leak_input() -> None:
+    """An invalid ``blood_pressure_position_and_site`` raises ``ValueError`` from enum
+    coercion in ``VitalsParser.build`` (the parser's ``validate`` does not guard the
+    enum domain, see commands/base.py:44). The legacy implementation used
+    ``str(exc)`` in the ``except ValueError`` branch, which echoes the raw input
+    value verbatim into the message.
+
+    Critical leak sink: ``session_view.py`` writes ``build_errors`` to
+    ``audit_event("VALIDATION_FAILED", source="build")``, so any echoed PHI is
+    persisted to audit logs — a direct HIPAA violation.
+
+    The PHI marker MUST NOT appear anywhere in the rendered error string.
+    """
+    phi_marker = "PHI_PLACEHOLDER_abc"
+    proposals: list[dict[str, Any]] = [
+        {
+            "command_type": "vitals",
+            "data": {"blood_pressure_position_and_site": phi_marker},
+            "display": "BP free text",
+        },
+    ]
+    _, _, _, build_errors = build_effects(proposals, "note-uuid")
+    assert len(build_errors) == 1
+    assert build_errors[0]["command_type"] == "vitals"
+    assert build_errors[0]["display"] == "Vitals"
+    rendered = " ".join(build_errors[0]["errors"])
+    assert phi_marker not in rendered, f"PHI marker leaked into error message: {rendered!r}"
+
+
+def test_value_error_branch_message_preserves_field_name() -> None:
+    """The ``except ValueError`` branch must surface the failing field name (``loc``)
+    so the clinician knows *which* field is wrong and can re-prompt / correct it.
+
+    Paired contract with ``test_build_effects_vitals_enum_value_error_does_not_leak_input``:
+    that test guards against echoing the *raw input* (PHI leak); this test guards against
+    over-sanitizing into a generic message that loses the field name (a UX regression).
+    Together they pin both directions: field name in, raw input out.
+
+    The field name is developer-defined (``blood_pressure_position_and_site``), not
+    user/LLM input, so PHI-safe. See the loc-invariant comment in builder.py.
+    """
+    proposals: list[dict[str, Any]] = [
+        {
+            "command_type": "vitals",
+            "data": {"blood_pressure_position_and_site": "sitting-and-on-the-left-wrist"},
+            "display": "BP bad site",
+        },
+    ]
+    _, _, _, build_errors = build_effects(proposals, "note-uuid")
+    assert len(build_errors) == 1
+    rendered = " ".join(build_errors[0]["errors"])
+    assert "blood_pressure_position_and_site" in rendered, (
+        f"Field name missing from rendered ValueError-branch message: {rendered!r}. "
+        "Clinician must see which field is wrong; a generic 'invalid value' is unactionable."
+    )
+
+
+# Pydantic v2 type-string contract: each row is (type_string, model_factory, bad_input,
+# friendly_substring). The point of this parametrized test is to catch the day Pydantic
+# renames any of these type strings — the current implementation matches them by string
+# in an if/elif chain, and a silent rename would degrade every match into the ``else:``
+# fallback (PHI-leak branch). This test fails loudly instead.
+@pytest.mark.parametrize(
+    ("type_string", "model_factory", "bad_input", "friendly_substring"),
+    [
+        (
+            "greater_than_equal",
+            lambda: _make_constrained_int_model(ge=10),
+            5,
+            "greater than or equal to 10",
+        ),
+        (
+            "less_than_equal",
+            lambda: _make_constrained_int_model(le=100),
+            200,
+            "less than or equal to 100",
+        ),
+        (
+            "greater_than",
+            lambda: _make_constrained_int_model(gt=0),
+            -1,
+            "greater than 0",
+        ),
+        (
+            "less_than",
+            lambda: _make_constrained_int_model(lt=100),
+            200,
+            "less than 100",
+        ),
+        (
+            "string_too_long",
+            lambda: _make_constrained_str_model(max_length=5),
+            "x" * 10,
+            "at most 5 characters",
+        ),
+        (
+            "string_too_short",
+            lambda: _make_constrained_str_model(min_length=5),
+            "ab",
+            "at least 5 characters",
+        ),
+        (
+            "missing",
+            lambda: _make_required_field_model(),
+            None,  # sentinel - factory triggers a missing-field error itself
+            "is required",
+        ),
+    ],
+)
+def test_format_pydantic_errors_recognized_type_strings_take_friendly_path(
+    type_string: str,
+    model_factory: Any,
+    bad_input: Any,
+    friendly_substring: str,
+) -> None:
+    """Each Pydantic v2 type string in the if/elif chain must produce its friendly
+    rendering — never the ``else:`` fallback (which is the PHI-leak branch).
+
+    Mechanism: construct a real Pydantic v2 BaseModel with the matching constraint,
+    instantiate with bad input, catch the real ValidationError, run it through
+    ``_format_pydantic_errors``, then assert (a) the resulting message contains the
+    friendly substring and (b) the canonical "Input should be" / "(got " Pydantic
+    phrasing is absent — which is how the fallback branch renders.
+    """
+    model = model_factory()
+    try:
+        if type_string == "missing":
+            model()  # type: ignore[call-arg]
+        else:
+            model(value=bad_input)
+    except ValidationError as exc:
+        # First confirm Pydantic still emits this exact type string. If this assertion
+        # fails, Pydantic renamed the type and the if/elif chain in builder.py is now
+        # silently degrading into the fallback.
+        emitted_types = [err.get("type") for err in exc.errors()]
+        assert type_string in emitted_types, (
+            f"Pydantic emitted {emitted_types!r}, expected {type_string!r}. "
+            "The if/elif chain in _format_pydantic_errors will now fall through "
+            "to the PHI-leak fallback for this constraint."
+        )
+        messages = _format_pydantic_errors(exc)
+    else:
+        raise AssertionError("Expected ValidationError but none was raised")
+
+    rendered = " ".join(messages)
+    assert friendly_substring in rendered, (
+        f"Friendly substring {friendly_substring!r} missing from rendered "
+        f"messages {messages!r} - likely fell through to the fallback branch."
+    )
+    # The fallback formats as "<loc>: <msg> (currently <input>)" where <msg> is
+    # Pydantic's "Input should be ..." phrasing. None of those markers should appear.
+    assert "Input should be" not in rendered
+    assert "(got " not in rendered

--- a/tests/hyperscribe/scribe/commands/test_image_results.py
+++ b/tests/hyperscribe/scribe/commands/test_image_results.py
@@ -89,9 +89,7 @@ def test_narrative_to_html_hard_line_break_within_paragraph() -> None:
 def test_narrative_to_html_bullets_can_resume_after_paragraph() -> None:
     text = "- first\n\nintroductory text\n\n- second\n- third"
     assert _narrative_to_html(text) == (
-        "<ul><li>first</li></ul>"
-        "<p>introductory text</p>"
-        "<ul><li>second</li><li>third</li></ul>"
+        "<ul><li>first</li></ul><p>introductory text</p><ul><li>second</li><li>third</li></ul>"
     )
 
 

--- a/tests/hyperscribe/scribe/commands/test_medication_statement.py
+++ b/tests/hyperscribe/scribe/commands/test_medication_statement.py
@@ -254,10 +254,7 @@ def test_pending_metadata_flag_off_returns_none() -> None:
     proposal = {"data": {"alert_facility": True}}
     assert MedicationParser().pending_metadata(cmd, proposal, feature_flags={}) is None
     assert MedicationParser().pending_metadata(cmd, proposal, feature_flags=None) is None
-    assert (
-        MedicationParser().pending_metadata(cmd, proposal, feature_flags={"AlertFacilityEnabled": False})
-        is None
-    )
+    assert MedicationParser().pending_metadata(cmd, proposal, feature_flags={"AlertFacilityEnabled": False}) is None
 
 
 def test_pending_metadata_flag_on_alert_truthy_returns_yes() -> None:

--- a/tests/hyperscribe/scribe/commands/test_stop_medication.py
+++ b/tests/hyperscribe/scribe/commands/test_stop_medication.py
@@ -62,18 +62,13 @@ def test_pending_metadata_flag_off_returns_none() -> None:
     proposal = {"data": {"alert_facility": True}}
     assert StopMedicationParser().pending_metadata(cmd, proposal, feature_flags={}) is None
     assert StopMedicationParser().pending_metadata(cmd, proposal, feature_flags=None) is None
-    assert (
-        StopMedicationParser().pending_metadata(cmd, proposal, feature_flags={"AlertFacilityEnabled": False})
-        is None
-    )
+    assert StopMedicationParser().pending_metadata(cmd, proposal, feature_flags={"AlertFacilityEnabled": False}) is None
 
 
 def test_pending_metadata_flag_on_alert_truthy_returns_yes() -> None:
     cmd = _make_stop_command()
     proposal = {"data": {"alert_facility": True}}
-    result = StopMedicationParser().pending_metadata(
-        cmd, proposal, feature_flags={"AlertFacilityEnabled": True}
-    )
+    result = StopMedicationParser().pending_metadata(cmd, proposal, feature_flags={"AlertFacilityEnabled": True})
     assert result == {
         "command_uuid": cmd.command_uuid,
         "command_type": "stop_medication",
@@ -89,8 +84,6 @@ def test_pending_metadata_flag_on_alert_falsy_defaults_to_no() -> None:
         {"data": {}},
         None,
     ):
-        result = StopMedicationParser().pending_metadata(
-            cmd, proposal, feature_flags={"AlertFacilityEnabled": True}
-        )
+        result = StopMedicationParser().pending_metadata(cmd, proposal, feature_flags={"AlertFacilityEnabled": True})
         assert result is not None
         assert result["metadata"] == {"alert_facility": "No"}

--- a/uv.lock
+++ b/uv.lock
@@ -2,6 +2,13 @@ version = 1
 revision = 3
 requires-python = ">=3.11, <3.13"
 
+[options]
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer-span = "P7D"
+
+[options.exclude-newer-package]
+canvas = { timestamp = "0001-01-01T00:00:00Z", span = "PT1S" }
+
 [[package]]
 name = "annotated-doc"
 version = "0.0.4"


### PR DESCRIPTION
[KOALA-5476](https://canvasmedical.atlassian.net/browse/KOALA-5476)

## Summary

When a Scribe-generated command contains a value outside an SDK pydantic range (the production trigger was a dictation parser emitting `pulse: 8`), the `/insert-commands` route was raising the `ValidationError` out of `build_effects` unhandled, returning a generic 500. The frontend's `res.json()` then threw into its catch block and rendered the catch-all `"Failed to insert commands"` banner — blocking every command on the note, not just the bad one. The Brigade evidence on the ticket shows a provider hitting Approve 8+ times against the same opaque error.

This change makes `build_effects` catch `pydantic.ValidationError` and `ValueError` (the enum-coerce path) per command, translates them into the existing `{command_type, display, errors[]}` shape that `validate_proposals` already uses, and returns them via a new fourth element in the tuple. `post_insert_commands` returns 400 with `validation_errors` when present — same payload shape the frontend already renders in the `summary.js` "Please fix before approving" list. Sibling commands aren't blocked by one bad value, and the SDK stays the source of truth (no need to mirror pydantic ranges in `VitalsParser.validate`).

The commit also picks up `ruff format` drift in 8 unrelated scribe modules and a `uv` lockfile metadata migration — both surfaced by the pre-commit hook running over the whole repo. Logical changes are confined to the four files listed first below.

## Files changed

**Logic:**
- `hyperscribe/scribe/commands/builder.py` — `build_effects` catches per-command build failures; new `_format_pydantic_errors` helper; returns 4-tuple including `build_errors`.
- `hyperscribe/scribe/api/session_view.py` — `/insert-commands` returns 400 with `validation_errors` when `build_errors` is non-empty.
- `tests/hyperscribe/scribe/commands/test_builder.py` — 3 new tests (out-of-range vital, isolation from siblings, ValueError enum branch) + 6 call-site fixes for the 4-tuple.
- `tests/hyperscribe/scribe/api/test_session_view.py` — 1 new test for the route's 400 + structured payload + 3 existing mock-return fixes.

**Incidental (ruff format / uv lockfile):** transcript_app.py, image_results.py, lab_results.py, test_transcript_app.py, test_backend.py, test_image_results.py, test_medication_statement.py, test_stop_medication.py, uv.lock.

## Test plan

- [x] `uv run pytest tests/hyperscribe/scribe/` — 615 passing, including the 4 new regression tests.
- [x] `uv run ruff check .` / `uv run ruff format .` / `uv run mypy .` — clean.
- [x] Manual UAT against local Canvas (Playwright + direct fetch to `/plugin-io/api/hyperscribe/scribe-session/insert-commands`):
  - `pulse: 8` alone → 400 with `"pulse: Input should be greater than or equal to 30 (got 8)"`.
  - `pulse: 8` mixed with valid RFV → 400, only vitals in `validation_errors`, sibling not inserted.
  - Valid RFV alone → 200 (no regression).
  - `blood_pressure_position_and_site: 999` (ValueError branch) → 400, `"999 is not a valid VitalsCommand.BloodPressureSite"`.

The provider-visible result: instead of a generic "Failed to insert commands", the existing "Please fix before approving" UI now renders the specific bad field, the value, and the valid range — and the provider can correct it without losing other commands on the note.

## Out of scope (follow-ups)

- The manual Vitals card form already enforces SDK ranges client-side. This fix only triggers when a command bypasses that form (today: the Nabla transcript parser). If/when we want to ALSO improve the dictation parser's clamping at parse-time, that's a separate change.
- Removing the formatter drift from the repo more broadly (other modules likely have the same drift; this PR only touches what the hook found on this branch).

[KOALA-5476]: https://canvasmedical.atlassian.net/browse/KOALA-5476?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ