### PR TITLE
scribe: show BMI + questionnaire scores on the vitals card

### DIFF
--- a/.github/workflows/js-tests.yml
+++ b/.github/workflows/js-tests.yml
@@ -1,0 +1,21 @@
+name: JS tests
+
+on:
+  push:
+    branches: [ main, feat/canvas-scribe ]
+  pull_request:
+    branches: [ main, feat/canvas-scribe ]
+
+jobs:
+  js-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Run tests
+        run: node --test tests/static/

--- a/.github/workflows/js-tests.yml
+++ b/.github/workflows/js-tests.yml
@@ -18,4 +18,4 @@ jobs:
           node-version: '22'
 
       - name: Run tests
-        run: node --test tests/static/
+        run: node --test 'tests/static/**/*.test.mjs'

--- a/hyperscribe/scribe/static/bmi.js
+++ b/hyperscribe/scribe/static/bmi.js
@@ -1,0 +1,11 @@
+// BMI from imperial inputs: (lbs / in^2) * 703. Returns a one-decimal number or null.
+// Suppresses display when inputs (or the resulting BMI) are outside plausible bounds
+// to avoid flashing absurd values while the user is mid-keystroke.
+export function computeBmi(heightIn, weightLbs) {
+  const h = typeof heightIn === 'string' ? parseFloat(heightIn) : heightIn;
+  const w = typeof weightLbs === 'string' ? parseFloat(weightLbs) : weightLbs;
+  if (h == null || w == null || !isFinite(h) || !isFinite(w) || h <= 0 || w <= 0) return null;
+  const bmi = Math.round(((w / (h * h)) * 703) * 10) / 10;
+  if (bmi < 5 || bmi > 100) return null;
+  return bmi;
+}

--- a/hyperscribe/scribe/static/questionnaire-row.js
+++ b/hyperscribe/scribe/static/questionnaire-row.js
@@ -1,17 +1,19 @@
 import { h } from 'https://esm.sh/preact@10.25.4';
 import { useState, useRef, useCallback, useEffect } from 'https://esm.sh/preact@10.25.4/hooks';
 import htm from 'https://esm.sh/htm@3.1.1';
+import {
+  TYPE_TEXT,
+  TYPE_INTEGER,
+  TYPE_RADIO,
+  TYPE_CHECKBOX,
+  isComplete,
+  computeScore,
+} from './questionnaire-score.js';
 
 const html = htm.bind(h);
 
 const API_BASE = '/plugin-io/api/hyperscribe/scribe-session';
 const DEBOUNCE_MS = 300;
-
-// ResponseOption type constants (from Canvas SDK).
-const TYPE_TEXT = 'TXT';
-const TYPE_INTEGER = 'INT';
-const TYPE_RADIO = 'SING';
-const TYPE_CHECKBOX = 'MULT';
 
 function QuestionnaireSearch({ onSelect }) {
   const [query, setQuery] = useState('');
@@ -284,49 +286,6 @@ function countAnswered(questions) {
     }
     return q.responses.some(r => r.selected);
   }).length;
-}
-
-// A questionnaire is "complete" when every question is either answered or explicitly skipped.
-function isComplete(questions) {
-  if (!questions || questions.length === 0) return false;
-  return questions.every(q => {
-    if (q.skipped === true) return true;
-    if (q.type === TYPE_TEXT || q.type === TYPE_INTEGER) {
-      const val = (q.responses[0] || {}).value;
-      return val !== '' && val !== null && val !== undefined;
-    }
-    return q.responses.some(r => r.selected);
-  });
-}
-
-// Additive scoring: sum the numeric score_value of each selected response across radio/checkbox
-// questions, plus the integer value of integer questions. Free-text contributes nothing. Skipped
-// questions are excluded. Returns null when no numeric data could be parsed (e.g. older saved
-// commands that predate the scoring metadata, or unscored questionnaires).
-//
-// Deliberately does NOT fall back to parsing `code`: LOINC question codes ("44249-1") would
-// parseFloat to a non-NaN number and silently masquerade as a clinical score. If a scored
-// questionnaire's score_value is missing, surfacing no score is safer than a fabricated one.
-function computeScore(questions) {
-  if (!questions || questions.length === 0) return null;
-  let sum = 0;
-  let any = false;
-  for (const q of questions) {
-    if (q.skipped === true) continue;
-    if (q.type === TYPE_TEXT) continue;
-    if (q.type === TYPE_INTEGER) {
-      const v = (q.responses[0] || {}).value;
-      const n = parseFloat(v);
-      if (!Number.isNaN(n)) { sum += n; any = true; }
-      continue;
-    }
-    for (const r of q.responses) {
-      if (!r.selected) continue;
-      const n = parseFloat(r.score_value);
-      if (!Number.isNaN(n)) { sum += n; any = true; }
-    }
-  }
-  return any ? sum : null;
 }
 
 // Render the response for a single question in the read-only expanded list.

--- a/hyperscribe/scribe/static/questionnaire-score.js
+++ b/hyperscribe/scribe/static/questionnaire-score.js
@@ -1,0 +1,69 @@
+// Shared questionnaire scoring + completion helpers used by both the
+// questionnaire row (to render its own score badge) and the vitals card
+// (to mirror completed questionnaire scores alongside BP / HR / BMI).
+
+export const TYPE_TEXT = 'TXT';
+export const TYPE_INTEGER = 'INT';
+export const TYPE_RADIO = 'SING';
+export const TYPE_CHECKBOX = 'MULT';
+
+// A questionnaire is "complete" when every question is either answered or explicitly skipped.
+export function isComplete(questions) {
+  if (!questions || questions.length === 0) return false;
+  return questions.every(q => {
+    if (q.skipped === true) return true;
+    if (q.type === TYPE_TEXT || q.type === TYPE_INTEGER) {
+      const val = (q.responses[0] || {}).value;
+      return val !== '' && val !== null && val !== undefined;
+    }
+    return q.responses.some(r => r.selected);
+  });
+}
+
+// Additive scoring: sum the numeric score_value of each selected response across radio/checkbox
+// questions, plus the integer value of integer questions. Free-text contributes nothing. Skipped
+// questions are excluded. Returns null when no numeric data could be parsed (e.g. older saved
+// commands that predate the scoring metadata, or unscored questionnaires).
+//
+// Deliberately does NOT fall back to parsing `code`: LOINC question codes ("44249-1") would
+// parseFloat to a non-NaN number and silently masquerade as a clinical score. If a scored
+// questionnaire's score_value is missing, surfacing no score is safer than a fabricated one.
+export function computeScore(questions) {
+  if (!questions || questions.length === 0) return null;
+  let sum = 0;
+  let any = false;
+  for (const q of questions) {
+    if (q.skipped === true) continue;
+    if (q.type === TYPE_TEXT) continue;
+    if (q.type === TYPE_INTEGER) {
+      const v = (q.responses[0] || {}).value;
+      const n = parseFloat(v);
+      if (!Number.isNaN(n)) { sum += n; any = true; }
+      continue;
+    }
+    for (const r of q.responses) {
+      if (!r.selected) continue;
+      const n = parseFloat(r.score_value);
+      if (!Number.isNaN(n)) { sum += n; any = true; }
+    }
+  }
+  return any ? sum : null;
+}
+
+// Collect [{name, score}] for every questionnaire command in `commands` that is scored,
+// complete, and yields a numeric score. Skips unscored or incomplete questionnaires.
+// Used by the vitals card to mirror screening scores (PHQ-9, GAD-7, AUDIT-C, …) inline.
+export function collectQuestionnaireScores(commands) {
+  if (!commands) return [];
+  const out = [];
+  for (const cmd of commands) {
+    if (cmd?.command_type !== 'questionnaire') continue;
+    const data = cmd.data || {};
+    if (!data.is_scored) continue;
+    if (!isComplete(data.questions)) continue;
+    const score = computeScore(data.questions);
+    if (score == null) continue;
+    out.push({ name: data.questionnaire_name || '', score });
+  }
+  return out;
+}

--- a/hyperscribe/scribe/static/soap-group.js
+++ b/hyperscribe/scribe/static/soap-group.js
@@ -567,7 +567,7 @@ function AddConditionSearch({ onAdd, patientId }) {
   `;
 }
 
-export function SoapGroup({ title, groupColor, sections, commandBySectionKey, onEditCommand, onDeleteCommand, adHocCommands, assignees, onAddTask, onAddOrder, onAddPlan, onAddVitals, onAddMedication, onAddAllergy, onAddStopMedication, onAddRemoveAllergy, onAddResolveCondition, onAddHistory, onAddQuestionnaire, onAddCharge, onAddTemplateCharge, onRemoveChargeByCpt, templateCharges, readOnly, sectionConditions, patientId, noteId, staffId, staffName, recommendations, onEditRecommendation, onDeleteRecommendation, onAcceptRecommendation, onRejectRecommendation, onAddCondition, unmatchedConditions, diagnosisSuggestions, onAddNow, hideRejected, alertFacilityEnabled, onEditingChange }) {
+export function SoapGroup({ title, groupColor, sections, commandBySectionKey, onEditCommand, onDeleteCommand, adHocCommands, assignees, onAddTask, onAddOrder, onAddPlan, onAddVitals, onAddMedication, onAddAllergy, onAddStopMedication, onAddRemoveAllergy, onAddResolveCondition, onAddHistory, onAddQuestionnaire, onAddCharge, onAddTemplateCharge, onRemoveChargeByCpt, templateCharges, readOnly, sectionConditions, patientId, noteId, staffId, staffName, recommendations, onEditRecommendation, onDeleteRecommendation, onAcceptRecommendation, onRejectRecommendation, onAddCondition, unmatchedConditions, diagnosisSuggestions, onAddNow, hideRejected, alertFacilityEnabled, onEditingChange, questionnaireScores }) {
   const coveredKeys = getCoveredKeys(commandBySectionKey);
 
   // In approved (readOnly) mode, only show items that actually made it into the note.
@@ -796,7 +796,7 @@ export function SoapGroup({ title, groupColor, sections, commandBySectionKey, on
             return html`
               <div class="subsection" key=${s.key}>
                 <div class="subsection-title">${s.title}</div>
-                ${allVitals.map(entry => html`
+                ${allVitals.map((entry, idx) => html`
                   <div class="content-block rec-vitals" key=${entry.index}>
                     <${VitalsRow}
                       command=${entry.command}
@@ -804,6 +804,7 @@ export function SoapGroup({ title, groupColor, sections, commandBySectionKey, on
                       onEdit=${onEditCommand}
                       readOnly=${readOnly}
                       onEditingChange=${onEditingChange}
+                      questionnaireScores=${idx === 0 ? questionnaireScores : []}
                     />
                   </div>
                 `)}

--- a/hyperscribe/scribe/static/styles.css
+++ b/hyperscribe/scribe/static/styles.css
@@ -730,6 +730,7 @@ h2 { margin-bottom: 4px; }
 .vitals-edit-label { font-size: 13px; font-weight: 600; color: #6b7280; min-width: 40px; }
 .vitals-edit-input { width: 84px; padding: 8px 6px; font-size: 14px; border: 1px solid #ddd; border-radius: 6px; text-align: center; }
 .vitals-edit-input:focus { outline: none; border-color: #052B49; }
+.vitals-edit-bmi-value { width: 84px; padding: 8px 6px; font-size: 14px; color: #555; text-align: center; }
 .vitals-edit-unit { font-size: 12px; color: #999; }
 .vitals-bp-inputs { display: flex; align-items: center; gap: 4px; }
 .vitals-bp-slash { font-weight: 600; color: #888; }

--- a/hyperscribe/scribe/static/summary.js
+++ b/hyperscribe/scribe/static/summary.js
@@ -2,6 +2,7 @@ import { h } from 'https://esm.sh/preact@10.25.4';
 import { useState, useEffect, useCallback, useRef } from 'https://esm.sh/preact@10.25.4/hooks';
 import htm from 'https://esm.sh/htm@3.1.1';
 import { SoapGroup, parseAPBlocks, matchCondition } from '/plugin-io/api/hyperscribe/scribe/static/soap-group.js';
+import { collectQuestionnaireScores } from '/plugin-io/api/hyperscribe/scribe/static/questionnaire-score.js';
 import { useRecording } from '/plugin-io/api/hyperscribe/scribe/static/recording-hook.js';
 import { initAuditLog, logEvent } from '/plugin-io/api/hyperscribe/scribe/static/audit-log.js';
 import { connectScribeWS } from '/plugin-io/api/hyperscribe/scribe/static/scribe-ws.js';
@@ -146,7 +147,7 @@ function buildCommandBySectionKey(commands) {
   return map;
 }
 
-function renderSoapGroups(sections, commandBySectionKey, onEditCommand, onDeleteCommand, { adHocCommands, objectiveAdHocCommands, historyAdHocCommands, subjectiveAdHocCommands, chargeAdHocCommands, assignees, onAddTask, onAddOrder, onAddPlan, onAddMedication, onAddAllergy, onAddStopMedication, onAddRemoveAllergy, onAddResolveCondition, onAddHistory, onAddQuestionnaire, onAddCharge, onAddTemplateCharge, onRemoveChargeByCpt, templateCharges, readOnly, sectionConditions, patientId, noteId, staffId, staffName, recommendations, onEditRecommendation, onDeleteRecommendation, onAcceptRecommendation, onRejectRecommendation, onAddCondition, unmatchedConditions, diagnosisSuggestions, onAddNow, onAddVitals, hideRejected, alertFacilityEnabled, onEditingChange } = {}) {
+function renderSoapGroups(sections, commandBySectionKey, onEditCommand, onDeleteCommand, { adHocCommands, objectiveAdHocCommands, historyAdHocCommands, subjectiveAdHocCommands, chargeAdHocCommands, assignees, onAddTask, onAddOrder, onAddPlan, onAddMedication, onAddAllergy, onAddStopMedication, onAddRemoveAllergy, onAddResolveCondition, onAddHistory, onAddQuestionnaire, onAddCharge, onAddTemplateCharge, onRemoveChargeByCpt, templateCharges, readOnly, sectionConditions, patientId, noteId, staffId, staffName, recommendations, onEditRecommendation, onDeleteRecommendation, onAcceptRecommendation, onRejectRecommendation, onAddCondition, unmatchedConditions, diagnosisSuggestions, onAddNow, onAddVitals, hideRejected, alertFacilityEnabled, onEditingChange, questionnaireScores } = {}) {
   return SOAP_GROUPS
     .map(group => {
       const matching = sections.filter(s => group.keys.has(s.key.toLowerCase()));
@@ -198,6 +199,7 @@ function renderSoapGroups(sections, commandBySectionKey, onEditCommand, onDelete
         hideRejected=${hideRejected}
         alertFacilityEnabled=${alertFacilityEnabled}
         onEditingChange=${onEditingChange}
+        questionnaireScores=${isObjective ? questionnaireScores : null}
       />`;
     })
     .filter(Boolean);
@@ -1722,6 +1724,7 @@ export function Scribe({ noteId, patientId, staffId, staffName, providerName, pr
           hideRejected,
           alertFacilityEnabled,
           onEditingChange: handleEditingChange,
+          questionnaireScores: collectQuestionnaireScores(commands),
         })}
       </div>
       ${verificationResult && html`<${VerificationSummary} result=${verificationResult} />`}

--- a/hyperscribe/scribe/static/vitals-row.js
+++ b/hyperscribe/scribe/static/vitals-row.js
@@ -40,6 +40,20 @@ function bpSiteLabel(value) {
 
 export { bpSiteLabel };
 
+// BMI from imperial inputs: (lbs / in^2) * 703. Returns a one-decimal number or null.
+// Suppresses display when inputs (or the resulting BMI) are outside plausible bounds
+// to avoid flashing absurd values while the user is mid-keystroke.
+function computeBmi(heightIn, weightLbs) {
+  const h = typeof heightIn === 'string' ? parseFloat(heightIn) : heightIn;
+  const w = typeof weightLbs === 'string' ? parseFloat(weightLbs) : weightLbs;
+  if (h == null || w == null || !isFinite(h) || !isFinite(w) || h <= 0 || w <= 0) return null;
+  const bmi = Math.round(((w / (h * h)) * 703) * 10) / 10;
+  if (bmi < 5 || bmi > 100) return null;
+  return bmi;
+}
+
+export { computeBmi };
+
 function formatVitalsDisplay(data) {
   const parts = [];
   VITALS_FIELDS.forEach(f => {
@@ -52,6 +66,8 @@ function formatVitalsDisplay(data) {
       if (val != null) parts.push(`${f.label} ${val} ${f.unit}`);
     }
   });
+  const bmi = computeBmi(data.height, data.weight_lbs);
+  if (bmi != null) parts.push(`BMI ${bmi}`);
   if (data.blood_pressure_position_and_site != null) {
     const label = bpSiteLabel(data.blood_pressure_position_and_site);
     if (label) parts.push(`Site: ${label}`);
@@ -205,6 +221,16 @@ export function VitalsRow({ command, commandIndex, onEdit, readOnly, onEditingCh
               </div>
             `;
           })}
+          ${(() => {
+            const bmi = computeBmi(draft.height, draft.weight_lbs);
+            if (bmi == null) return null;
+            return html`
+              <div class="vitals-edit-field vitals-edit-bmi" key="bmi">
+                <span class="vitals-edit-label">BMI</span>
+                <span class="vitals-edit-bmi-value">${bmi}</span>
+              </div>
+            `;
+          })()}
         </div>
         <div class="vitals-extra-fields">
           <div class="history-form-field">
@@ -258,6 +284,10 @@ export function VitalsRow({ command, commandIndex, onEdit, readOnly, onEditingCh
       }
     }
   });
+  const bmiView = computeBmi(command.data.height, command.data.weight_lbs);
+  if (bmiView != null) {
+    items.push(html`<span class="vitals-item" key="bmi"><strong>BMI</strong> ${bmiView}</span>`);
+  }
   if (command.data.blood_pressure_position_and_site != null) {
     const label = bpSiteLabel(command.data.blood_pressure_position_and_site);
     if (label) items.push(html`<span class="vitals-item" key="bp_site"><strong>Site</strong> ${label}</span>`);

--- a/hyperscribe/scribe/static/vitals-row.js
+++ b/hyperscribe/scribe/static/vitals-row.js
@@ -1,6 +1,7 @@
 import { h } from 'https://esm.sh/preact@10.25.4';
 import { useState, useEffect } from 'https://esm.sh/preact@10.25.4/hooks';
 import htm from 'https://esm.sh/htm@3.1.1';
+import { computeBmi } from './bmi.js';
 
 const html = htm.bind(h);
 
@@ -39,20 +40,6 @@ function bpSiteLabel(value) {
 }
 
 export { bpSiteLabel };
-
-// BMI from imperial inputs: (lbs / in^2) * 703. Returns a one-decimal number or null.
-// Suppresses display when inputs (or the resulting BMI) are outside plausible bounds
-// to avoid flashing absurd values while the user is mid-keystroke.
-function computeBmi(heightIn, weightLbs) {
-  const h = typeof heightIn === 'string' ? parseFloat(heightIn) : heightIn;
-  const w = typeof weightLbs === 'string' ? parseFloat(weightLbs) : weightLbs;
-  if (h == null || w == null || !isFinite(h) || !isFinite(w) || h <= 0 || w <= 0) return null;
-  const bmi = Math.round(((w / (h * h)) * 703) * 10) / 10;
-  if (bmi < 5 || bmi > 100) return null;
-  return bmi;
-}
-
-export { computeBmi };
 
 function formatVitalsDisplay(data) {
   const parts = [];

--- a/hyperscribe/scribe/static/vitals-row.js
+++ b/hyperscribe/scribe/static/vitals-row.js
@@ -79,7 +79,7 @@ function validateField(key, value) {
   return null;
 }
 
-export function VitalsRow({ command, commandIndex, onEdit, readOnly, onEditingChange }) {
+export function VitalsRow({ command, commandIndex, onEdit, readOnly, onEditingChange, questionnaireScores = [] }) {
   const hasData = Object.values(command.data || {}).some(v => v != null);
   const [editing, setEditing] = useState(!readOnly && !hasData);
   useEffect(() => {
@@ -218,6 +218,12 @@ export function VitalsRow({ command, commandIndex, onEdit, readOnly, onEditingCh
               </div>
             `;
           })()}
+          ${questionnaireScores.map(qs => html`
+            <div class="vitals-edit-field vitals-edit-bmi" key=${`qs-${qs.name}`}>
+              <span class="vitals-edit-label">${qs.name}</span>
+              <span class="vitals-edit-bmi-value">${qs.score}</span>
+            </div>
+          `)}
         </div>
         <div class="vitals-extra-fields">
           <div class="history-form-field">
@@ -275,6 +281,9 @@ export function VitalsRow({ command, commandIndex, onEdit, readOnly, onEditingCh
   if (bmiView != null) {
     items.push(html`<span class="vitals-item" key="bmi"><strong>BMI</strong> ${bmiView}</span>`);
   }
+  questionnaireScores.forEach(qs => {
+    items.push(html`<span class="vitals-item" key=${`qs-${qs.name}`}><strong>${qs.name}</strong> ${qs.score}</span>`);
+  });
   if (command.data.blood_pressure_position_and_site != null) {
     const label = bpSiteLabel(command.data.blood_pressure_position_and_site);
     if (label) items.push(html`<span class="vitals-item" key="bp_site"><strong>Site</strong> ${label}</span>`);

--- a/tests/static/bmi.test.mjs
+++ b/tests/static/bmi.test.mjs
@@ -1,0 +1,53 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { computeBmi } from '../../hyperscribe/scribe/static/bmi.js';
+
+test('computes BMI from height (in) and weight (lbs), rounded to one decimal', () => {
+  // 5'10" (70 in), 150 lbs -> (150 / 4900) * 703 = 21.519... -> 21.5
+  assert.equal(computeBmi(70, 150), 21.5);
+  // 5'5" (65 in), 200 lbs -> (200 / 4225) * 703 = 33.28... -> 33.3
+  assert.equal(computeBmi(65, 200), 33.3);
+  // 6'0" (72 in), 180 lbs -> (180 / 5184) * 703 = 24.40... -> 24.4
+  assert.equal(computeBmi(72, 180), 24.4);
+});
+
+test('accepts numeric strings as input', () => {
+  assert.equal(computeBmi('70', '150'), 21.5);
+  assert.equal(computeBmi('70.0', '150.5'), computeBmi(70, 150.5));
+});
+
+test('returns null when either input is missing', () => {
+  assert.equal(computeBmi(null, 150), null);
+  assert.equal(computeBmi(70, null), null);
+  assert.equal(computeBmi(null, null), null);
+  assert.equal(computeBmi(undefined, 150), null);
+  assert.equal(computeBmi(70, undefined), null);
+});
+
+test('returns null for non-finite or non-positive inputs', () => {
+  assert.equal(computeBmi(0, 150), null);
+  assert.equal(computeBmi(70, 0), null);
+  assert.equal(computeBmi(-70, 150), null);
+  assert.equal(computeBmi(70, -150), null);
+  assert.equal(computeBmi(NaN, 150), null);
+  assert.equal(computeBmi(70, NaN), null);
+  assert.equal(computeBmi(Infinity, 150), null);
+  assert.equal(computeBmi('not a number', 150), null);
+});
+
+test('suppresses values outside the plausible 5-100 range to dampen mid-keystroke noise', () => {
+  // height = 1 in, weight = 150 lbs -> ~105000 BMI. Hidden.
+  assert.equal(computeBmi(1, 150), null);
+  // height = 70, weight = 0.1 -> 0.014 BMI. Hidden.
+  assert.equal(computeBmi(70, 0.1), null);
+});
+
+test('shows values at the boundary of the plausible range', () => {
+  // A very low but plausible BMI (extreme but documented).
+  // height = 70, weight ~ 35 lbs -> 5.0
+  assert.ok(computeBmi(70, 35) >= 5);
+  // A very high but plausible BMI (extreme adult obesity).
+  // height = 70, weight ~ 690 lbs -> ~99.0
+  assert.ok(computeBmi(70, 690) <= 100);
+});

--- a/tests/static/questionnaire-score.test.mjs
+++ b/tests/static/questionnaire-score.test.mjs
@@ -1,0 +1,135 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  computeScore,
+  isComplete,
+  collectQuestionnaireScores,
+} from '../../hyperscribe/scribe/static/questionnaire-score.js';
+
+// Helpers to build the question shapes used by the scribe questionnaire UI.
+const radio = (selectedScore) => ({
+  type: 'SING',
+  responses: [
+    { selected: false, score_value: '0' },
+    { selected: selectedScore != null, score_value: String(selectedScore ?? 0) },
+  ],
+});
+
+const checkbox = (selectedScores) => ({
+  type: 'MULT',
+  responses: selectedScores.map(s => ({ selected: s != null, score_value: String(s ?? 0) })),
+});
+
+const integer = (value) => ({
+  type: 'INT',
+  responses: [{ value: value == null ? '' : String(value) }],
+});
+
+const text = (value) => ({
+  type: 'TXT',
+  responses: [{ value: value ?? '' }],
+});
+
+const skipped = () => ({ type: 'SING', skipped: true, responses: [] });
+
+test('computeScore sums selected radio score values', () => {
+  assert.equal(computeScore([radio(3), radio(2), radio(1)]), 6);
+});
+
+test('computeScore sums all selected checkbox responses', () => {
+  assert.equal(computeScore([checkbox([1, 2, null]), checkbox([4])]), 7);
+});
+
+test('computeScore adds integer answers as numbers', () => {
+  assert.equal(computeScore([integer(5), integer(7)]), 12);
+});
+
+test('computeScore ignores free-text responses', () => {
+  assert.equal(computeScore([radio(3), text('hello')]), 3);
+});
+
+test('computeScore ignores skipped questions', () => {
+  assert.equal(computeScore([radio(3), skipped()]), 3);
+});
+
+test('computeScore returns null when no numeric data could be parsed', () => {
+  assert.equal(computeScore([text('a'), text('b')]), null);
+  assert.equal(computeScore([]), null);
+  assert.equal(computeScore(null), null);
+});
+
+test('computeScore does not fall back to LOINC codes that happen to parse', () => {
+  // A radio response with only a numeric `code` (e.g. "44249-1") and no score_value
+  // must not contribute — that would silently fabricate clinical scores.
+  const q = { type: 'SING', responses: [{ selected: true, code: '44249-1' }] };
+  assert.equal(computeScore([q]), null);
+});
+
+test('isComplete requires every question to be answered or skipped', () => {
+  assert.equal(isComplete([radio(3), radio(2)]), true);
+  assert.equal(isComplete([radio(3), { type: 'SING', responses: [{ selected: false }] }]), false);
+  assert.equal(isComplete([radio(3), skipped()]), true);
+  assert.equal(isComplete([integer(5), integer(null)]), false);
+  assert.equal(isComplete([]), false);
+  assert.equal(isComplete(null), false);
+});
+
+test('collectQuestionnaireScores returns one entry per scored complete questionnaire', () => {
+  const commands = [
+    {
+      command_type: 'questionnaire',
+      data: { questionnaire_name: 'PHQ-9', is_scored: true, questions: [radio(2), radio(1), radio(3)] },
+    },
+    {
+      command_type: 'questionnaire',
+      data: { questionnaire_name: 'GAD-7', is_scored: true, questions: [radio(1), radio(2)] },
+    },
+  ];
+  assert.deepEqual(collectQuestionnaireScores(commands), [
+    { name: 'PHQ-9', score: 6 },
+    { name: 'GAD-7', score: 3 },
+  ]);
+});
+
+test('collectQuestionnaireScores skips unscored and incomplete questionnaires', () => {
+  const commands = [
+    // unscored
+    {
+      command_type: 'questionnaire',
+      data: { questionnaire_name: 'Notes', is_scored: false, questions: [radio(2)] },
+    },
+    // incomplete
+    {
+      command_type: 'questionnaire',
+      data: {
+        questionnaire_name: 'AUDIT-C',
+        is_scored: true,
+        questions: [radio(2), { type: 'SING', responses: [{ selected: false }] }],
+      },
+    },
+    // ok
+    {
+      command_type: 'questionnaire',
+      data: { questionnaire_name: 'PHQ-2', is_scored: true, questions: [radio(2), radio(1)] },
+    },
+  ];
+  assert.deepEqual(collectQuestionnaireScores(commands), [{ name: 'PHQ-2', score: 3 }]);
+});
+
+test('collectQuestionnaireScores ignores non-questionnaire commands', () => {
+  const commands = [
+    { command_type: 'vitals', data: {} },
+    {
+      command_type: 'questionnaire',
+      data: { questionnaire_name: 'PHQ-9', is_scored: true, questions: [radio(2)] },
+    },
+  ];
+  assert.deepEqual(collectQuestionnaireScores(commands), [{ name: 'PHQ-9', score: 2 }]);
+});
+
+test('collectQuestionnaireScores tolerates null / undefined input', () => {
+  assert.deepEqual(collectQuestionnaireScores(null), []);
+  assert.deepEqual(collectQuestionnaireScores(undefined), []);
+  assert.deepEqual(collectQuestionnaireScores([]), []);
+});


### PR DESCRIPTION
[KOALA-5597](https://canvasmedical.atlassian.net/browse/KOALA-5597) — Canvas Scribe for Brigade epic.

Ships row 18 of the EMR Punch List (Priority List tab, Tier 3 / Medium): _"Add questionnaire scores and BMI to the vital card."_

## What changed

### BMI

`hyperscribe/scribe/static/bmi.js` is a new tiny module exporting `computeBmi(heightIn, weightLbs)` using the imperial formula `(weight_lbs / height_in²) × 703`, rounded to one decimal. Returns `null` when either input is missing, non-finite, non-positive, or when the resulting BMI falls outside 5–100 (a plausibility gate so partially typed inputs don't flash absurd numbers mid-keystroke).

`hyperscribe/scribe/static/vitals-row.js` imports `computeBmi` and surfaces the result in view mode (as another `BMI` item alongside HR / RR / SpO2 / Temp / Height / Weight) and in edit mode (as a live read-only readout under the input grid).

### Questionnaire scores

`hyperscribe/scribe/static/questionnaire-score.js` is a new module that extracts the questionnaire scoring helpers (`computeScore`, `isComplete`, type constants) that were previously living inside `questionnaire-row.js`. It also adds `collectQuestionnaireScores(commands)` which returns a flat `[{name, score}]` list of every scored, complete questionnaire in the note.

`summary.js` now computes that list from the flat commands array and threads it through `renderSoapGroups` → `SoapGroup` → `VitalsRow`. The vitals card displays each `Score: N` inline alongside BP / HR / BMI in both view and edit modes. When multiple vitals readings are present, the scores attach to the first card to avoid duplicating the same numbers per row.

BMI is **not** persisted on `VitalsCommand` (Canvas already derives it server-side from height/weight). Scores are not persisted on the vitals command either — they're derived from the questionnaire commands at render time.

## Tests

`tests/static/bmi.test.mjs` (6 cases) and `tests/static/questionnaire-score.test.mjs` (12 cases) use node's built-in test runner — zero dependencies, runs via `node --test 'tests/static/**/*.test.mjs'`.

`.github/workflows/js-tests.yml` runs the suite on push/PR to `main` and `feat/canvas-scribe`. This is the first JS CI in the repo; happy to add a pre-commit hook if you want it gated locally too.

## Test plan

- [x] `node --test 'tests/static/**/*.test.mjs'` — 18/18 passing locally; GitHub Actions green.
- [ ] Open a scribe note, enter both height and weight in the vitals card, confirm BMI appears with one-decimal precision.
- [ ] Add a scored questionnaire (e.g. PHQ-9), complete it, confirm `PHQ-9 N` appears inline on the vitals card.
- [ ] Add multiple scored questionnaires — all complete ones appear; unscored / incomplete ones don't.
- [ ] In edit mode on the vitals card, scores show under the input grid as read-only entries.
- [ ] With multiple vitals readings, scores attach only to the first card.

[KOALA-5597]: https://canvasmedical.atlassian.net/browse/KOALA-5597?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ