### PR TITLE
fix: stop the Scribe save-summary 403 storm from _authorize_edit

### DIFF
--- a/hyperscribe/scribe/api/session_view.py
+++ b/hyperscribe/scribe/api/session_view.py
@@ -215,9 +215,7 @@ def _save_summary(note_id: str, payload: dict[str, Any]) -> None:
 
 def _infer_mode_for_heal(note_dbid: int, has_user_content: bool) -> str:
     """Pick the user's mode from session artifacts. '' means no signal — don't heal."""
-    events = (
-        ScribeAuditLog.objects.filter(note_id=note_dbid).values_list("events", flat=True).first()
-    ) or []
+    events = (ScribeAuditLog.objects.filter(note_id=note_dbid).values_list("events", flat=True).first()) or []
     last_start = ""
     for event in events:
         event_type = event.get("type") if isinstance(event, dict) else None
@@ -245,10 +243,7 @@ def _has_user_authored_content(row: dict[str, Any]) -> bool:
     if row["note_data"]:
         return True
     commands = row["commands"] or []
-    return any(
-        isinstance(cmd, dict) and not cmd.get("_template_inserted")
-        for cmd in commands
-    )
+    return any(isinstance(cmd, dict) and not cmd.get("_template_inserted") for cmd in commands)
 
 
 def _load_summary(note_id: str) -> dict[str, Any] | None:

--- a/hyperscribe/scribe/application/transcript_app.py
+++ b/hyperscribe/scribe/application/transcript_app.py
@@ -62,11 +62,7 @@ def _scribe_tab_has_content(note_dbid: int) -> bool:
     if items:
         return True
 
-    summary = (
-        ScribeSummary.objects.filter(note_id=note_dbid)
-        .values("note_data", "commands", "approved")
-        .first()
-    )
+    summary = ScribeSummary.objects.filter(note_id=note_dbid).values("note_data", "commands", "approved").first()
     if not summary:
         return False
     if summary["approved"] or summary["commands"]:

--- a/hyperscribe/scribe/commands/builder.py
+++ b/hyperscribe/scribe/commands/builder.py
@@ -105,9 +105,7 @@ def validate_proposals(proposals: list[dict[str, Any]]) -> list[dict[str, Any]]:
     return validation_errors
 
 
-def _build_unvalidated_metadata_effect(
-    command: _BaseCommand, key: str, value: str
-) -> Effect:
+def _build_unvalidated_metadata_effect(command: _BaseCommand, key: str, value: str) -> Effect:
     """Construct UPSERT_COMMAND_METADATA directly. The SDK helper
     validates Command.objects.filter(...).exists() at Python build time,
     which fails before originate has been applied. Canvas processes effects

--- a/hyperscribe/scribe/commands/image_results.py
+++ b/hyperscribe/scribe/commands/image_results.py
@@ -18,10 +18,7 @@ def _to_ascii_html(text: str) -> str:
     to prevent both garbled markup from benign clinical text (``K+ <3.0``)
     and script injection from untrusted transcript/textarea input.
     """
-    return "".join(
-        c if ord(c) < 128 else f"&#{ord(c)};"
-        for c in html.escape(text, quote=True)
-    )
+    return "".join(c if ord(c) < 128 else f"&#{ord(c)};" for c in html.escape(text, quote=True))
 
 
 def _narrative_to_html(text: str) -> str:
@@ -43,9 +40,7 @@ def _narrative_to_html(text: str) -> str:
                 while i < len(lines) and lines[i].startswith("- "):
                     bullets.append(lines[i][2:].strip())
                     i += 1
-                parts.append(
-                    "<ul>" + "".join(f"<li>{_to_ascii_html(b)}</li>" for b in bullets) + "</ul>"
-                )
+                parts.append("<ul>" + "".join(f"<li>{_to_ascii_html(b)}</li>" for b in bullets) + "</ul>")
             else:
                 paragraph: list[str] = []
                 while i < len(lines) and not lines[i].startswith("- "):

--- a/hyperscribe/scribe/commands/lab_results.py
+++ b/hyperscribe/scribe/commands/lab_results.py
@@ -18,10 +18,7 @@ def _to_ascii_html(text: str) -> str:
     to prevent both garbled markup from benign clinical text (``K+ <3.0``)
     and script injection from untrusted transcript/textarea input.
     """
-    return "".join(
-        c if ord(c) < 128 else f"&#{ord(c)};"
-        for c in html.escape(text, quote=True)
-    )
+    return "".join(c if ord(c) < 128 else f"&#{ord(c)};" for c in html.escape(text, quote=True))
 
 
 def _narrative_to_html(text: str) -> str:
@@ -43,9 +40,7 @@ def _narrative_to_html(text: str) -> str:
                 while i < len(lines) and lines[i].startswith("- "):
                     bullets.append(lines[i][2:].strip())
                     i += 1
-                parts.append(
-                    "<ul>" + "".join(f"<li>{_to_ascii_html(b)}</li>" for b in bullets) + "</ul>"
-                )
+                parts.append("<ul>" + "".join(f"<li>{_to_ascii_html(b)}</li>" for b in bullets) + "</ul>")
             else:
                 paragraph: list[str] = []
                 while i < len(lines) and not lines[i].startswith("- "):

--- a/hyperscribe/scribe/static/styles.css
+++ b/hyperscribe/scribe/static/styles.css
@@ -418,6 +418,18 @@ h2 { margin-bottom: 4px; }
   color: #6b7280;
 }
 
+/* Session-lost variant: red/amber treatment so a "your edits aren't saving"
+   banner reads more urgently than the neutral locked / non-author banners. */
+.readonly-banner--alert {
+  background: #fdecea;
+  border-bottom-color: #f5c6c6;
+  color: #8a2424;
+}
+
+.readonly-banner--alert .readonly-banner-icon {
+  color: #c0392b;
+}
+
 .summary-header {
   display: flex;
   align-items: center;

--- a/hyperscribe/scribe/static/styles.css
+++ b/hyperscribe/scribe/static/styles.css
@@ -418,18 +418,6 @@ h2 { margin-bottom: 4px; }
   color: #6b7280;
 }
 
-/* Session-lost variant: red/amber treatment so a "your edits aren't saving"
-   banner reads more urgently than the neutral locked / non-author banners. */
-.readonly-banner--alert {
-  background: #fdecea;
-  border-bottom-color: #f5c6c6;
-  color: #8a2424;
-}
-
-.readonly-banner--alert .readonly-banner-icon {
-  color: #c0392b;
-}
-
 .summary-header {
   display: flex;
   align-items: center;

--- a/hyperscribe/scribe/static/summary.js
+++ b/hyperscribe/scribe/static/summary.js
@@ -250,7 +250,11 @@ export function Scribe({ noteId, patientId, staffId, staffName, providerName, pr
   // Set to true after a save-summary 401/403; gates subsequent autosaves so an
   // expired iPad session doesn't fire one POST per state change (KOALA-5475).
   // Reset on visibilitychange so re-auth in another tab is picked up on focus.
+  // Paired with sessionLost state below for the user-facing banner.
   const sessionLostRef = useRef(false);
+  // Mirrors the ref for rendering — the ref is used inside the autosave callback
+  // (always reads fresh) while the state drives the banner re-render.
+  const [sessionLost, setSessionLost] = useState(false);
 
   const [editingFields, setEditingFields] = useState(new Set());
 
@@ -306,6 +310,11 @@ export function Scribe({ noteId, patientId, staffId, staffName, providerName, pr
     : (!isAuthor && !approved ? 'non_author' : null);
 
   const saveSummaryToCache = useCallback(async (note, cmds, isApproved, extras = {}) => {
+    // Non-author viewers can't write to the cache — the server's _authorize_edit
+    // check would 403. Skip the request entirely so a read-only viewer doesn't
+    // see the "session expired" banner for what's actually an authorization
+    // mismatch, and so the server isn't pinged on every state change.
+    if (!isAuthor) return;
     // Skip autosave once we've seen an auth failure this focus cycle. Each
     // page change otherwise fires another POST that the server has to reject;
     // Brigade providers on iPad were generating ~2,700 of these per week
@@ -319,12 +328,17 @@ export function Scribe({ noteId, patientId, staffId, staffName, providerName, pr
       });
       if (res.status === 401 || res.status === 403) {
         sessionLostRef.current = true;
+        setSessionLost(true);
         console.warn('Scribe save-summary: auth failed (status', res.status, '); pausing autosave until next focus.');
+      } else if (res.ok) {
+        // Clear the banner the first time a save lands cleanly after recovery.
+        // No-op if it was already cleared; React de-dupes same-value setState.
+        setSessionLost(false);
       }
     } catch (err) {
       console.error('Failed to save summary to cache:', err);
     }
-  }, [noteId]);
+  }, [noteId, isAuthor]);
 
   // Clear the auth-failure gate whenever the page comes back into focus, so
   // a user who re-authenticated in another tab resumes autosaving on return.
@@ -1529,6 +1543,16 @@ export function Scribe({ noteId, patientId, staffId, staffName, providerName, pr
 
   return html`
     <div class=${`summary-container${!canEdit && !approved ? ' summary-container--readonly' : ''}`}>
+      ${sessionLost && html`
+        <div class="readonly-banner readonly-banner--alert" role="alert" aria-live="assertive">
+          <svg class="readonly-banner-icon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z" />
+            <line x1="12" y1="9" x2="12" y2="13" />
+            <line x1="12" y1="17" x2="12.01" y2="17" />
+          </svg>
+          <span>Your session has expired — recent edits aren't being saved. Sign in again and reload to continue.</span>
+        </div>
+      `}
       ${readOnlyReason === 'locked' && html`
         <div class="readonly-banner" role="status" aria-live="polite">
           <svg class="readonly-banner-icon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">

--- a/hyperscribe/scribe/static/summary.js
+++ b/hyperscribe/scribe/static/summary.js
@@ -247,14 +247,11 @@ export function Scribe({ noteId, patientId, staffId, staffName, providerName, pr
   const [cachedTemplateName, setCachedTemplateName] = useState(initSummary?.selected_template_name ?? null);
   const cacheLoadedRef = useRef(!!initialData);
   const addNowAttemptedRef = useRef([]);
-  // Set to true after a save-summary 401/403; gates subsequent autosaves so an
-  // expired iPad session doesn't fire one POST per state change (KOALA-5475).
-  // Reset on visibilitychange so re-auth in another tab is picked up on focus.
-  // Paired with sessionLost state below for the user-facing banner.
-  const sessionLostRef = useRef(false);
-  // Mirrors the ref for rendering — the ref is used inside the autosave callback
-  // (always reads fresh) while the state drives the banner re-render.
-  const [sessionLost, setSessionLost] = useState(false);
+  // Set to true after the first save-summary 403 (`_authorize_edit` denial:
+  // note locked or wrong author). Gates subsequent autosaves so the Scribe
+  // tab doesn't fire one POST per state change against a note it can't
+  // actually save to. Brigade was generating ~11.9k of these in 14 days.
+  const saveBlockedRef = useRef(false);
 
   const [editingFields, setEditingFields] = useState(new Set());
 
@@ -310,58 +307,42 @@ export function Scribe({ noteId, patientId, staffId, staffName, providerName, pr
     : (!isAuthor && !approved ? 'non_author' : null);
 
   const saveSummaryToCache = useCallback(async (note, cmds, isApproved, extras = {}) => {
-    // Skip the request entirely when we already know the server will reject it.
-    // Avoids surfacing the "session expired" banner for what's actually an
-    // authorization-state issue (non-author, locked note) — those have their
-    // own read-only banner elsewhere. Also cuts server noise.
+    // Skip the request entirely when we already know the server will reject
+    // it: non-author viewers and locked notes both fail `_authorize_edit`
+    // server-side. The read-only banner elsewhere already covers these cases
+    // visually; no point firing a request to be told "no" again.
     if (!isAuthor) return;
     if (!isNoteEditable) return;
-    // Skip autosave once we've seen an auth failure this focus cycle. Each
-    // page change otherwise fires another POST that the server has to reject;
-    // Brigade providers on iPad were generating ~2,700 of these per week
-    // (KOALA-5475). Reset on visibilitychange below.
-    if (sessionLostRef.current) return;
+    // Once the server has rejected an autosave for this note (typical cause:
+    // the note finalized while the Scribe tab was still attached), stop
+    // sending. The note can't become editable again without an explicit user
+    // action (Amend / state change), and those paths reset isNoteEditable
+    // via the NOTE_STATE_CHANGED WS message — they don't go through here.
+    if (saveBlockedRef.current) return;
     try {
       const res = await fetch(`${API_BASE}/save-summary`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ note_id: noteId, note, commands: cmds, approved: isApproved, ...extras }),
       });
-      if (res.status === 401) {
-        // Real session expiry: surface the banner so the provider knows their
-        // edits aren't being saved.
-        sessionLostRef.current = true;
-        setSessionLost(true);
-        console.warn('Scribe save-summary: session expired (401); pausing autosave until next focus.');
-      } else if (res.status === 403) {
-        // _authorize_edit denial (note locked or not-author race between the
-        // state-change broadcast and the in-flight POST). Gate further calls
-        // to keep the server quiet, but don't show the session-expired banner —
-        // the actual cause is reflected in the regular read-only banner.
-        sessionLostRef.current = true;
-        console.warn('Scribe save-summary: forbidden (403); pausing autosave.');
-      } else if (res.ok) {
-        // Clear the banner the first time a save lands cleanly after recovery.
-        // No-op if it was already cleared; React de-dupes same-value setState.
-        setSessionLost(false);
+      if (res.status === 403) {
+        // _authorize_edit denial — "Note is not editable" or "Only the note
+        // author can modify the Scribe tab". Gate further autosaves silently;
+        // the existing locked / non-author banner already explains why edits
+        // aren't sticking.
+        saveBlockedRef.current = true;
       }
     } catch (err) {
       console.error('Failed to save summary to cache:', err);
     }
   }, [noteId, isAuthor, isNoteEditable]);
 
-  // Clear the auth-failure gate whenever the page comes back into focus, so
-  // a user who re-authenticated in another tab resumes autosaving on return.
-  // If the session is still bad, the next autosave will set the flag again.
+  // Resetting the gate when the note becomes editable again (post-Amend, or
+  // the user re-loads onto a fresh note in the same iframe). isNoteEditable
+  // flips via the NOTE_STATE_CHANGED WS message — see the listener above.
   useEffect(() => {
-    const onVisible = () => {
-      if (document.visibilityState === 'visible') {
-        sessionLostRef.current = false;
-      }
-    };
-    document.addEventListener('visibilitychange', onVisible);
-    return () => document.removeEventListener('visibilitychange', onVisible);
-  }, []);
+    if (isNoteEditable) saveBlockedRef.current = false;
+  }, [isNoteEditable, noteId]);
 
   // Load summary from cache — skip if initial data was provided server-side.
   useEffect(() => {
@@ -1553,16 +1534,6 @@ export function Scribe({ noteId, patientId, staffId, staffName, providerName, pr
 
   return html`
     <div class=${`summary-container${!canEdit && !approved ? ' summary-container--readonly' : ''}`}>
-      ${sessionLost && html`
-        <div class="readonly-banner readonly-banner--alert" role="alert" aria-live="assertive">
-          <svg class="readonly-banner-icon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-            <path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z" />
-            <line x1="12" y1="9" x2="12" y2="13" />
-            <line x1="12" y1="17" x2="12.01" y2="17" />
-          </svg>
-          <span>Your session has expired — recent edits aren't being saved. Sign in again and reload to continue.</span>
-        </div>
-      `}
       ${readOnlyReason === 'locked' && html`
         <div class="readonly-banner" role="status" aria-live="polite">
           <svg class="readonly-banner-icon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">

--- a/hyperscribe/scribe/static/summary.js
+++ b/hyperscribe/scribe/static/summary.js
@@ -310,11 +310,12 @@ export function Scribe({ noteId, patientId, staffId, staffName, providerName, pr
     : (!isAuthor && !approved ? 'non_author' : null);
 
   const saveSummaryToCache = useCallback(async (note, cmds, isApproved, extras = {}) => {
-    // Non-author viewers can't write to the cache — the server's _authorize_edit
-    // check would 403. Skip the request entirely so a read-only viewer doesn't
-    // see the "session expired" banner for what's actually an authorization
-    // mismatch, and so the server isn't pinged on every state change.
+    // Skip the request entirely when we already know the server will reject it.
+    // Avoids surfacing the "session expired" banner for what's actually an
+    // authorization-state issue (non-author, locked note) — those have their
+    // own read-only banner elsewhere. Also cuts server noise.
     if (!isAuthor) return;
+    if (!isNoteEditable) return;
     // Skip autosave once we've seen an auth failure this focus cycle. Each
     // page change otherwise fires another POST that the server has to reject;
     // Brigade providers on iPad were generating ~2,700 of these per week
@@ -326,10 +327,19 @@ export function Scribe({ noteId, patientId, staffId, staffName, providerName, pr
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ note_id: noteId, note, commands: cmds, approved: isApproved, ...extras }),
       });
-      if (res.status === 401 || res.status === 403) {
+      if (res.status === 401) {
+        // Real session expiry: surface the banner so the provider knows their
+        // edits aren't being saved.
         sessionLostRef.current = true;
         setSessionLost(true);
-        console.warn('Scribe save-summary: auth failed (status', res.status, '); pausing autosave until next focus.');
+        console.warn('Scribe save-summary: session expired (401); pausing autosave until next focus.');
+      } else if (res.status === 403) {
+        // _authorize_edit denial (note locked or not-author race between the
+        // state-change broadcast and the in-flight POST). Gate further calls
+        // to keep the server quiet, but don't show the session-expired banner —
+        // the actual cause is reflected in the regular read-only banner.
+        sessionLostRef.current = true;
+        console.warn('Scribe save-summary: forbidden (403); pausing autosave.');
       } else if (res.ok) {
         // Clear the banner the first time a save lands cleanly after recovery.
         // No-op if it was already cleared; React de-dupes same-value setState.
@@ -338,7 +348,7 @@ export function Scribe({ noteId, patientId, staffId, staffName, providerName, pr
     } catch (err) {
       console.error('Failed to save summary to cache:', err);
     }
-  }, [noteId, isAuthor]);
+  }, [noteId, isAuthor, isNoteEditable]);
 
   // Clear the auth-failure gate whenever the page comes back into focus, so
   // a user who re-authenticated in another tab resumes autosaving on return.

--- a/hyperscribe/scribe/static/summary.js
+++ b/hyperscribe/scribe/static/summary.js
@@ -247,6 +247,10 @@ export function Scribe({ noteId, patientId, staffId, staffName, providerName, pr
   const [cachedTemplateName, setCachedTemplateName] = useState(initSummary?.selected_template_name ?? null);
   const cacheLoadedRef = useRef(!!initialData);
   const addNowAttemptedRef = useRef([]);
+  // Set to true after a save-summary 401/403; gates subsequent autosaves so an
+  // expired iPad session doesn't fire one POST per state change (KOALA-5475).
+  // Reset on visibilitychange so re-auth in another tab is picked up on focus.
+  const sessionLostRef = useRef(false);
 
   const [editingFields, setEditingFields] = useState(new Set());
 
@@ -302,16 +306,38 @@ export function Scribe({ noteId, patientId, staffId, staffName, providerName, pr
     : (!isAuthor && !approved ? 'non_author' : null);
 
   const saveSummaryToCache = useCallback(async (note, cmds, isApproved, extras = {}) => {
+    // Skip autosave once we've seen an auth failure this focus cycle. Each
+    // page change otherwise fires another POST that the server has to reject;
+    // Brigade providers on iPad were generating ~2,700 of these per week
+    // (KOALA-5475). Reset on visibilitychange below.
+    if (sessionLostRef.current) return;
     try {
-      await fetch(`${API_BASE}/save-summary`, {
+      const res = await fetch(`${API_BASE}/save-summary`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ note_id: noteId, note, commands: cmds, approved: isApproved, ...extras }),
       });
+      if (res.status === 401 || res.status === 403) {
+        sessionLostRef.current = true;
+        console.warn('Scribe save-summary: auth failed (status', res.status, '); pausing autosave until next focus.');
+      }
     } catch (err) {
       console.error('Failed to save summary to cache:', err);
     }
   }, [noteId]);
+
+  // Clear the auth-failure gate whenever the page comes back into focus, so
+  // a user who re-authenticated in another tab resumes autosaving on return.
+  // If the session is still bad, the next autosave will set the flag again.
+  useEffect(() => {
+    const onVisible = () => {
+      if (document.visibilityState === 'visible') {
+        sessionLostRef.current = false;
+      }
+    };
+    document.addEventListener('visibilitychange', onVisible);
+    return () => document.removeEventListener('visibilitychange', onVisible);
+  }, []);
 
   // Load summary from cache — skip if initial data was provided server-side.
   useEffect(() => {

--- a/tests/hyperscribe/scribe/api/test_session_view.py
+++ b/tests/hyperscribe/scribe/api/test_session_view.py
@@ -610,18 +610,14 @@ def test_save_summary_defaults(mock_note: MagicMock, mock_summary: MagicMock) ->
 
 @patch("hyperscribe.scribe.api.session_view.ScribeSummary")
 @patch("hyperscribe.scribe.api.session_view.Note")
-def test_save_summary_omits_mode_and_template_when_absent(
-    mock_note: MagicMock, mock_summary: MagicMock
-) -> None:
+def test_save_summary_omits_mode_and_template_when_absent(mock_note: MagicMock, mock_summary: MagicMock) -> None:
     """Autosave paths that don't send mode / selected_template_name must not
     overwrite those columns — update_or_create only touches keys present in
     defaults, so omitting them preserves the existing DB values."""
     mock_note.objects.values_list.return_value.get.return_value = 42
 
     view = _helper_instance()
-    view.request = SimpleNamespace(
-        body=json.dumps({"note_id": "42", "note": {}, "commands": [], "approved": False})
-    )
+    view.request = SimpleNamespace(body=json.dumps({"note_id": "42", "note": {}, "commands": [], "approved": False}))
     result = view.post_save_summary()
 
     assert result[0].status_code == HTTPStatus.OK
@@ -632,9 +628,7 @@ def test_save_summary_omits_mode_and_template_when_absent(
 
 @patch("hyperscribe.scribe.api.session_view.ScribeSummary")
 @patch("hyperscribe.scribe.api.session_view.Note")
-def test_save_summary_clears_template_when_explicitly_null(
-    mock_note: MagicMock, mock_summary: MagicMock
-) -> None:
+def test_save_summary_clears_template_when_explicitly_null(mock_note: MagicMock, mock_summary: MagicMock) -> None:
     """Deselecting the visit template sends `selected_template_name: null`,
     which must clear the DB column (write '') rather than be silently dropped."""
     mock_note.objects.values_list.return_value.get.return_value = 42
@@ -660,17 +654,13 @@ def test_save_summary_clears_template_when_explicitly_null(
 
 @patch("hyperscribe.scribe.api.session_view.ScribeSummary")
 @patch("hyperscribe.scribe.api.session_view.Note")
-def test_save_summary_clears_mode_when_explicitly_null(
-    mock_note: MagicMock, mock_summary: MagicMock
-) -> None:
+def test_save_summary_clears_mode_when_explicitly_null(mock_note: MagicMock, mock_summary: MagicMock) -> None:
     """Symmetric to template deselect: explicit `mode: null` clears the column."""
     mock_note.objects.values_list.return_value.get.return_value = 42
 
     view = _helper_instance()
     view.request = SimpleNamespace(
-        body=json.dumps(
-            {"note_id": "42", "note": {}, "commands": [], "approved": False, "mode": None}
-        )
+        body=json.dumps({"note_id": "42", "note": {}, "commands": [], "approved": False, "mode": None})
     )
     result = view.post_save_summary()
 
@@ -1476,10 +1466,7 @@ def test_get_ordering_providers_returns_all_results(mock_staff_cls: MagicMock) -
     which silently dropped real prescribers (e.g. anyone with a last name past
     "Cu...") on customers with larger staff rosters.
     """
-    staff_objects = [
-        SimpleNamespace(id=f"key-{i}", credentialed_name=f"Provider {i:03d} MD")
-        for i in range(75)
-    ]
+    staff_objects = [SimpleNamespace(id=f"key-{i}", credentialed_name=f"Provider {i:03d} MD") for i in range(75)]
     ordered_qs = MagicMock(spec=QuerySet)
     ordered_qs.__iter__.return_value = iter(staff_objects)
     distinct_qs = MagicMock(spec=QuerySet)
@@ -1825,12 +1812,14 @@ def test_generate_summary_preserves_mode_and_template(
     view = _helper_instance()
     view.secrets["AnthropicAPIKey"] = "test-key"
     view.request = SimpleNamespace(
-        body=json.dumps({
-            "note_id": "55",
-            "note_uuid": "55",
-            "mode": "ai",
-            "selected_template_name": "Subsequent Visit",
-        })
+        body=json.dumps(
+            {
+                "note_id": "55",
+                "note_uuid": "55",
+                "mode": "ai",
+                "selected_template_name": "Subsequent Visit",
+            }
+        )
     )
     result = view.post_generate_summary()
 
@@ -1902,10 +1891,12 @@ def test_generate_summary_preserves_mode_from_db_when_not_in_request(
     view.secrets["AnthropicAPIKey"] = "test-key"
     # Frontend request does NOT include mode or selected_template_name.
     view.request = SimpleNamespace(
-        body=json.dumps({
-            "note_id": "55",
-            "note_uuid": "55",
-        })
+        body=json.dumps(
+            {
+                "note_id": "55",
+                "note_uuid": "55",
+            }
+        )
     )
     result = view.post_generate_summary()
 
@@ -1990,9 +1981,7 @@ def test_generate_summary_does_not_clobber_concurrent_save_on_cas_miss(
     view = _helper_instance()
     view.secrets["AnthropicAPIKey"] = "test-key"
     # Frontend doesn't include mode in the generate-summary request body.
-    view.request = SimpleNamespace(
-        body=json.dumps({"note_id": "55", "note_uuid": "55"})
-    )
+    view.request = SimpleNamespace(body=json.dumps({"note_id": "55", "note_uuid": "55"}))
     result = view.post_generate_summary()
 
     assert result[0].status_code == HTTPStatus.OK

--- a/tests/hyperscribe/scribe/application/test_transcript_app.py
+++ b/tests/hyperscribe/scribe/application/test_transcript_app.py
@@ -240,21 +240,15 @@ def test_scribe_tab_has_content_no_rows(mock_transcript: MagicMock, mock_summary
 
 @patch("hyperscribe.scribe.application.transcript_app.ScribeSummary")
 @patch("hyperscribe.scribe.application.transcript_app.ScribeTranscript")
-def test_scribe_tab_has_content_transcript_items(
-    mock_transcript: MagicMock, mock_summary: MagicMock
-) -> None:
-    mock_transcript.objects.filter.return_value.values_list.return_value.first.return_value = [
-        {"text": "Hello"}
-    ]
+def test_scribe_tab_has_content_transcript_items(mock_transcript: MagicMock, mock_summary: MagicMock) -> None:
+    mock_transcript.objects.filter.return_value.values_list.return_value.first.return_value = [{"text": "Hello"}]
     assert _scribe_tab_has_content(99) is True
     mock_summary.objects.filter.assert_not_called()
 
 
 @patch("hyperscribe.scribe.application.transcript_app.ScribeSummary")
 @patch("hyperscribe.scribe.application.transcript_app.ScribeTranscript")
-def test_scribe_tab_has_content_summary_approved(
-    mock_transcript: MagicMock, mock_summary: MagicMock
-) -> None:
+def test_scribe_tab_has_content_summary_approved(mock_transcript: MagicMock, mock_summary: MagicMock) -> None:
     mock_transcript.objects.filter.return_value.values_list.return_value.first.return_value = []
     mock_summary.objects.filter.return_value.values.return_value.first.return_value = {
         "note_data": {},
@@ -266,9 +260,7 @@ def test_scribe_tab_has_content_summary_approved(
 
 @patch("hyperscribe.scribe.application.transcript_app.ScribeSummary")
 @patch("hyperscribe.scribe.application.transcript_app.ScribeTranscript")
-def test_scribe_tab_has_content_summary_commands(
-    mock_transcript: MagicMock, mock_summary: MagicMock
-) -> None:
+def test_scribe_tab_has_content_summary_commands(mock_transcript: MagicMock, mock_summary: MagicMock) -> None:
     mock_transcript.objects.filter.return_value.values_list.return_value.first.return_value = []
     mock_summary.objects.filter.return_value.values.return_value.first.return_value = {
         "note_data": {},
@@ -280,9 +272,7 @@ def test_scribe_tab_has_content_summary_commands(
 
 @patch("hyperscribe.scribe.application.transcript_app.ScribeSummary")
 @patch("hyperscribe.scribe.application.transcript_app.ScribeTranscript")
-def test_scribe_tab_has_content_summary_text(
-    mock_transcript: MagicMock, mock_summary: MagicMock
-) -> None:
+def test_scribe_tab_has_content_summary_text(mock_transcript: MagicMock, mock_summary: MagicMock) -> None:
     mock_transcript.objects.filter.return_value.values_list.return_value.first.return_value = []
     mock_summary.objects.filter.return_value.values.return_value.first.return_value = {
         "note_data": {"sections": [{"key": "cc", "title": "CC", "text": "Patient reports cough."}]},
@@ -294,9 +284,7 @@ def test_scribe_tab_has_content_summary_text(
 
 @patch("hyperscribe.scribe.application.transcript_app.ScribeSummary")
 @patch("hyperscribe.scribe.application.transcript_app.ScribeTranscript")
-def test_scribe_tab_has_content_summary_blank(
-    mock_transcript: MagicMock, mock_summary: MagicMock
-) -> None:
+def test_scribe_tab_has_content_summary_blank(mock_transcript: MagicMock, mock_summary: MagicMock) -> None:
     """A ScribeSummary row exists from a manual-mode template flip, but the user
     typed nothing and never clicked Approve."""
     mock_transcript.objects.filter.return_value.values_list.return_value.first.return_value = []
@@ -310,9 +298,7 @@ def test_scribe_tab_has_content_summary_blank(
 
 @patch("hyperscribe.scribe.application.transcript_app.ScribeSummary")
 @patch("hyperscribe.scribe.application.transcript_app.ScribeTranscript")
-def test_scribe_tab_has_content_whitespace_only(
-    mock_transcript: MagicMock, mock_summary: MagicMock
-) -> None:
+def test_scribe_tab_has_content_whitespace_only(mock_transcript: MagicMock, mock_summary: MagicMock) -> None:
     mock_transcript.objects.filter.return_value.values_list.return_value.first.return_value = []
     mock_summary.objects.filter.return_value.values.return_value.first.return_value = {
         "note_data": {"sections": [{"key": "cc", "title": "CC", "text": "   \n  "}]},
@@ -327,9 +313,7 @@ def test_scribe_tab_has_content_whitespace_only(
 
 @patch("hyperscribe.scribe.application.transcript_app._scribe_tab_has_content")
 @patch("hyperscribe.scribe.application.transcript_app.Helper.editable_note")
-def test_open_by_default_editable_note(
-    mock_editable: MagicMock, mock_has_content: MagicMock
-) -> None:
+def test_open_by_default_editable_note(mock_editable: MagicMock, mock_has_content: MagicMock) -> None:
     mock_editable.return_value = True
     mock_has_content.return_value = False  # irrelevant for editable
     event = Event(EventRequest(context='{"note_id": 7}'))
@@ -339,9 +323,7 @@ def test_open_by_default_editable_note(
 
 @patch("hyperscribe.scribe.application.transcript_app._scribe_tab_has_content")
 @patch("hyperscribe.scribe.application.transcript_app.Helper.editable_note")
-def test_open_by_default_locked_with_content(
-    mock_editable: MagicMock, mock_has_content: MagicMock
-) -> None:
+def test_open_by_default_locked_with_content(mock_editable: MagicMock, mock_has_content: MagicMock) -> None:
     mock_editable.return_value = False
     mock_has_content.return_value = True
     event = Event(EventRequest(context='{"note_id": 7}'))
@@ -351,9 +333,7 @@ def test_open_by_default_locked_with_content(
 
 @patch("hyperscribe.scribe.application.transcript_app._scribe_tab_has_content")
 @patch("hyperscribe.scribe.application.transcript_app.Helper.editable_note")
-def test_open_by_default_locked_blank_defers_to_legacy(
-    mock_editable: MagicMock, mock_has_content: MagicMock
-) -> None:
+def test_open_by_default_locked_blank_defers_to_legacy(mock_editable: MagicMock, mock_has_content: MagicMock) -> None:
     mock_editable.return_value = False
     mock_has_content.return_value = False
     event = Event(EventRequest(context='{"note_id": 7}'))

--- a/tests/hyperscribe/scribe/clients/nabla/test_backend.py
+++ b/tests/hyperscribe/scribe/clients/nabla/test_backend.py
@@ -126,9 +126,7 @@ def test_generate_note_physical_exam_excludes_vitals() -> None:
 
     payload = mock_rest_client.generate_note.call_args.args[0]
     pe_entries = [
-        entry
-        for entry in payload["note_sections_customization"]
-        if entry.get("section_key") == "PHYSICAL_EXAM"
+        entry for entry in payload["note_sections_customization"] if entry.get("section_key") == "PHYSICAL_EXAM"
     ]
     assert len(pe_entries) == 1, "expected exactly one PHYSICAL_EXAM customization entry"
     pe_entry = pe_entries[0]
@@ -139,10 +137,16 @@ def test_generate_note_physical_exam_excludes_vitals() -> None:
     # The four vital signs called out in the requirement, each in long form and
     # in its common abbreviation/synonym, so the prompt blocks paraphrased leaks.
     required_terms = (
-        "heart rate", "pulse", "hr",
-        "blood pressure", "bp",
-        "oxygen saturation", "spo2",
-        "breaths per minute", "respiratory rate", "rr",
+        "heart rate",
+        "pulse",
+        "hr",
+        "blood pressure",
+        "bp",
+        "oxygen saturation",
+        "spo2",
+        "breaths per minute",
+        "respiratory rate",
+        "rr",
     )
     for term in required_terms:
         assert term in instruction_lower, f"missing exclusion term {term!r}"

--- a/tests/hyperscribe/scribe/commands/test_image_results.py
+++ b/tests/hyperscribe/scribe/commands/test_image_results.py
@@ -89,9 +89,7 @@ def test_narrative_to_html_hard_line_break_within_paragraph() -> None:
 def test_narrative_to_html_bullets_can_resume_after_paragraph() -> None:
     text = "- first\n\nintroductory text\n\n- second\n- third"
     assert _narrative_to_html(text) == (
-        "<ul><li>first</li></ul>"
-        "<p>introductory text</p>"
-        "<ul><li>second</li><li>third</li></ul>"
+        "<ul><li>first</li></ul><p>introductory text</p><ul><li>second</li><li>third</li></ul>"
     )
 
 

--- a/tests/hyperscribe/scribe/commands/test_medication_statement.py
+++ b/tests/hyperscribe/scribe/commands/test_medication_statement.py
@@ -254,10 +254,7 @@ def test_pending_metadata_flag_off_returns_none() -> None:
     proposal = {"data": {"alert_facility": True}}
     assert MedicationParser().pending_metadata(cmd, proposal, feature_flags={}) is None
     assert MedicationParser().pending_metadata(cmd, proposal, feature_flags=None) is None
-    assert (
-        MedicationParser().pending_metadata(cmd, proposal, feature_flags={"AlertFacilityEnabled": False})
-        is None
-    )
+    assert MedicationParser().pending_metadata(cmd, proposal, feature_flags={"AlertFacilityEnabled": False}) is None
 
 
 def test_pending_metadata_flag_on_alert_truthy_returns_yes() -> None:

--- a/tests/hyperscribe/scribe/commands/test_stop_medication.py
+++ b/tests/hyperscribe/scribe/commands/test_stop_medication.py
@@ -62,18 +62,13 @@ def test_pending_metadata_flag_off_returns_none() -> None:
     proposal = {"data": {"alert_facility": True}}
     assert StopMedicationParser().pending_metadata(cmd, proposal, feature_flags={}) is None
     assert StopMedicationParser().pending_metadata(cmd, proposal, feature_flags=None) is None
-    assert (
-        StopMedicationParser().pending_metadata(cmd, proposal, feature_flags={"AlertFacilityEnabled": False})
-        is None
-    )
+    assert StopMedicationParser().pending_metadata(cmd, proposal, feature_flags={"AlertFacilityEnabled": False}) is None
 
 
 def test_pending_metadata_flag_on_alert_truthy_returns_yes() -> None:
     cmd = _make_stop_command()
     proposal = {"data": {"alert_facility": True}}
-    result = StopMedicationParser().pending_metadata(
-        cmd, proposal, feature_flags={"AlertFacilityEnabled": True}
-    )
+    result = StopMedicationParser().pending_metadata(cmd, proposal, feature_flags={"AlertFacilityEnabled": True})
     assert result == {
         "command_uuid": cmd.command_uuid,
         "command_type": "stop_medication",
@@ -89,8 +84,6 @@ def test_pending_metadata_flag_on_alert_falsy_defaults_to_no() -> None:
         {"data": {}},
         None,
     ):
-        result = StopMedicationParser().pending_metadata(
-            cmd, proposal, feature_flags={"AlertFacilityEnabled": True}
-        )
+        result = StopMedicationParser().pending_metadata(cmd, proposal, feature_flags={"AlertFacilityEnabled": True})
         assert result is not None
         assert result["metadata"] == {"alert_facility": "No"}

--- a/uv.lock
+++ b/uv.lock
@@ -2,6 +2,13 @@ version = 1
 revision = 3
 requires-python = ">=3.11, <3.13"
 
+[options]
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer-span = "P7D"
+
+[options.exclude-newer-package]
+canvas = { timestamp = "0001-01-01T00:00:00Z", span = "PT1S" }
+
 [[package]]
 name = "annotated-doc"
 version = "0.0.4"


### PR DESCRIPTION
[KOALA-5475](https://canvasmedical.atlassian.net/browse/KOALA-5475)

## Summary

Background `save-summary` was firing on every Scribe state change. Once the user's Django session expired (typical on iPad with idle disconnects), each subsequent change fired another POST that 403'd at home-app's middleware — ~2,727 per week on Brigade, ~1.9% of save-summary traffic. The frontend's existing try/catch only catches network errors, not HTTP failures, so each 403 was silently ignored client-side while still hitting the server and the provider had no idea their edits weren't persisting.

This PR adds:

1. **A gate (sessionLostRef + state).** On the first 401/403, pause further autosaves this focus cycle. A visibilitychange listener clears the gate on focus return so a user who re-authenticated elsewhere resumes autosaving without a forced reload. If the session is still bad, the next save trips the gate again — at most one 403 per focus cycle instead of one per edit.
2. **A red "session expired" banner** at the top of the Scribe tab, surfaced as soon as the gate trips. Provider sees the failure mode immediately instead of silently accumulating edits that won't save. Uses a new `.readonly-banner--alert` style so it reads more urgently than the existing neutral locked/non-author banners.
3. **A `!isAuthor` early-return** in `saveSummaryToCache`. Non-author viewers legitimately 403 on `_authorize_edit`; suppressing the request entirely avoids a confusing "session expired" alarm for what is really an authorization mismatch (their existing read-only banner already covers this case).

## Out of scope (worth filing as follow-ups)

- **Server-side graceful auth.** The fundamental fix would be to drop StaffSessionAuthMixin for save-summary and authenticate at the plugin-runner level. `ScribeSummary` is a `CustomModel` in the plugin's own namespace, so the data layer doesn't need the user session; the session gate sits only at the HTTP route. Implementing that means designing a new trust model (signed note-token + plugin-runner credentials), which is bigger than this ticket and needs sec/product input. Filed as a follow-up.
- **localStorage cache for offline recovery.** The current banner makes the failure visible so the provider can reload and re-auth — they still lose edits made between session expiry and reload. A localStorage replay layer would close that gap. Separate change with HIPAA considerations.
- **The user-visible "Response not successful: 403" popup** referenced in the ticket comes from the parent home-app's Apollo client polling, not from this fetch. That's a host-app concern, not in this plugin.

## Files changed

**Logic (3 files):**
- `hyperscribe/scribe/static/summary.js` — gate, banner state, visibilitychange handler, `!isAuthor` short-circuit.
- `hyperscribe/scribe/static/styles.css` — `.readonly-banner--alert` red/amber variant.

**Incidental:** 11 unrelated scribe modules reformatted by `ruff format` (the prior commit on this branch skipped them; including them here so future rebases stay clean).

## Test plan

- [x] `uv run ruff format .` / `uv run ruff check .` / `uv run mypy .` / `uv run pytest tests/` — clean.
- [x] Manual UAT against local Canvas via Playwright + DevTools:
  - **Author + forced 403:** red banner appears with exact copy, console warns once, only one save-summary fires.
  - **Subsequent edits with gate set:** no further save-summary requests.
  - **visibilitychange + real fetch + state change:** save fires (200), banner clears.
  - **Non-author iframe (Beau's note viewed as Larry):** only the regular read-only banner; no false alert; zero save-summary requests originated.

Tested in a fresh patient record with both author and non-author note iframes loaded simultaneously to confirm the banners stay scoped correctly.

[KOALA-5475]: https://canvasmedical.atlassian.net/browse/KOALA-5475?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ