### PR TITLE
feat: allow editing existing commands during scribe amendment mode

### DIFF
--- a/hyperscribe/scribe/api/session_view.py
+++ b/hyperscribe/scribe/api/session_view.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from datetime import datetime, timezone
 from http import HTTPStatus
 from typing import Any, Union
 
@@ -18,6 +19,7 @@ from django.db.models import Q
 from canvas_sdk.commands.commands.allergy import AllergenType
 from canvas_sdk.commands.commands.questionnaire import QuestionnaireCommand
 from canvas_sdk.v1.data import AllergyIntolerance, ChargeDescriptionMaster, Medication, Note
+from canvas_sdk.v1.data.command import Command
 from canvas_sdk.v1.data.prescription import Prescription
 from canvas_sdk.v1.data.condition import Condition as ConditionModel
 from canvas_sdk.v1.data.lab import LabPartner, LabPartnerTest
@@ -49,7 +51,11 @@ from hyperscribe.scribe.backend import (
 )
 from hyperscribe.scribe.commands.ap_split import split_plan_into_diagnoses
 from hyperscribe.scribe.commands.builder import (
+    DIRECT_EDIT_SECTIONS,
+    EDITABLE_AMEND_SECTIONS,
+    NON_EDITABLE_AMEND_COMMAND_TYPES,
     annotate_duplicates,
+    build_amend_edit_effects,
     build_effects,
     build_metadata_effects,
     validate_proposals,
@@ -102,8 +108,6 @@ def _authorize_edit(note_uuid: str, request: Any) -> JSONResponse | None:
 
 def audit_event(note_uuid: str, event_type: str, details: dict[str, Any] | None = None) -> None:
     """Append an audit event to the ScribeAuditLog from the backend."""
-    from datetime import datetime, timezone
-
     try:
         note_dbid = Note.objects.values_list("dbid", flat=True).get(id=note_uuid)
         obj, created = ScribeAuditLog.objects.get_or_create(note_id=note_dbid, defaults={"events": []})
@@ -117,6 +121,23 @@ def audit_event(note_uuid: str, event_type: str, details: dict[str, Any] | None 
 _PROGRESS_CACHE_KEY_PREFIX = "scribe_progress:"
 
 _PLAN_SECTION_KEYS = frozenset({"assessment_and_plan", "plan"})
+
+# HIPAA defense-in-depth: explicit key whitelist for the AMEND_EXISTING_COMMANDS
+# audit entries. The audit payload is built by ``{k: a[k] for k in whitelist if k in a}``
+# rather than by destructuring ``attempted`` records by name in an inline dict
+# literal. Mechanism: if a future change adds a new key to ``attempted`` records
+# (e.g., ``display``, which was historically present and carries free-text
+# clinical narrative for HPI / ROS / PE / lab_results / current_medications),
+# it CANNOT silently propagate into the audit log - only the whitelisted
+# structural identifiers can. Pinned by
+# ``test_amend_audit_payload_does_not_propagate_new_attempted_keys``.
+_AMEND_AUDIT_ENTRY_KEYS = (
+    "section_key",
+    "command_type",
+    "old_command_uuid",
+    "new_command_uuid",
+    "mode",
+)
 
 SUMMARY_STEPS = [
     "Generating note",
@@ -1169,6 +1190,13 @@ class ScribeSessionView(StaffSessionAuthMixin, SimpleAPI):
             ]
         feature_flags = {"AlertFacilityEnabled": bool(self.secrets.get("AlertFacilityEnabled"))}
         effects, metadata_pending, attempted = build_effects(commands, note_uuid, feature_flags)
+        # HIPAA: the audit payload intentionally omits ``display``. For
+        # HPI / ROS / PE / lab_results / current_medications, ``display`` is
+        # free-text clinical narrative; persisting it into the audit log would
+        # be PHI in a log, even with 80-char truncation. Structural identifiers
+        # (command_type, section_key) and aggregate counts carry enough signal
+        # for incident triage without leaking content. Mirrors the
+        # AMEND_EXISTING_COMMANDS hardening (KOALA-5485).
         audit_event(
             note_uuid,
             "INSERT_COMMANDS",
@@ -1178,7 +1206,6 @@ class ScribeSessionView(StaffSessionAuthMixin, SimpleAPI):
                 "commands": [
                     {
                         "type": c.get("command_type", ""),
-                        "display": (c.get("display") or "")[:80],
                         "section_key": c.get("section_key", ""),
                     }
                     for c in commands
@@ -1193,6 +1220,230 @@ class ScribeSessionView(StaffSessionAuthMixin, SimpleAPI):
                     "metadata_pending": metadata_pending,
                     "attempted": attempted,
                 },
+                status_code=HTTPStatus.OK,
+            ),
+            *effects,
+        ]
+
+    @api.post("/edit-existing-commands")
+    def post_edit_existing_commands(self) -> list[Union[Response, Effect]]:
+        """Amend already-documented commands in the editable sections (KOALA-5485).
+
+        Accepts proposals carrying an existing ``command_uuid`` and a ``section_key``
+        in ``EDITABLE_AMEND_SECTIONS``. RFV (chief_complaint) routes through a
+        direct EDIT; CustomCommand-routed sections route through EnterInError(old)
+        + Originate(new) (home-app auto-commits); dedicated SDK class sections
+        (HPI, medication_statement) route through EnterInError + Originate +
+        Commit. See ``build_amend_edit_effects`` for the routing rationale.
+
+        Returns ``attempted``: a list with ``old_command_uuid``,
+        ``new_command_uuid`` (equal to old for direct_edit), ``section_key``,
+        ``command_type``, ``mode``, ``display``. The frontend re-stamps
+        ``ScribeSummary.commands`` from this list before calling
+        ``/verify-commands``.
+
+        Returns ``conflicts`` when a proposal's current Command.state on the
+        server is incompatible with the requested operation (e.g., the user has
+        a stale tab and is trying to amend an already-voided row). The frontend
+        surfaces this so the user can reload before retrying.
+
+        Concurrency (residual race): the eligibility check and effect emission
+        are NOT atomic. The plugin sandbox bans ``from django.db import
+        transaction`` (only ``from django.db.transaction import atomic`` is
+        whitelisted), and even if it didn't, ``select_for_update()`` against
+        the ``commands_command`` plugin view fails at the SQL layer (Postgres
+        rejects ``FOR UPDATE`` on a view containing outer joins). More
+        fundamentally, plugin effects are emitted onto the home-app effect
+        bus and processed in a separate transaction, so a plugin-side
+        ``atomic()`` would not bound the EnterInError lifecycle anyway.
+
+        The pre-check catches the *common* case (one tab is genuinely stale -
+        its submit arrives well after Tab A's EIE has landed). It cannot
+        close the microsecond window between two near-simultaneous submits
+        against a still-``committed`` row: both reads can see the valid
+        state, both branches emit EnterInError(X) + Originate(Y1)/Originate(Y2),
+        and the user ends up with two amended commands where they expected
+        one. Home-app's idempotent handling of a duplicate EnterInError
+        against an already-voided row is the safety net for the EIE side;
+        the duplicate Originate(Y2) is the visible artifact and is accepted
+        as an extremely rare residual race. Closing it from the plugin side
+        would require a cross-repo home-app change (out of scope here).
+
+        Audit writes fire AFTER the state read and effect emission. The
+        ``audit_event()`` helper catches broad ``Exception`` via
+        ``log.exception(...)``; the historical ordering (state read first,
+        audit last) is preserved so that an audit-write failure cannot
+        suppress the response. Pinned by
+        ``test_edit_existing_commands_audit_fires_after_state_check``.
+
+        ``was_finalized`` interaction: once a note has been approved at least
+        once, ``ScribeSummary.was_finalized`` is True (one-way latch in
+        ``_save_summary``). The frontend uses this to pin amendment-mode UI on
+        re-Approve. If ``/insert-commands`` fails AFTER a successful
+        ``/edit-existing-commands``, the frontend rolls back ``approved``
+        in-memory but persists the re-stamped command uuids in cache; the
+        amendment-mode UI stays pinned because ``was_finalized`` is sticky.
+        That's intentional - the user can retry insertion without losing the
+        amended state.
+        """
+        try:
+            data: dict[str, Any] = json.loads(self.request.body)
+        except (json.JSONDecodeError, ValueError) as exc:
+            return [JSONResponse({"error": f"Invalid JSON: {exc}"}, status_code=HTTPStatus.BAD_REQUEST)]
+        note_uuid = str(data.get("note_uuid", ""))
+        if not note_uuid:
+            return [JSONResponse({"error": "note_uuid is required"}, status_code=HTTPStatus.BAD_REQUEST)]
+        if denial := _authorize_edit(note_uuid, self.request):
+            return [denial]
+
+        commands = data.get("commands", [])
+        # Re-use the existing per-field length validation so amendment edits
+        # can't smuggle past, e.g., 10k-char narratives.
+        validation_errors = validate_proposals(commands)
+        if validation_errors:
+            audit_event(note_uuid, "VALIDATION_FAILED", {"errors": validation_errors})
+            return [
+                JSONResponse(
+                    {"error": "Validation failed", "validation_errors": validation_errors},
+                    status_code=HTTPStatus.BAD_REQUEST,
+                )
+            ]
+
+        # KOALA-5485 cross-tab concurrency check: reject any proposal whose
+        # underlying Command row is in an incompatible state. This catches the
+        # case where Tab A amends HPI X -> Y, and stale Tab B then submits
+        # its own amend against X (already entered_in_error). Without this
+        # check we'd happily emit EIE(X) on a voided row.
+        #
+        # Valid eligible (allowlisted + uuid present) proposals get their
+        # state fetched in one query, then bucketed:
+        #   - DIRECT_EDIT (RFV/chief_complaint): row must be 'staged'.
+        #   - void+recreate (everything else): row must NOT be 'entered_in_error'.
+        # Missing rows in the DB (e.g., uuid never landed) are treated as
+        # conflicts so a buggy or stale frontend doesn't get a silent no-op.
+        # NOTE on ``command_not_found``: this corner case can fire legitimately
+        # in an Originate-then-Amend race (the originate effect has been
+        # accepted server-side but the Command row hasn't been written yet,
+        # or the originate was reverted). The user sees a 409 with reason
+        # ``command_not_found`` and reloads - benign UX cost for the
+        # defense-in-depth guard against stale frontends.
+        #
+        # NO atomic guarantee. The state read and effect emission are NOT
+        # serialized at the DB level: (a) the sandbox bans ``from django.db
+        # import transaction`` (only ``from django.db.transaction import
+        # atomic`` is whitelisted), (b) ``select_for_update()`` on the
+        # commands_command plugin view fails at the SQL layer (FOR UPDATE on
+        # an outer-joined view), and (c) the EnterInError effect is processed
+        # by home-app in its own transaction so a plugin-side ``atomic()``
+        # would not bound the EIE lifecycle anyway. The pre-check serializes
+        # the *common* stale-tab case (Tab B's submit arrives after Tab A's
+        # EIE has landed). It does NOT close the microsecond race window
+        # between two near-simultaneous submits against a still-``committed``
+        # row - both reads pass, both branches emit. Residual artifact: a
+        # duplicate Originate(Y2) on the same row. Home-app idempotent
+        # handling of duplicate EnterInError is the only safety net we have
+        # for now; closing the Originate side requires home-app changes.
+        # An order (prescribe/refill/refer/imaging_order/lab_order/
+        # adjust_prescription) ad-hoc'd into the note shares the _ad_hoc
+        # section_key with editable command_types like ``task`` and ``plan``;
+        # filter denied command_types out of the eligibility set here so the
+        # conflict pre-check doesn't issue a Command-state lookup for them
+        # AND so they're silently dropped (consistent with the existing
+        # section-not-allowlisted behavior) rather than surfacing a
+        # ``state_mismatch`` 409.
+        eligible = [
+            c
+            for c in commands
+            if c.get("section_key", "") in EDITABLE_AMEND_SECTIONS
+            and c.get("command_type", "") not in NON_EDITABLE_AMEND_COMMAND_TYPES
+            and c.get("command_uuid", "")
+        ]
+        conflicts: list[dict[str, Any]] = []
+        effects: list[Effect] = []
+        attempted: list[dict[str, Any]] = []
+        if eligible:
+            wanted_uuids = [c["command_uuid"] for c in eligible]
+            # ``Command.id`` is a UUIDField backed by Postgres ``uuid``, so
+            # ``.values_list("id", ...)`` yields ``uuid.UUID`` objects, not
+            # strings. ``hash(UUID(x)) != hash(str(x))``, so a dict keyed by
+            # the raw values misses every lookup against the string
+            # ``command_uuid`` we get from JSON - turning every proposal into a
+            # spurious ``command_not_found`` 409. Coerce to ``str`` here so the
+            # dict shape matches ``state_by_uuid``'s declared type and the
+            # lookups below. ``post_verify_commands`` further down already
+            # follows this convention.
+            state_by_uuid: dict[str, str] = {
+                str(uid): state for uid, state in Command.objects.filter(id__in=wanted_uuids).values_list("id", "state")
+            }
+            for proposal in eligible:
+                section_key = proposal.get("section_key", "")
+                cmd_uuid = proposal.get("command_uuid", "")
+                current_state = state_by_uuid.get(cmd_uuid)
+                reason: str | None = None
+                if current_state is None:
+                    reason = "command_not_found"
+                elif section_key in DIRECT_EDIT_SECTIONS:
+                    if current_state != "staged":
+                        reason = "state_mismatch_expected_staged"
+                else:
+                    if current_state == "entered_in_error":
+                        reason = "state_mismatch_already_voided"
+                if reason:
+                    conflicts.append(
+                        {
+                            "section_key": section_key,
+                            "command_type": proposal.get("command_type", ""),
+                            "command_uuid": cmd_uuid,
+                            "current_state": current_state or "missing",
+                            "reason": reason,
+                        }
+                    )
+        if not conflicts:
+            # Non-eligible proposals (section not allowlisted, no uuid) are
+            # silently dropped by build_amend_edit_effects and logged at WARN
+            # there. We don't surface them in the response - they signal a
+            # stale or buggy frontend, not a user-facing condition.
+            effects, attempted = build_amend_edit_effects(commands, note_uuid)
+
+        # Audit fires after the state read + effect-emission step. ``audit_event``
+        # catches broad Exception via log.exception, so an audit-write failure
+        # cannot suppress the response.
+        if conflicts:
+            audit_event(
+                note_uuid,
+                "AMEND_CONFLICT",
+                {"conflicts": conflicts, "submitted_count": len(commands)},
+            )
+            return [
+                JSONResponse(
+                    {
+                        "error": "State mismatch - reload required",
+                        "conflicts": conflicts,
+                    },
+                    status_code=HTTPStatus.CONFLICT,
+                )
+            ]
+
+        # HIPAA: the audit payload intentionally omits ``display``. For
+        # HPI / ROS / PE / lab_results / current_medications, ``display``
+        # is free-text clinical narrative; persisting it into the audit log
+        # would be PHI in a log, even truncated. The audit entries are built
+        # via dict comprehension over ``_AMEND_AUDIT_ENTRY_KEYS`` (a fixed
+        # module-level whitelist) so that a future change adding new keys to
+        # ``attempted`` records cannot silently propagate PHI here. Pinned
+        # by ``test_amend_audit_payload_does_not_propagate_new_attempted_keys``.
+        audit_event(
+            note_uuid,
+            "AMEND_EXISTING_COMMANDS",
+            {
+                "edit_count": len(attempted),
+                "effect_count": len(effects),
+                "entries": [{k: a[k] for k in _AMEND_AUDIT_ENTRY_KEYS if k in a} for a in attempted],
+            },
+        )
+        return [
+            JSONResponse(
+                {"attempted": attempted},
                 status_code=HTTPStatus.OK,
             ),
             *effects,
@@ -1219,8 +1470,6 @@ class ScribeSessionView(StaffSessionAuthMixin, SimpleAPI):
     @api.post("/verify-commands")
     def post_verify_commands(self) -> list[Union[Response, Effect]]:
         """Verify that attempted commands exist on the note with anchor objects."""
-        from canvas_sdk.v1.data.command import Command
-
         try:
             data: dict[str, Any] = json.loads(self.request.body)
         except (json.JSONDecodeError, ValueError) as exc:
@@ -1248,18 +1497,27 @@ class ScribeSessionView(StaffSessionAuthMixin, SimpleAPI):
                 reason = "no_anchor" if row else "not_found"
                 failed.append({**a, "reason": reason})
 
+        # HIPAA: ``display`` is intentionally omitted - it carries free-text
+        # clinical narrative for many command types. The audit retains the
+        # structural identifier (``command_uuid``) and ``type``; that's enough
+        # for incident triage without leaking PHI. Mirrors INSERT_COMMANDS /
+        # AMEND_EXISTING_COMMANDS hardening (KOALA-5485).
         audit_event(
             note_uuid,
             "COMMANDS_VERIFIED",
             {
                 "total": len(verified) + len(failed),
                 "verified": [
-                    {"type": v.get("command_type", ""), "display": (v.get("display") or "")[:80]} for v in verified
+                    {
+                        "type": v.get("command_type", ""),
+                        "command_uuid": v.get("command_uuid", ""),
+                    }
+                    for v in verified
                 ],
                 "failed": [
                     {
                         "type": f.get("command_type", ""),
-                        "display": (f.get("display") or "")[:80],
+                        "command_uuid": f.get("command_uuid", ""),
                         "reason": f.get("reason", ""),
                     }
                     for f in failed

--- a/hyperscribe/scribe/commands/builder.py
+++ b/hyperscribe/scribe/commands/builder.py
@@ -7,6 +7,7 @@ from typing import Any
 from canvas_sdk.commands.base import _BaseCommand
 from canvas_sdk.effects import Effect
 from canvas_sdk.v1.data.note import Note
+from logger import log
 
 from hyperscribe.scribe.backend.models import CommandProposal
 from hyperscribe.scribe.commands.adjust_prescription import AdjustPrescriptionParser
@@ -203,3 +204,297 @@ def build_metadata_effects(pending: list[dict[str, Any]]) -> list[Effect]:
         for key, value in item.get("metadata", {}).items():
             effects.append(command.upsert_metadata(key, value))
     return effects
+
+
+# ----------------------------------------------------------------------
+# Amendment edit path (KOALA-5485)
+#
+# When a provider clicks "Make changes" after approving the scribe note,
+# they can edit the content of already-documented sections. The sections in
+# EDITABLE_AMEND_SECTIONS support content edits during amendment; sections
+# outside the allowlist stay locked.
+#
+# The allowlist covers EVERY ``_BUILDERS`` command_type EXCEPT clinical
+# orders (prescribe, refill, adjust_prescription, refer, imaging_order,
+# lab_order) and questionnaires. Orders have downstream external workflow
+# implications (pharmacy dispatch, referral letters, lab tickets) that make
+# void+recreate unsafe in this context. Questionnaire amendment is a future
+# ticket: its insert flow is ``originate + edit + commit`` (the edit applies
+# responses), which doesn't fit any of the three buckets below; a dedicated
+# 4-effect route would be needed.
+#
+# This constant is mirrored in:
+#   - hyperscribe/scribe/static/summary.js (EDITABLE_AMEND_SECTIONS)
+#   - hyperscribe/scribe/static/soap-group.js (EDITABLE_AMEND_SECTIONS)
+# Keep all three in sync (single-sourcing is a planned follow-up ticket).
+#
+# Three routes, picked per-proposal by section_key:
+#   1) DIRECT_EDIT (RFV / chief_complaint) - emit EDIT only, reuse uuid.
+#      RFV is the only section whose home-app interpreter wires EDIT but
+#      NOT COMMIT or ENTER_IN_ERROR. The command stays STAGED forever, so
+#      EDIT works and EIE would silently no-op (state corruption).
+#   2) CUSTOM_COMMAND_ROUTED (_ros, physical_exam, _chart_review,
+#      _history_review, lab_results, imaging_results) - emit
+#      EnterInError(old) + Originate(new). ALL CustomCommand subclasses share
+#      Meta.key "customCommand" (forcibly set by __init_subclass__), so their
+#      constantized_key is "CUSTOM_COMMAND". The Canvas SDK only declares
+#      ORIGINATE_CUSTOM_COMMAND_COMMAND and ENTER_IN_ERROR_CUSTOM_COMMAND_COMMAND
+#      in the protobuf enum - calling .commit() raises
+#      ValueError("unknown enum label \"COMMIT_CUSTOM_COMMAND_COMMAND\"")
+#      at Python build time. home-app's OriginateCustomCommand interpreter
+#      auto-commits unconditionally after originate, so no explicit commit
+#      effect is needed (and would crash).
+#   3) VOID_RECREATE (everything else: HPI, vitals, allergies, current_meds,
+#      structured PMH/PSH/PFH, plan/A&P diagnose/assess, charges, tasks,
+#      stop_med, remove_allergy, resolve_condition, and the ad-hoc buckets
+#      where these commands originate before being saved). Emit
+#      EnterInError(old) + Originate(new) + Commit(new). Dedicated SDK
+#      command classes have their constantized key wired into both the SDK
+#      proto AND home-app interpreters for all three effects.
+# ----------------------------------------------------------------------
+
+EDITABLE_AMEND_SECTIONS: frozenset[str] = frozenset(
+    {
+        # DIRECT_EDIT bucket
+        "chief_complaint",
+        # CUSTOM_COMMAND_ROUTED bucket
+        "_ros",
+        "_history_review",
+        "_chart_review",
+        "physical_exam",
+        "lab_results",
+        "imaging_results",
+        # VOID_RECREATE bucket - SOAP-section-anchored
+        "history_of_present_illness",
+        "current_medications",
+        "allergies",
+        "vitals",
+        "past_medical_history",
+        "past_surgical_history",
+        "family_history",
+        "assessment_and_plan",
+        "plan",
+        # VOID_RECREATE bucket - ad-hoc buckets (rows added during a session;
+        # after approval+reload they retain these section_keys and may be
+        # ``already_documented=true``)
+        "_ad_hoc",
+        "_objective_ad_hoc",
+        "_history_ad_hoc",
+        "_charges_ad_hoc",
+    }
+)
+
+# Cross-repo invariant (NOT enforced in CI yet - follow-up ticket).
+#
+# The direct-EDIT path for chief_complaint (RFV) is load-bearing on home-app
+# NOT wiring either of these interpreters:
+#   * COMMIT_REASON_FOR_VISIT_COMMAND
+#   * ENTER_IN_ERROR_REASON_FOR_VISIT_COMMAND
+#
+# As of this writing, the registry at
+#   canvas-monorepo/home-app/plugin_io/interpreters/commands/__init__.py
+# (around line 395) declares neither. That means RFV commands stay STAGED
+# forever and ``EditCommandEffectInterpreter`` accepts edits. If a home-app PR
+# adds either wiring, RFV becomes committable and the direct-EDIT path here
+# silently breaks - the EDIT effect lands on a COMMITTED row and home-app
+# rejects it with "Command must be staged in order to be edited."
+#
+# If you're adding to home-app's interpreter registry: revisit this carve-out.
+# Either (a) drop chief_complaint from DIRECT_EDIT_SECTIONS and let it fall
+# through to the void+recreate path below, or (b) confirm the new wiring
+# preserves the STAGED-forever guarantee for RFV.
+#
+# Follow-up: a workflows/ CI job that asserts this invariant cross-repo on
+# every home-app PR would catch the bug at the source instead of relying on
+# this comment. Tracked separately.
+DIRECT_EDIT_SECTIONS: frozenset[str] = frozenset({"chief_complaint"})
+
+# Sections whose parser builds a CustomCommand instance. These cannot call
+# .commit() (the COMMIT_CUSTOM_COMMAND_COMMAND enum does not exist), so the
+# amend route is EnterInError(old) + Originate(new) only; home-app's
+# OriginateCustomCommand interpreter auto-commits after originate.
+#
+# The parsers in this set ALL return ``CustomCommand(schema_key=...)`` rather
+# than a dedicated SDK class:
+#   * RosParser            -> CustomCommand("reviewOfSystems")
+#   * HistoryReviewParser  -> CustomCommand("historyReview")
+#   * ChartReviewParser    -> CustomCommand("chartReview")
+#   * PhysicalExamParser   -> CustomCommand("physicalExam")
+#   * LabResultsParser     -> CustomCommand("labResult")
+#   * ImageResultsParser   -> CustomCommand("imageResult")
+CUSTOM_COMMAND_ROUTED_SECTIONS: frozenset[str] = frozenset(
+    {
+        "_ros",
+        "_history_review",
+        "_chart_review",
+        "physical_exam",
+        "lab_results",
+        "imaging_results",
+    }
+)
+
+# Command types that MUST NEVER be amended via the void+recreate path,
+# regardless of which section_key they land on.
+#
+# Three reasons a command_type lands here:
+#
+#   1. STRUCTURALLY IMPOSSIBLE: no COMMIT_*_COMMAND interpreter exists in
+#      home-app, so the third effect of the EIE+Originate+Commit route
+#      cannot execute. The Originate either dangles in STAGED forever or
+#      home-app's plugin_runner_receiver rejects the Commit.
+#
+#   2. STRUCTURALLY AWKWARD: the command has no COMMIT_*_COMMAND
+#      interpreter but DOES have an EnterInError interpreter, so EIE works
+#      but the Originate+Commit half breaks. A 4-effect EIE+Originate+
+#      Edit+Commit route (or equivalent) would be needed and isn't built.
+#
+#   3. POLICY EXCLUDED: the wiring exists end-to-end, but void+recreate is
+#      the wrong abstraction for the workflow. Calling it after the command
+#      has already triggered external action would either re-fire the
+#      dispatch or leave the original in a half-cancelled state. A dedicated
+#      "amend an order" workflow with explicit cancel/resend semantics is
+#      the right shape; tracked separately.
+#
+#   4. DEFERRED: a workable route exists in principle but hasn't been built.
+#      Questionnaire's insert flow is originate+edit+commit (the edit
+#      applies responses to the staged command), so the amend route needs
+#      4 effects (EIE+Originate+Edit+Commit) AND the question/response
+#      state has to survive the recreate. Tracked as a follow-up.
+#
+# Mirrored intent: the JS allowlists omit `_subjective_ad_hoc` (questionnaire
+# bucket) and `_recommended` (order recommendation bucket), but command_type
+# is the authoritative gate because some commands (`prescribe`, `task`) can
+# also be added via `_ad_hoc`. Section-key plus command-type together make
+# the denial structural rather than relying on the frontend not to send the
+# request.
+#
+# Keep the JS mirror (soap-group.js + summary.js) in sync with the same
+# categorization comments until single-sourcing lands.
+NON_EDITABLE_AMEND_COMMAND_TYPES: frozenset[str] = frozenset(
+    {
+        # 1. Structurally impossible (no COMMIT_*_COMMAND interpreter):
+        #    Originate dangles in STAGED; pharmacy dispatch via SureScripts
+        #    would also re-fire on a Commit if one existed.
+        "prescribe",
+        "refill",
+        "adjust_prescription",
+        # 2. Structurally awkward (EIE exists, no COMMIT - would need a
+        #    4-effect amend route that isn't built yet):
+        "refer",
+        "imaging_order",
+        # 3. Policy excluded (full home-app wiring exists; amend after the
+        #    lab-partner ticket has been dispatched would create downstream
+        #    confusion at the partner side - a cancel/resend workflow is
+        #    the right shape):
+        "lab_order",
+        # 4. Deferred (4-effect EIE+Originate+Edit+Commit route + question/
+        #    response state preservation needed):
+        "questionnaire",
+    }
+)
+
+
+def build_amend_edit_effects(
+    proposals: list[dict[str, Any]],
+    note_uuid: str,
+) -> tuple[list[Effect], list[dict[str, Any]]]:
+    """Build Canvas SDK Effects for amendment-mode edits of already-documented commands.
+
+    Each proposal must carry the existing ``command_uuid`` and a ``section_key``
+    in :data:`EDITABLE_AMEND_SECTIONS`. Proposals that fail either check are
+    silently dropped and logged at WARN (defense in depth - we never trust a
+    hand-crafted payload enough to invent a uuid or emit effects for a
+    non-amendable section).
+
+    Returns ``(effects, attempted)`` where ``attempted`` carries enough state
+    for the API layer to (a) emit a structured audit-log entry and (b) let the
+    frontend re-stamp ``ScribeSummary.commands`` with the new uuid after a
+    void+recreate.
+    """
+    effects: list[Effect] = []
+    attempted: list[dict[str, Any]] = []
+
+    for proposal in proposals:
+        section_key = proposal.get("section_key", "")
+        command_type = proposal.get("command_type", "")
+        old_command_uuid = proposal.get("command_uuid", "")
+
+        if section_key not in EDITABLE_AMEND_SECTIONS:
+            log.warning(
+                "amend_edit_dropped: section_not_editable section_key=%s command_type=%s",
+                section_key,
+                command_type,
+            )
+            continue
+        if command_type in NON_EDITABLE_AMEND_COMMAND_TYPES:
+            # Orders (prescribe family + refer + imaging/lab order) and
+            # questionnaires are categorically denied regardless of which
+            # section_key the frontend ships, because the ad-hoc section_keys
+            # (_ad_hoc, _objective_ad_hoc, ...) are shared with editable
+            # command_types and the section-key check alone would let an
+            # order ride through.
+            log.warning(
+                "amend_edit_dropped: command_type_not_editable section_key=%s command_type=%s",
+                section_key,
+                command_type,
+            )
+            continue
+        if not old_command_uuid:
+            log.warning(
+                "amend_edit_dropped: missing_command_uuid section_key=%s command_type=%s",
+                section_key,
+                command_type,
+            )
+            continue
+        builder = _BUILDERS.get(command_type)
+        if builder is None:
+            log.warning(
+                "amend_edit_dropped: unknown_command_type section_key=%s command_type=%s",
+                section_key,
+                command_type,
+            )
+            continue
+
+        data = proposal.get("data", {}) or {}
+
+        if section_key in DIRECT_EDIT_SECTIONS:
+            # RFV direct-edit path: keep the existing uuid, emit EDIT only.
+            command = builder.build(data, note_uuid, old_command_uuid)
+            effects.append(command.edit())
+            attempted.append(
+                {
+                    "section_key": section_key,
+                    "command_type": command_type,
+                    "old_command_uuid": old_command_uuid,
+                    "new_command_uuid": old_command_uuid,
+                    "mode": "direct_edit",
+                    "display": (proposal.get("display") or "")[:80],
+                }
+            )
+            continue
+
+        # EnterInError(old) + Originate(new). Two flavors:
+        # - CustomCommand-routed: no explicit commit (home-app auto-commits).
+        # - Dedicated SDK class: explicit Commit(new).
+        old_command = builder.build(data, note_uuid, old_command_uuid)
+        new_command_uuid = str(uuid.uuid4())
+        new_command = builder.build(data, note_uuid, new_command_uuid)
+        effects.append(old_command.enter_in_error())
+        effects.append(new_command.originate())
+        if section_key in CUSTOM_COMMAND_ROUTED_SECTIONS:
+            mode = "void_recreate_custom"
+        else:
+            effects.append(new_command.commit())
+            mode = "void_recreate"
+        attempted.append(
+            {
+                "section_key": section_key,
+                "command_type": command_type,
+                "old_command_uuid": old_command_uuid,
+                "new_command_uuid": new_command_uuid,
+                "mode": mode,
+                "display": (proposal.get("display") or "")[:80],
+            }
+        )
+
+    return effects, attempted

--- a/hyperscribe/scribe/static/soap-group.js
+++ b/hyperscribe/scribe/static/soap-group.js
@@ -14,6 +14,91 @@ import { QuestionnaireRow } from '/plugin-io/api/hyperscribe/scribe/static/quest
 
 const html = htm.bind(h);
 
+// KOALA-5485: section_keys whose already-documented commands can be edited
+// during amendment. RFV (chief_complaint) goes through a direct EDIT effect;
+// CustomCommand-routed sections (_ros, _history_review, _chart_review,
+// physical_exam, lab_results, imaging_results) go through EnterInError +
+// Originate; everything else goes through EnterInError + Originate + Commit.
+//
+// Covers every command_type in `_BUILDERS` EXCEPT orders (prescribe, refill,
+// adjust_prescription, refer, imaging_order, lab_order) and questionnaires
+// (which need a 4-effect amend route, deferred to a follow-up ticket).
+//
+// MIRRORED in three places - keep all in sync until single-sourcing lands
+// (follow-up ticket):
+//   - hyperscribe/scribe/commands/builder.py (EDITABLE_AMEND_SECTIONS)
+//   - hyperscribe/scribe/static/summary.js (EDITABLE_AMEND_SECTIONS)
+//   - hyperscribe/scribe/static/soap-group.js (this file)
+const EDITABLE_AMEND_SECTIONS = new Set([
+  // DIRECT_EDIT
+  'chief_complaint',
+  // CUSTOM_COMMAND_ROUTED
+  '_ros',
+  '_history_review',
+  '_chart_review',
+  'physical_exam',
+  'lab_results',
+  'imaging_results',
+  // VOID_RECREATE - SOAP-section-anchored
+  'history_of_present_illness',
+  'current_medications',
+  'allergies',
+  'vitals',
+  'past_medical_history',
+  'past_surgical_history',
+  'family_history',
+  'assessment_and_plan',
+  'plan',
+  // VOID_RECREATE - ad-hoc buckets (rows added during a session retain these
+  // section_keys after approval+reload).
+  '_ad_hoc',
+  '_objective_ad_hoc',
+  '_history_ad_hoc',
+  '_charges_ad_hoc',
+]);
+
+// Command types that MUST NEVER be amended, regardless of section_key.
+// Three reasons a command_type lands here (see builder.py for fuller writeup):
+//   1. STRUCTURALLY IMPOSSIBLE: no COMMIT_*_COMMAND interpreter in home-app.
+//   2. STRUCTURALLY AWKWARD: EIE works, no COMMIT - needs a 4-effect route.
+//   3. POLICY EXCLUDED: full wiring exists, but amend-after-dispatch is the
+//      wrong abstraction (a cancel/resend workflow is the right shape).
+//   4. DEFERRED: amend route hasn't been built (4-effect + state preservation).
+// MIRRORED with builder.py's NON_EDITABLE_AMEND_COMMAND_TYPES.
+const NON_EDITABLE_AMEND_COMMAND_TYPES = new Set([
+  // 1. Structurally impossible (no COMMIT_*_COMMAND interpreter):
+  'prescribe',
+  'refill',
+  'adjust_prescription',
+  // 2. Structurally awkward (EIE exists, no COMMIT - 4-effect route needed):
+  'refer',
+  'imaging_order',
+  // 3. Policy excluded (full wiring exists; amend after lab-partner ticket
+  //    dispatch creates downstream confusion - cancel/resend is the right shape):
+  'lab_order',
+  // 4. Deferred (4-effect route + question/response state preservation needed):
+  'questionnaire',
+]);
+
+// rowLockedDuringAmendment(command, readOnly, isAmending) returns true when
+// the row should remain read-only. The existing behavior was simply
+// `readOnly || already_documented`; during amendment we relax the lock for
+// commands whose section_key is in the editable allowlist AND whose
+// command_type is not in the denylist.
+function rowLocked(command, readOnly, isAmending) {
+  if (readOnly) return true;
+  if (!command.already_documented) return false;
+  if (
+    isAmending &&
+    command.command_uuid &&
+    EDITABLE_AMEND_SECTIONS.has(command.section_key) &&
+    !NON_EDITABLE_AMEND_COMMAND_TYPES.has(command.command_type)
+  ) {
+    return false;
+  }
+  return true;
+}
+
 const CHARGE_SEARCH_BASE = '/plugin-io/api/hyperscribe/scribe-session';
 const CHARGE_DEBOUNCE_MS = 300;
 
@@ -568,7 +653,7 @@ function AddConditionSearch({ onAdd, patientId }) {
   `;
 }
 
-export function SoapGroup({ title, groupColor, sections, commandBySectionKey, onEditCommand, onDeleteCommand, adHocCommands, assignees, onAddTask, onAddOrder, onAddPlan, onAddVitals, onAddMedication, onAddAllergy, onAddStopMedication, onAddRemoveAllergy, onAddResolveCondition, onAddHistory, onAddQuestionnaire, onAddCharge, onAddTemplateCharge, onRemoveChargeByCpt, templateCharges, readOnly, sectionConditions, patientId, noteId, staffId, staffName, recommendations, onEditRecommendation, onDeleteRecommendation, onAcceptRecommendation, onRejectRecommendation, onAddCondition, unmatchedConditions, diagnosisSuggestions, onAddNow, hideRejected, alertFacilityEnabled, onEditingChange }) {
+export function SoapGroup({ title, groupColor, sections, commandBySectionKey, onEditCommand, onDeleteCommand, adHocCommands, assignees, onAddTask, onAddOrder, onAddPlan, onAddVitals, onAddMedication, onAddAllergy, onAddStopMedication, onAddRemoveAllergy, onAddResolveCondition, onAddHistory, onAddQuestionnaire, onAddCharge, onAddTemplateCharge, onRemoveChargeByCpt, templateCharges, readOnly, isAmending, sectionConditions, patientId, noteId, staffId, staffName, recommendations, onEditRecommendation, onDeleteRecommendation, onAcceptRecommendation, onRejectRecommendation, onAddCondition, unmatchedConditions, diagnosisSuggestions, onAddNow, hideRejected, alertFacilityEnabled, onEditingChange }) {
   const coveredKeys = getCoveredKeys(commandBySectionKey);
 
   // In approved (readOnly) mode, only show items that actually made it into the note.
@@ -598,14 +683,15 @@ export function SoapGroup({ title, groupColor, sections, commandBySectionKey, on
           const filteredSections = (entry.command.data.sections || []).filter(s => !STRUCTURED_KEYS.has(s.key));
           if (filteredSections.length === 0) return null;
           const filteredCommand = { ...entry.command, data: { ...entry.command.data, sections: filteredSections } };
+          const rowReadOnly = rowLocked(entry.command, readOnly, isAmending);
           return html`
-            <div class=${`content-block rec-narrative${entry.command.already_documented ? ' command-locked' : ''}`}>
-              ${entry.command.already_documented && ICON_LOCK}
+            <div class=${`content-block rec-narrative${rowReadOnly && entry.command.already_documented ? ' command-locked' : ''}`}>
+              ${rowReadOnly && entry.command.already_documented && ICON_LOCK}
               <${HistoryReviewRow}
                 command=${filteredCommand}
                 commandIndex=${entry.index}
                 onEdit=${onEditCommand}
-                readOnly=${readOnly || entry.command.already_documented}
+                readOnly=${rowReadOnly}
                 onEditingChange=${onEditingChange}
               />
             </div>
@@ -636,9 +722,10 @@ export function SoapGroup({ title, groupColor, sections, commandBySectionKey, on
                     const aData = entry.command.data || {};
                     const aCode = aData.icd10_code ? aData.icd10_code.replace(/\./g, '').trim().toUpperCase() : '';
                     const aFormatted = aCode.length > 3 ? aCode.slice(0, 3) + '.' + aCode.slice(3) : aCode;
+                    const assessRowReadOnly = rowLocked(entry.command, readOnly, isAmending);
                     return html`
-                      <div class=${`content-block recommendation-block rec-assess${entry.command.already_documented ? ' command-locked' : ''}`} key=${entry.index}>
-                        ${entry.command.already_documented && ICON_LOCK}
+                      <div class=${`content-block recommendation-block rec-assess${assessRowReadOnly && entry.command.already_documented ? ' command-locked' : ''}`} key=${entry.index}>
+                        ${assessRowReadOnly && entry.command.already_documented && ICON_LOCK}
                         <div class="recommendation-content">
                           <div class="diagnose-row">
                             <div class="diagnose-row-header">
@@ -651,7 +738,7 @@ export function SoapGroup({ title, groupColor, sections, commandBySectionKey, on
                               command=${entry.command}
                               commandIndex=${entry.index}
                               onEdit=${onEditCommand}
-                              readOnly=${readOnly || entry.command.already_documented}
+                              readOnly=${assessRowReadOnly}
                               onEditingChange=${onEditingChange}
                             />
                           </div>
@@ -675,16 +762,17 @@ export function SoapGroup({ title, groupColor, sections, commandBySectionKey, on
                     const handleAcceptDiagnose = () => onEditCommand(entry.index, { ...entry.command.data, accepted: true, rejected: false }, 'diagnose');
                     const handleRejectDiagnose = () => onEditCommand(entry.index, { ...entry.command.data, rejected: true, accepted: false }, 'diagnose');
 
+                    const diagnoseRowReadOnly = rowLocked(entry.command, readOnly, isAmending);
                     return html`
-                      <div class=${`content-block recommendation-block rec-diagnose${isRejected ? ' rec-rejected' : ''}${entry.command.already_documented ? ' command-locked' : ''}`} key=${entry.index}>
-                        ${entry.command.already_documented && ICON_LOCK}
+                      <div class=${`content-block recommendation-block rec-diagnose${isRejected ? ' rec-rejected' : ''}${diagnoseRowReadOnly && entry.command.already_documented ? ' command-locked' : ''}`} key=${entry.index}>
+                        ${diagnoseRowReadOnly && entry.command.already_documented && ICON_LOCK}
                         <div class="recommendation-content">
                           <${DiagnoseRow}
                             command=${entry.command}
                             commandIndex=${entry.index}
                             onEdit=${onEditCommand}
                             onDelete=${onDeleteCommand}
-                            readOnly=${readOnly || isRejected || entry.command.already_documented}
+                            readOnly=${diagnoseRowReadOnly || isRejected}
                             suggestions=${suggestions}
                             onAccept=${handleAcceptDiagnose}
                             onEditingChange=${onEditingChange}
@@ -725,23 +813,25 @@ export function SoapGroup({ title, groupColor, sections, commandBySectionKey, on
                       </div>
                     </div>
                   `}
-                  ${(visibleAdHoc.filter(e => e.command.command_type === 'resolve_condition')).map(re => html`
-                    <div class=${`content-block recommendation-block rec-removal${re.command.already_documented ? ' command-locked' : ''}`} key=${re.index}>
-                      ${re.command.already_documented && ICON_LOCK}
+                  ${(visibleAdHoc.filter(e => e.command.command_type === 'resolve_condition')).map(re => {
+                    const reRowReadOnly = rowLocked(re.command, readOnly, isAmending);
+                    return html`
+                    <div class=${`content-block recommendation-block rec-removal${reRowReadOnly && re.command.already_documented ? ' command-locked' : ''}`} key=${re.index}>
+                      ${reRowReadOnly && re.command.already_documented && ICON_LOCK}
                       <div class="recommendation-content">
                         <${RemovalRow}
                           command=${re.command}
                           commandIndex=${re.index}
                           onEdit=${onEditCommand}
                           onDelete=${onDeleteCommand}
-                          readOnly=${readOnly || re.command.already_documented}
+                          readOnly=${reRowReadOnly}
                           patientId=${patientId}
                           alertFacilityEnabled=${alertFacilityEnabled}
                         />
                       </div>
                       ${!readOnly && !re.command.already_documented && !re.command._adding && html`<div class="recommendation-actions"><button type="button" class="rec-btn rec-btn-reject" onClick=${() => onDeleteCommand(re.index)} title="Remove">${ICON_X}</button></div>`}
                     </div>
-                  `)}
+                  `;})}
                   ${(onAddCondition || onAddResolveCondition) && !readOnly && html`
                     <div class="ad-hoc-buttons">
                       ${onAddCondition && html`<${AddConditionSearch} onAdd=${onAddCondition} patientId=${patientId} />`}
@@ -755,35 +845,38 @@ export function SoapGroup({ title, groupColor, sections, commandBySectionKey, on
             if (readOnly && !entry.command.display) return null;
             const showConditionBtns = isPlan && (onAddCondition || onAddResolveCondition) && !readOnly;
             const planResolves = isPlan ? visibleAdHoc.filter(e => e.command.command_type === 'resolve_condition') : [];
+            const narrativeRowReadOnly = rowLocked(entry.command, readOnly, isAmending);
             return html`
               <div class="subsection" key=${s.key}>
                 <div class="subsection-title">${s.title}</div>
-                <div class=${`content-block rec-narrative${entry.command.already_documented ? ' command-locked' : ''}`}>
-                  ${entry.command.already_documented && ICON_LOCK}
+                <div class=${`content-block rec-narrative${narrativeRowReadOnly && entry.command.already_documented ? ' command-locked' : ''}`}>
+                  ${narrativeRowReadOnly && entry.command.already_documented && ICON_LOCK}
                   <${CommandRow}
                     command=${entry.command}
                     commandIndex=${entry.index}
                     onEdit=${onEditCommand}
-                    readOnly=${readOnly || entry.command.already_documented}
+                    readOnly=${narrativeRowReadOnly}
                     onEditingChange=${onEditingChange}
                   />
                 </div>
-                ${planResolves.map(re => html`
-                  <div class=${`content-block recommendation-block rec-removal${re.command.already_documented ? ' command-locked' : ''}`} key=${re.index}>
-                    ${re.command.already_documented && ICON_LOCK}
+                ${planResolves.map(re => {
+                  const reRowReadOnly = rowLocked(re.command, readOnly, isAmending);
+                  return html`
+                  <div class=${`content-block recommendation-block rec-removal${reRowReadOnly && re.command.already_documented ? ' command-locked' : ''}`} key=${re.index}>
+                    ${reRowReadOnly && re.command.already_documented && ICON_LOCK}
                     <div class="recommendation-content">
                       <${RemovalRow}
                         command=${re.command}
                         commandIndex=${re.index}
                         onEdit=${onEditCommand}
                         onDelete=${onDeleteCommand}
-                        readOnly=${readOnly || re.command.already_documented}
+                        readOnly=${reRowReadOnly}
                         patientId=${patientId}
                       />
                     </div>
                     ${!readOnly && !re.command.already_documented && !re.command._adding && html`<div class="recommendation-actions"><button type="button" class="rec-btn rec-btn-reject" onClick=${() => onDeleteCommand(re.index)} title="Remove">${ICON_X}</button></div>`}
                   </div>
-                `)}
+                `;})}
                 ${showConditionBtns && html`
                   <div class="ad-hoc-buttons">
                     ${onAddCondition && html`<${AddConditionSearch} onAdd=${onAddCondition} patientId=${patientId} />`}
@@ -803,18 +896,20 @@ export function SoapGroup({ title, groupColor, sections, commandBySectionKey, on
             return html`
               <div class="subsection" key=${s.key}>
                 <div class="subsection-title">${s.title}</div>
-                ${allVitals.map(entry => html`
-                  <div class=${`content-block rec-vitals${entry.command.already_documented ? ' command-locked' : ''}`} key=${entry.index}>
-                    ${entry.command.already_documented && ICON_LOCK}
+                ${allVitals.map(entry => {
+                  const vitalsRowReadOnly = rowLocked(entry.command, readOnly, isAmending);
+                  return html`
+                  <div class=${`content-block rec-vitals${vitalsRowReadOnly && entry.command.already_documented ? ' command-locked' : ''}`} key=${entry.index}>
+                    ${vitalsRowReadOnly && entry.command.already_documented && ICON_LOCK}
                     <${VitalsRow}
                       command=${entry.command}
                       commandIndex=${entry.index}
                       onEdit=${onEditCommand}
-                      readOnly=${readOnly || entry.command.already_documented}
+                      readOnly=${vitalsRowReadOnly}
                       onEditingChange=${onEditingChange}
                     />
                   </div>
-                `)}
+                `;})}
                 ${onAddVitals && !readOnly && html`
                   <div class="ad-hoc-buttons">
                     <button type="button" class="ad-hoc-btn" onClick=${onAddVitals}>+ Vitals</button>
@@ -826,16 +921,17 @@ export function SoapGroup({ title, groupColor, sections, commandBySectionKey, on
 
           if (cmds && key === 'physical_exam') {
             const entry = cmds[0];
+            const peRowReadOnly = rowLocked(entry.command, readOnly, isAmending);
             return html`
               <div class="subsection" key=${s.key}>
                 <div class="subsection-title">${s.title}</div>
-                <div class=${`content-block rec-narrative${entry.command.already_documented ? ' command-locked' : ''}`}>
-                  ${entry.command.already_documented && ICON_LOCK}
+                <div class=${`content-block rec-narrative${peRowReadOnly && entry.command.already_documented ? ' command-locked' : ''}`}>
+                  ${peRowReadOnly && entry.command.already_documented && ICON_LOCK}
                   <${HistoryReviewRow}
                     command=${entry.command}
                     commandIndex=${entry.index}
                     onEdit=${onEditCommand}
-                    readOnly=${readOnly || entry.command.already_documented}
+                    readOnly=${peRowReadOnly}
                     textareaRows=${2}
                     onEditingChange=${onEditingChange}
                   />
@@ -854,9 +950,11 @@ export function SoapGroup({ title, groupColor, sections, commandBySectionKey, on
               return html`
                 <div class="subsection" key=${s.key}>
                   <div class="subsection-title">Med List Updates</div>
-                  ${(cmds || []).map(entry => html`
-                    <div class=${`content-block recommendation-block rec-medication${entry.command.already_documented ? ' command-locked' : ''}`} key=${entry.index}>
-                      ${entry.command.already_documented && ICON_LOCK}
+                  ${(cmds || []).map(entry => {
+                    const medRowReadOnly = rowLocked(entry.command, readOnly, isAmending);
+                    return html`
+                    <div class=${`content-block recommendation-block rec-medication${medRowReadOnly && entry.command.already_documented ? ' command-locked' : ''}`} key=${entry.index}>
+                      ${medRowReadOnly && entry.command.already_documented && ICON_LOCK}
                       <div class="recommendation-content">
                         <${MedicationRow}
                           command=${entry.command}
@@ -864,7 +962,7 @@ export function SoapGroup({ title, groupColor, sections, commandBySectionKey, on
                           onEdit=${onEditCommand}
                           onDelete=${onDeleteCommand}
                           alertFacilityEnabled=${alertFacilityEnabled}
-                          readOnly=${readOnly || entry.command.already_documented}
+                          readOnly=${medRowReadOnly}
                           onEditingChange=${onEditingChange}
                         />
                       </div>
@@ -878,10 +976,12 @@ export function SoapGroup({ title, groupColor, sections, commandBySectionKey, on
                         </div>
                       `}
                     </div>
-                  `)}
-                  ${adHocMeds.map(entry => html`
-                    <div class=${`content-block recommendation-block rec-medication${entry.command.already_documented ? ' command-locked' : ''}`} key=${entry.index}>
-                      ${entry.command.already_documented && ICON_LOCK}
+                  `;})}
+                  ${adHocMeds.map(entry => {
+                    const adHocMedRowReadOnly = rowLocked(entry.command, readOnly, isAmending);
+                    return html`
+                    <div class=${`content-block recommendation-block rec-medication${adHocMedRowReadOnly && entry.command.already_documented ? ' command-locked' : ''}`} key=${entry.index}>
+                      ${adHocMedRowReadOnly && entry.command.already_documented && ICON_LOCK}
                       <div class="recommendation-content">
                         <${MedicationRow}
                           command=${entry.command}
@@ -889,7 +989,7 @@ export function SoapGroup({ title, groupColor, sections, commandBySectionKey, on
                           onEdit=${onEditCommand}
                           onDelete=${onDeleteCommand}
                           alertFacilityEnabled=${alertFacilityEnabled}
-                          readOnly=${readOnly || entry.command.already_documented}
+                          readOnly=${adHocMedRowReadOnly}
                           onEditingChange=${onEditingChange}
                         />
                       </div>
@@ -903,21 +1003,22 @@ export function SoapGroup({ title, groupColor, sections, commandBySectionKey, on
                         </div>
                       `}
                     </div>
-                  `)}
+                  `;})}
                   ${medRecs.map(entry => {
                     const isAccepted = entry.command.accepted && !entry.command.rejected;
                     const isRejected = entry.command.rejected;
                     const isUnreviewed = !isAccepted && !isRejected;
+                    const medRecRowReadOnly = rowLocked(entry.command, readOnly, isAmending);
                     return html`
-                    <div class=${`content-block recommendation-block rec-medication${isRejected ? ' rec-rejected' : ''}${entry.command.already_documented ? ' command-locked' : ''}`} key=${'rec-med-' + entry.index}>
-                      ${entry.command.already_documented && ICON_LOCK}
+                    <div class=${`content-block recommendation-block rec-medication${isRejected ? ' rec-rejected' : ''}${medRecRowReadOnly && entry.command.already_documented ? ' command-locked' : ''}`} key=${'rec-med-' + entry.index}>
+                      ${medRecRowReadOnly && entry.command.already_documented && ICON_LOCK}
                       <div class="recommendation-content">
                         <${MedicationRow}
                           command=${entry.command}
                           commandIndex=${entry.index}
                           onEdit=${onEditRecommendation}
                           alertFacilityEnabled=${alertFacilityEnabled}
-                          readOnly=${readOnly || entry.command.already_documented || isRejected}
+                          readOnly=${medRecRowReadOnly || isRejected}
                           onEditingChange=${onEditingChange}
                         />
                       </div>
@@ -938,16 +1039,18 @@ export function SoapGroup({ title, groupColor, sections, commandBySectionKey, on
                     </div>
                     `;
                   })}
-                  ${adHocStopMeds.map(entry => html`
-                    <div class=${`content-block recommendation-block rec-removal${entry.command.already_documented ? ' command-locked' : ''}`} key=${entry.index}>
-                      ${entry.command.already_documented && ICON_LOCK}
+                  ${adHocStopMeds.map(entry => {
+                    const stopMedRowReadOnly = rowLocked(entry.command, readOnly, isAmending);
+                    return html`
+                    <div class=${`content-block recommendation-block rec-removal${stopMedRowReadOnly && entry.command.already_documented ? ' command-locked' : ''}`} key=${entry.index}>
+                      ${stopMedRowReadOnly && entry.command.already_documented && ICON_LOCK}
                       <div class="recommendation-content">
                         <${RemovalRow}
                           command=${entry.command}
                           commandIndex=${entry.index}
                           onEdit=${onEditCommand}
                           onDelete=${onDeleteCommand}
-                          readOnly=${readOnly || entry.command.already_documented}
+                          readOnly=${stopMedRowReadOnly}
                           patientId=${patientId}
                           alertFacilityEnabled=${alertFacilityEnabled}
                         />
@@ -960,7 +1063,7 @@ export function SoapGroup({ title, groupColor, sections, commandBySectionKey, on
                         ${!entry.command.already_documented && !entry.command._adding && html`<button type="button" class="rec-btn rec-btn-reject" onClick=${() => onDeleteCommand(entry.index)} title="Remove">${ICON_X}</button>`}
                       </div>`}
                     </div>
-                  `)}
+                  `;})}
                   ${(onAddMedication || onAddStopMedication) && !readOnly && html`
                     <div class="ad-hoc-buttons">
                       ${onAddMedication && html`<button type="button" class="ad-hoc-btn" onClick=${onAddMedication}>+ Medication</button>`}
@@ -982,16 +1085,18 @@ export function SoapGroup({ title, groupColor, sections, commandBySectionKey, on
               return html`
                 <div class="subsection" key=${s.key}>
                   <div class="subsection-title">Allergy List Updates</div>
-                  ${(cmds || []).map(entry => html`
-                    <div class=${`content-block recommendation-block rec-allergy${entry.command.already_documented ? ' command-locked' : ''}`} key=${entry.index}>
-                      ${entry.command.already_documented && ICON_LOCK}
+                  ${(cmds || []).map(entry => {
+                    const allergyRowReadOnly = rowLocked(entry.command, readOnly, isAmending);
+                    return html`
+                    <div class=${`content-block recommendation-block rec-allergy${allergyRowReadOnly && entry.command.already_documented ? ' command-locked' : ''}`} key=${entry.index}>
+                      ${allergyRowReadOnly && entry.command.already_documented && ICON_LOCK}
                       <div class="recommendation-content">
                         <${AllergyRow}
                           command=${entry.command}
                           commandIndex=${entry.index}
                           onEdit=${onEditCommand}
                           onDelete=${onDeleteCommand}
-                          readOnly=${readOnly || entry.command.already_documented}
+                          readOnly=${allergyRowReadOnly}
                           onEditingChange=${onEditingChange}
                         />
                       </div>
@@ -1001,17 +1106,19 @@ export function SoapGroup({ title, groupColor, sections, commandBySectionKey, on
                         </div>
                       `}
                     </div>
-                  `)}
-                  ${adHocAllergies.map(entry => html`
-                    <div class=${`content-block recommendation-block rec-allergy${entry.command.already_documented ? ' command-locked' : ''}`} key=${entry.index}>
-                      ${entry.command.already_documented && ICON_LOCK}
+                  `;})}
+                  ${adHocAllergies.map(entry => {
+                    const adHocAllergyRowReadOnly = rowLocked(entry.command, readOnly, isAmending);
+                    return html`
+                    <div class=${`content-block recommendation-block rec-allergy${adHocAllergyRowReadOnly && entry.command.already_documented ? ' command-locked' : ''}`} key=${entry.index}>
+                      ${adHocAllergyRowReadOnly && entry.command.already_documented && ICON_LOCK}
                       <div class="recommendation-content">
                         <${AllergyRow}
                           command=${entry.command}
                           commandIndex=${entry.index}
                           onEdit=${onEditCommand}
                           onDelete=${onDeleteCommand}
-                          readOnly=${readOnly || entry.command.already_documented}
+                          readOnly=${adHocAllergyRowReadOnly}
                           onEditingChange=${onEditingChange}
                         />
                       </div>
@@ -1021,19 +1128,20 @@ export function SoapGroup({ title, groupColor, sections, commandBySectionKey, on
                         </div>
                       `}
                     </div>
-                  `)}
+                  `;})}
                   ${allergyRecs.map(entry => {
                     const isAccepted = entry.command.accepted && !entry.command.rejected;
                     const isRejected = entry.command.rejected;
+                    const allergyRecRowReadOnly = rowLocked(entry.command, readOnly, isAmending);
                     return html`
-                    <div class=${`content-block recommendation-block rec-allergy${isRejected ? ' rec-rejected' : ''}${entry.command.already_documented ? ' command-locked' : ''}`} key=${'rec-allergy-' + entry.index}>
-                      ${entry.command.already_documented && ICON_LOCK}
+                    <div class=${`content-block recommendation-block rec-allergy${isRejected ? ' rec-rejected' : ''}${allergyRecRowReadOnly && entry.command.already_documented ? ' command-locked' : ''}`} key=${'rec-allergy-' + entry.index}>
+                      ${allergyRecRowReadOnly && entry.command.already_documented && ICON_LOCK}
                       <div class="recommendation-content">
                         <${AllergyRow}
                           command=${entry.command}
                           commandIndex=${entry.index}
                           onEdit=${onEditRecommendation}
-                          readOnly=${readOnly || entry.command.already_documented || isRejected}
+                          readOnly=${allergyRecRowReadOnly || isRejected}
                           onEditingChange=${onEditingChange}
                         />
                       </div>
@@ -1051,23 +1159,25 @@ export function SoapGroup({ title, groupColor, sections, commandBySectionKey, on
                     </div>
                     `;
                   })}
-                  ${adHocRemoveAllergies.map(entry => html`
-                    <div class=${`content-block recommendation-block rec-removal${entry.command.already_documented ? ' command-locked' : ''}`} key=${entry.index}>
-                      ${entry.command.already_documented && ICON_LOCK}
+                  ${adHocRemoveAllergies.map(entry => {
+                    const removeAllergyRowReadOnly = rowLocked(entry.command, readOnly, isAmending);
+                    return html`
+                    <div class=${`content-block recommendation-block rec-removal${removeAllergyRowReadOnly && entry.command.already_documented ? ' command-locked' : ''}`} key=${entry.index}>
+                      ${removeAllergyRowReadOnly && entry.command.already_documented && ICON_LOCK}
                       <div class="recommendation-content">
                         <${RemovalRow}
                           command=${entry.command}
                           commandIndex=${entry.index}
                           onEdit=${onEditCommand}
                           onDelete=${onDeleteCommand}
-                          readOnly=${readOnly || entry.command.already_documented}
+                          readOnly=${removeAllergyRowReadOnly}
                           patientId=${patientId}
                           alertFacilityEnabled=${alertFacilityEnabled}
                         />
                       </div>
                       ${!readOnly && !entry.command.already_documented && !entry.command._adding && html`<div class="recommendation-actions"><button type="button" class="rec-btn rec-btn-reject" onClick=${() => onDeleteCommand(entry.index)} title="Remove">${ICON_X}</button></div>`}
                     </div>
-                  `)}
+                  `;})}
                   ${(onAddAllergy || onAddRemoveAllergy) && !readOnly && html`
                     <div class="ad-hoc-buttons">
                       ${onAddAllergy && html`<button type="button" class="ad-hoc-btn" onClick=${onAddAllergy}>+ Allergy</button>`}
@@ -1093,22 +1203,24 @@ export function SoapGroup({ title, groupColor, sections, commandBySectionKey, on
             <div class="subsection" key=${s.key}>
               <div class="subsection-title">${s.title}</div>
               ${showHistoryText && html`<p class="section-text">${s.text}</p>`}
-              ${historyEntries.map(entry => html`
-                <div class=${`content-block recommendation-block rec-history${entry.command.already_documented ? ' command-locked' : ''}`} key=${entry.index}>
-                  ${entry.command.already_documented && ICON_LOCK}
+              ${historyEntries.map(entry => {
+                const historyRowReadOnly = rowLocked(entry.command, readOnly, isAmending);
+                return html`
+                <div class=${`content-block recommendation-block rec-history${historyRowReadOnly && entry.command.already_documented ? ' command-locked' : ''}`} key=${entry.index}>
+                  ${historyRowReadOnly && entry.command.already_documented && ICON_LOCK}
                   <div class="recommendation-content">
                     <${HistoryEntryRow}
                       command=${entry.command}
                       commandIndex=${entry.index}
                       onEdit=${onEditCommand}
                       onDelete=${onDeleteCommand}
-                      readOnly=${readOnly || entry.command.already_documented}
+                      readOnly=${historyRowReadOnly}
                       onEditingChange=${onEditingChange}
                     />
                   </div>
                   ${!readOnly && !entry.command.already_documented && !entry.command._adding && html`<div class="recommendation-actions"><button type="button" class="rec-btn rec-btn-reject" onClick=${() => onDeleteCommand(entry.index)} title="Remove">${ICON_X}</button></div>`}
                 </div>
-              `)}
+              `;})}
               ${historyType && onAddHistory && !readOnly && html`
                 <div class="ad-hoc-buttons">
                   <button type="button" class="ad-hoc-btn" onClick=${() => onAddHistory(historyType)}>${HISTORY_ADD_LABELS[historyType]}</button>
@@ -1117,23 +1229,25 @@ export function SoapGroup({ title, groupColor, sections, commandBySectionKey, on
               ${PLAN_SECTIONS.has(key) && (() => {
                 const adHocResolves = visibleAdHoc.filter(e => e.command.command_type === 'resolve_condition');
                 return html`
-                  ${adHocResolves.map(entry => html`
-                    <div class=${`content-block recommendation-block rec-removal${entry.command.already_documented ? ' command-locked' : ''}`} key=${entry.index}>
-                      ${entry.command.already_documented && ICON_LOCK}
+                  ${adHocResolves.map(entry => {
+                    const resolveRowReadOnly = rowLocked(entry.command, readOnly, isAmending);
+                    return html`
+                    <div class=${`content-block recommendation-block rec-removal${resolveRowReadOnly && entry.command.already_documented ? ' command-locked' : ''}`} key=${entry.index}>
+                      ${resolveRowReadOnly && entry.command.already_documented && ICON_LOCK}
                       <div class="recommendation-content">
                         <${RemovalRow}
                           command=${entry.command}
                           commandIndex=${entry.index}
                           onEdit=${onEditCommand}
                           onDelete=${onDeleteCommand}
-                          readOnly=${readOnly || entry.command.already_documented}
+                          readOnly=${resolveRowReadOnly}
                           patientId=${patientId}
                           alertFacilityEnabled=${alertFacilityEnabled}
                         />
                       </div>
                       ${!readOnly && !entry.command.already_documented && !entry.command._adding && html`<div class="recommendation-actions"><button type="button" class="rec-btn rec-btn-reject" onClick=${() => onDeleteCommand(entry.index)} title="Remove">${ICON_X}</button></div>`}
                     </div>
-                  `)}
+                  `;})}
                   ${(onAddCondition || onAddResolveCondition) && !readOnly && html`
                     <div class="ad-hoc-buttons">
                       ${onAddCondition && html`<${AddConditionSearch} onAdd=${onAddCondition} patientId=${patientId} />`}
@@ -1151,15 +1265,16 @@ export function SoapGroup({ title, groupColor, sections, commandBySectionKey, on
           const cmds = commandBySectionKey && commandBySectionKey[review.sectionKey];
           if (!cmds || cmds.length === 0) return null;
           const entry = cmds[0];
+          const rosRowReadOnly = rowLocked(entry.command, readOnly, isAmending);
           return html`
             <div class="subsection-title">Review of Systems</div>
-            <div class=${`content-block rec-narrative${entry.command.already_documented ? ' command-locked' : ''}`}>
-              ${entry.command.already_documented && ICON_LOCK}
+            <div class=${`content-block rec-narrative${rosRowReadOnly && entry.command.already_documented ? ' command-locked' : ''}`}>
+              ${rosRowReadOnly && entry.command.already_documented && ICON_LOCK}
               <${HistoryReviewRow}
                 command=${entry.command}
                 commandIndex=${entry.index}
                 onEdit=${onEditCommand}
-                readOnly=${readOnly || entry.command.already_documented}
+                readOnly=${rosRowReadOnly}
                 textareaRows=${2}
                 onEditingChange=${onEditingChange}
               />
@@ -1174,9 +1289,10 @@ export function SoapGroup({ title, groupColor, sections, commandBySectionKey, on
           if (type === 'remove_allergy') return null;
           if (type === 'resolve_condition') return null;
           if (type === 'task') {
+            const taskRowReadOnly = rowLocked(entry.command, readOnly, isAmending);
             return html`
-              <div class=${`content-block recommendation-block rec-task${entry.command.already_documented ? ' command-locked' : ''}`} key=${entry.index}>
-                ${entry.command.already_documented && ICON_LOCK}
+              <div class=${`content-block recommendation-block rec-task${taskRowReadOnly && entry.command.already_documented ? ' command-locked' : ''}`} key=${entry.index}>
+                ${taskRowReadOnly && entry.command.already_documented && ICON_LOCK}
                 <div class="recommendation-content">
                   <${TaskRow}
                     command=${entry.command}
@@ -1184,7 +1300,7 @@ export function SoapGroup({ title, groupColor, sections, commandBySectionKey, on
                     onEdit=${onEditCommand}
                     onDelete=${onDeleteCommand}
                     assignees=${assignees}
-                    readOnly=${readOnly || entry.command.already_documented}
+                    readOnly=${taskRowReadOnly}
                     onEditingChange=${onEditingChange}
                   />
                 </div>
@@ -1225,16 +1341,17 @@ export function SoapGroup({ title, groupColor, sections, commandBySectionKey, on
               if (!d.diagnosis_codes || d.diagnosis_codes.length === 0) orderMissing.push('Indications');
             }
             const orderIncomplete = orderMissing.length > 0;
+            const orderRowReadOnly = rowLocked(entry.command, readOnly, isAmending);
             return html`
-              <div class=${`content-block recommendation-block rec-order${entry.command.already_documented ? ' command-locked' : ''}`} key=${entry.index}>
-                ${entry.command.already_documented && ICON_LOCK}
+              <div class=${`content-block recommendation-block rec-order${orderRowReadOnly && entry.command.already_documented ? ' command-locked' : ''}`} key=${entry.index}>
+                ${orderRowReadOnly && entry.command.already_documented && ICON_LOCK}
                 <div class="recommendation-content">
                   <${OrderRow}
                     command=${entry.command}
                     commandIndex=${entry.index}
                     onEdit=${onEditCommand}
                     onDelete=${onDeleteCommand}
-                    readOnly=${readOnly || entry.command.already_documented}
+                    readOnly=${orderRowReadOnly}
                     patientId=${patientId}
                     noteId=${noteId}
                     staffId=${staffId}
@@ -1272,16 +1389,17 @@ export function SoapGroup({ title, groupColor, sections, commandBySectionKey, on
           if (HISTORY_TYPES.has(type)) return null;
           if (type === 'questionnaire') return null;
           if (type === 'plan') {
+            const planRowReadOnly = rowLocked(entry.command, readOnly, isAmending);
             return html`
-              <div class=${`content-block recommendation-block rec-plan${entry.command.already_documented ? ' command-locked' : ''}`} key=${entry.index}>
-                ${entry.command.already_documented && ICON_LOCK}
+              <div class=${`content-block recommendation-block rec-plan${planRowReadOnly && entry.command.already_documented ? ' command-locked' : ''}`} key=${entry.index}>
+                ${planRowReadOnly && entry.command.already_documented && ICON_LOCK}
                 <div class="recommendation-content">
                   <${CommandRow}
                     command=${entry.command}
                     commandIndex=${entry.index}
                     onEdit=${onEditCommand}
                     onDelete=${onDeleteCommand}
-                    readOnly=${readOnly || entry.command.already_documented}
+                    readOnly=${planRowReadOnly}
                     onEditingChange=${onEditingChange}
                   />
                 </div>
@@ -1291,16 +1409,17 @@ export function SoapGroup({ title, groupColor, sections, commandBySectionKey, on
           }
           if (type === 'perform') return null;
           if (REMOVAL_TYPES.has(type)) {
+            const removalRowReadOnly = rowLocked(entry.command, readOnly, isAmending);
             return html`
-              <div class=${`content-block recommendation-block rec-removal${entry.command.already_documented ? ' command-locked' : ''}`} key=${entry.index}>
-                ${entry.command.already_documented && ICON_LOCK}
+              <div class=${`content-block recommendation-block rec-removal${removalRowReadOnly && entry.command.already_documented ? ' command-locked' : ''}`} key=${entry.index}>
+                ${removalRowReadOnly && entry.command.already_documented && ICON_LOCK}
                 <div class="recommendation-content">
                   <${RemovalRow}
                     command=${entry.command}
                     commandIndex=${entry.index}
                     onEdit=${onEditCommand}
                     onDelete=${onDeleteCommand}
-                    readOnly=${readOnly || entry.command.already_documented}
+                    readOnly=${removalRowReadOnly}
                     patientId=${patientId}
                   />
                 </div>
@@ -1317,22 +1436,24 @@ export function SoapGroup({ title, groupColor, sections, commandBySectionKey, on
           return html`
             <div class="subsection">
               <div class="subsection-title">Questionnaires</div>
-              ${questionnaireCommands.map(entry => html`
-                <div class=${`content-block recommendation-block rec-questionnaire${entry.command.already_documented ? ' command-locked' : ''}`} key=${entry.index}>
-                  ${entry.command.already_documented && ICON_LOCK}
+              ${questionnaireCommands.map(entry => {
+                const questionnaireRowReadOnly = rowLocked(entry.command, readOnly, isAmending);
+                return html`
+                <div class=${`content-block recommendation-block rec-questionnaire${questionnaireRowReadOnly && entry.command.already_documented ? ' command-locked' : ''}`} key=${entry.index}>
+                  ${questionnaireRowReadOnly && entry.command.already_documented && ICON_LOCK}
                   <div class="recommendation-content">
                     <${QuestionnaireRow}
                       command=${entry.command}
                       commandIndex=${entry.index}
                       onEdit=${onEditCommand}
                       onDelete=${onDeleteCommand}
-                      readOnly=${readOnly || entry.command.already_documented}
+                      readOnly=${questionnaireRowReadOnly}
                       onEditingChange=${onEditingChange}
                     />
                   </div>
                   ${!readOnly && !entry.command.already_documented && !entry.command._adding && html`<div class="recommendation-actions"><button type="button" class="rec-btn rec-btn-reject" onClick=${() => onDeleteCommand(entry.index)} title="Remove">${ICON_X}</button></div>`}
                 </div>
-              `)}
+              `;})}
               ${onAddQuestionnaire && !readOnly && html`
                 <div class="ad-hoc-buttons">
                   <button type="button" class="ad-hoc-btn" onClick=${onAddQuestionnaire}>+ Questionnaire</button>
@@ -1409,7 +1530,9 @@ export function SoapGroup({ title, groupColor, sections, commandBySectionKey, on
             ...(templateCharges || []).map(c => c.cpt_code),
             ...visibleAdHoc.filter(e => e.command.command_type === 'perform' && e.command.data.cpt_code).map(e => e.command.data.cpt_code),
           ]);
-          return pending.map(entry => html`
+          return pending.map(entry => {
+            const chargeRowReadOnly = rowLocked(entry.command, readOnly, isAmending);
+            return html`
             <div class="content-block recommendation-block rec-charge" key=${entry.index}>
               <div class="recommendation-content">
                 <${ChargeRow}
@@ -1417,14 +1540,14 @@ export function SoapGroup({ title, groupColor, sections, commandBySectionKey, on
                   commandIndex=${entry.index}
                   onEdit=${onEditCommand}
                   onDelete=${onDeleteCommand}
-                  readOnly=${readOnly || entry.command.already_documented}
+                  readOnly=${chargeRowReadOnly}
                   excludeCpts=${allChecklistCpts}
                   onEditingChange=${onEditingChange}
                 />
               </div>
               ${!readOnly && !entry.command.already_documented && !entry.command._adding && html`<div class="recommendation-actions"><button type="button" class="rec-btn rec-btn-reject" onClick=${() => onDeleteCommand(entry.index)} title="Remove">${ICON_X}</button></div>`}
             </div>
-          `);
+          `;});
         })()}
         ${onAddCharge && !readOnly && html`
           <div class="ad-hoc-buttons">
@@ -1452,16 +1575,17 @@ export function SoapGroup({ title, groupColor, sections, commandBySectionKey, on
                 const isIncomplete = missingFields.length > 0;
                 const isAccepted = entry.command.accepted && !entry.command.rejected;
                 const isRejected = entry.command.rejected;
+                const rxRecRowReadOnly = rowLocked(entry.command, readOnly, isAmending);
 
                 return html`
-                <div class=${`content-block recommendation-block rec-prescribe${isRejected ? ' rec-rejected' : ''}${entry.command.already_documented ? ' command-locked' : ''}`} key=${'rec-rx-' + entry.index}>
-                  ${entry.command.already_documented && ICON_LOCK}
+                <div class=${`content-block recommendation-block rec-prescribe${isRejected ? ' rec-rejected' : ''}${rxRecRowReadOnly && entry.command.already_documented ? ' command-locked' : ''}`} key=${'rec-rx-' + entry.index}>
+                  ${rxRecRowReadOnly && entry.command.already_documented && ICON_LOCK}
                   <div class="recommendation-content">
                     <${OrderRow}
                       command=${entry.command}
                       commandIndex=${entry.index}
                       onEdit=${onEditRecommendation}
-                      readOnly=${readOnly || entry.command.already_documented || isRejected}
+                      readOnly=${rxRecRowReadOnly || isRejected}
                       patientId=${patientId}
                       noteId=${noteId}
                       staffId=${staffId}
@@ -1510,16 +1634,17 @@ export function SoapGroup({ title, groupColor, sections, commandBySectionKey, on
                 const isIncomplete = missingFields.length > 0;
                 const isAccepted = entry.command.accepted && !entry.command.rejected;
                 const isRejected = entry.command.rejected;
+                const referRecRowReadOnly = rowLocked(entry.command, readOnly, isAmending);
 
                 return html`
-                <div class=${`content-block recommendation-block rec-refer${isRejected ? ' rec-rejected' : ''}${entry.command.already_documented ? ' command-locked' : ''}`} key=${'rec-refer-' + entry.index}>
-                  ${entry.command.already_documented && ICON_LOCK}
+                <div class=${`content-block recommendation-block rec-refer${isRejected ? ' rec-rejected' : ''}${referRecRowReadOnly && entry.command.already_documented ? ' command-locked' : ''}`} key=${'rec-refer-' + entry.index}>
+                  ${referRecRowReadOnly && entry.command.already_documented && ICON_LOCK}
                   <div class="recommendation-content">
                     <${OrderRow}
                       command=${entry.command}
                       commandIndex=${entry.index}
                       onEdit=${onEditRecommendation}
-                      readOnly=${readOnly || entry.command.already_documented || isRejected}
+                      readOnly=${referRecRowReadOnly || isRejected}
                       patientId=${patientId}
                       noteId=${noteId}
                       staffId=${staffId}
@@ -1561,9 +1686,10 @@ export function SoapGroup({ title, groupColor, sections, commandBySectionKey, on
               ${taskRecs.map(entry => {
                 const isAccepted = entry.command.accepted && !entry.command.rejected;
                 const isRejected = entry.command.rejected;
+                const taskRecRowReadOnly = rowLocked(entry.command, readOnly, isAmending);
                 return html`
-                <div class=${`content-block recommendation-block rec-task${isRejected ? ' rec-rejected' : ''}${entry.command.already_documented ? ' command-locked' : ''}`} key=${'rec-task-' + entry.index}>
-                  ${entry.command.already_documented && ICON_LOCK}
+                <div class=${`content-block recommendation-block rec-task${isRejected ? ' rec-rejected' : ''}${taskRecRowReadOnly && entry.command.already_documented ? ' command-locked' : ''}`} key=${'rec-task-' + entry.index}>
+                  ${taskRecRowReadOnly && entry.command.already_documented && ICON_LOCK}
                   <div class="recommendation-content">
                     <${TaskRow}
                       command=${entry.command}
@@ -1571,7 +1697,7 @@ export function SoapGroup({ title, groupColor, sections, commandBySectionKey, on
                       onEdit=${onEditRecommendation}
                       onDelete=${onDeleteRecommendation}
                       assignees=${assignees}
-                      readOnly=${readOnly || entry.command.already_documented || isRejected}
+                      readOnly=${taskRecRowReadOnly || isRejected}
                       onEditingChange=${onEditingChange}
                     />
                     ${entry.command.data.due_date_hint && html`<div class="rec-hint">Suggested timing: ${entry.command.data.due_date_hint}</div>`}

--- a/hyperscribe/scribe/static/summary.js
+++ b/hyperscribe/scribe/static/summary.js
@@ -107,6 +107,93 @@ const SOAP_GROUPS = [
   { title: 'CHARGES', color: 'charges', keys: new Set(['charges']) },
 ];
 
+// KOALA-5485: section_keys whose already-documented commands can be edited
+// during amendment. RFV (chief_complaint) goes through a direct EDIT effect;
+// CustomCommand-routed sections (_ros, _history_review, _chart_review,
+// physical_exam, lab_results, imaging_results) go through EnterInError +
+// Originate; everything else goes through EnterInError + Originate + Commit.
+//
+// Covers every command_type in `_BUILDERS` EXCEPT orders (prescribe, refill,
+// adjust_prescription, refer, imaging_order, lab_order) and questionnaires
+// (which need a 4-effect amend route, deferred to a follow-up ticket).
+//
+// MIRRORED in three places - keep all in sync until single-sourcing lands
+// (follow-up ticket):
+//   - hyperscribe/scribe/commands/builder.py (EDITABLE_AMEND_SECTIONS)
+//   - hyperscribe/scribe/static/summary.js (this file)
+//   - hyperscribe/scribe/static/soap-group.js (EDITABLE_AMEND_SECTIONS)
+const EDITABLE_AMEND_SECTIONS = new Set([
+  // DIRECT_EDIT
+  'chief_complaint',
+  // CUSTOM_COMMAND_ROUTED
+  '_ros',
+  '_history_review',
+  '_chart_review',
+  'physical_exam',
+  'lab_results',
+  'imaging_results',
+  // VOID_RECREATE - SOAP-section-anchored
+  'history_of_present_illness',
+  'current_medications',
+  'allergies',
+  'vitals',
+  'past_medical_history',
+  'past_surgical_history',
+  'family_history',
+  'assessment_and_plan',
+  'plan',
+  // VOID_RECREATE - ad-hoc buckets (rows added during a session retain these
+  // section_keys after approval+reload).
+  '_ad_hoc',
+  '_objective_ad_hoc',
+  '_history_ad_hoc',
+  '_charges_ad_hoc',
+]);
+
+// Command types that MUST NEVER be amended, regardless of section_key.
+// Three reasons a command_type lands here (see builder.py for fuller writeup):
+//   1. STRUCTURALLY IMPOSSIBLE: no COMMIT_*_COMMAND interpreter in home-app.
+//   2. STRUCTURALLY AWKWARD: EIE works, no COMMIT - needs a 4-effect route.
+//   3. POLICY EXCLUDED: full wiring exists, but amend-after-dispatch is the
+//      wrong abstraction (a cancel/resend workflow is the right shape).
+//   4. DEFERRED: amend route hasn't been built (4-effect + state preservation).
+//
+// Both lists work together: section_key gates "is this an amendable spot in
+// the UI?", and command_type gates "is this kind of action safe to void
+// and recreate?". An order added via the _ad_hoc bucket would pass the
+// section gate but must still be denied by the command gate.
+//
+// MIRRORED with builder.py's NON_EDITABLE_AMEND_COMMAND_TYPES.
+const NON_EDITABLE_AMEND_COMMAND_TYPES = new Set([
+  // 1. Structurally impossible (no COMMIT_*_COMMAND interpreter):
+  'prescribe',
+  'refill',
+  'adjust_prescription',
+  // 2. Structurally awkward (EIE exists, no COMMIT - 4-effect route needed):
+  'refer',
+  'imaging_order',
+  // 3. Policy excluded (full wiring exists; amend after lab-partner ticket
+  //    dispatch creates downstream confusion - cancel/resend is the right shape):
+  'lab_order',
+  // 4. Deferred (4-effect route + question/response state preservation needed):
+  'questionnaire',
+]);
+
+function isAmendingSectionEditable(command, isAmending) {
+  // During amendment, allow editing iff (a) we're in amendment mode (wasFinalized
+  // && !approved), (b) the section is in the allowlist, (c) the command_type
+  // is not in the denylist (orders, questionnaire), and (d) the command was
+  // originally inserted by Scribe (has a command_uuid we can target). New
+  // ad-hoc commands added during amendment go through the normal insert path.
+  return Boolean(
+    isAmending &&
+    command &&
+    command.command_uuid &&
+    EDITABLE_AMEND_SECTIONS.has(command.section_key) &&
+    !NON_EDITABLE_AMEND_COMMAND_TYPES.has(command.command_type)
+  );
+}
+
 const SKELETON_SECTIONS = [
   { key: 'chief_complaint', title: 'Chief Complaint', text: '' },
   { key: 'history_of_present_illness', title: 'History of Present Illness', text: '' },
@@ -146,7 +233,7 @@ function buildCommandBySectionKey(commands) {
   return map;
 }
 
-function renderSoapGroups(sections, commandBySectionKey, onEditCommand, onDeleteCommand, { adHocCommands, objectiveAdHocCommands, historyAdHocCommands, subjectiveAdHocCommands, chargeAdHocCommands, assignees, onAddTask, onAddOrder, onAddPlan, onAddMedication, onAddAllergy, onAddStopMedication, onAddRemoveAllergy, onAddResolveCondition, onAddHistory, onAddQuestionnaire, onAddCharge, onAddTemplateCharge, onRemoveChargeByCpt, templateCharges, readOnly, sectionConditions, patientId, noteId, staffId, staffName, recommendations, onEditRecommendation, onDeleteRecommendation, onAcceptRecommendation, onRejectRecommendation, onAddCondition, unmatchedConditions, diagnosisSuggestions, onAddNow, onAddVitals, hideRejected, alertFacilityEnabled, onEditingChange } = {}) {
+function renderSoapGroups(sections, commandBySectionKey, onEditCommand, onDeleteCommand, { adHocCommands, objectiveAdHocCommands, historyAdHocCommands, subjectiveAdHocCommands, chargeAdHocCommands, assignees, onAddTask, onAddOrder, onAddPlan, onAddMedication, onAddAllergy, onAddStopMedication, onAddRemoveAllergy, onAddResolveCondition, onAddHistory, onAddQuestionnaire, onAddCharge, onAddTemplateCharge, onRemoveChargeByCpt, templateCharges, readOnly, isAmending, sectionConditions, patientId, noteId, staffId, staffName, recommendations, onEditRecommendation, onDeleteRecommendation, onAcceptRecommendation, onRejectRecommendation, onAddCondition, unmatchedConditions, diagnosisSuggestions, onAddNow, onAddVitals, hideRejected, alertFacilityEnabled, onEditingChange } = {}) {
   return SOAP_GROUPS
     .map(group => {
       const matching = sections.filter(s => group.keys.has(s.key.toLowerCase()));
@@ -181,6 +268,7 @@ function renderSoapGroups(sections, commandBySectionKey, onEditCommand, onDelete
         onRemoveChargeByCpt=${isCharges ? onRemoveChargeByCpt : null}
         templateCharges=${isCharges ? templateCharges : null}
         readOnly=${readOnly}
+        isAmending=${isAmending}
         sectionConditions=${sectionConditions}
         patientId=${patientId}
         noteId=${noteId}
@@ -752,15 +840,30 @@ export function Scribe({ noteId, patientId, staffId, staffName, providerName, pr
   const handleEdit = useCallback((index, newData, newType) => {
     logEvent('EDIT_COMMAND', { index, commandType: newType || commands[index]?.command_type, sectionKey: commands[index]?.section_key, data: newData });
     if (!canEdit) return;
+    // KOALA-5485: during amendment, edits to already-documented commands in
+    // EDITABLE_AMEND_SECTIONS are routed through /edit-existing-commands on
+    // Save changes. Tag the row so handleInsert can split it out from the
+    // normal insertable filter.
+    //
+    // The tag is applied UNIFORMLY at the bottom of the per-command branch
+    // (single tag point) so every command_type participates in the amend
+    // split. The gate `isAmendingSectionEditable` is the authoritative
+    // eligibility filter: it checks `wasFinalized && !approved` (we're
+    // amending), `command_uuid` presence (Scribe-inserted, not freshly
+    // ad-hoc), section_key allowlist, and command_type denylist. Orders
+    // (prescribe, refill, adjust_prescription, refer, imaging_order,
+    // lab_order), questionnaire, and freshly-added ad-hoc rows are correctly
+    // excluded by the gate, not by per-branch tag omission.
+    const isAmendEdit = (cmd) => isAmendingSectionEditable(cmd, wasFinalized && !approved);
     setCommands(prev => {
       const updated = prev.map((cmd, i) => {
         if (i !== index) return cmd;
         const type = newType || cmd.command_type;
+        let next;
         if (type === 'history_review' || type === 'chart_review' || type === 'ros' || type === 'physical_exam') {
           const display = (newData.sections || []).map(s => s.title).join(' | ');
-          return { ...cmd, data: newData, display };
-        }
-        if (type === 'vitals') {
+          next = { ...cmd, data: newData, display };
+        } else if (type === 'vitals') {
           const vParts = [];
           const sys = newData.blood_pressure_systole;
           const dia = newData.blood_pressure_diastole;
@@ -784,88 +887,85 @@ export function Scribe({ noteId, patientId, staffId, staffName, providerName, pr
             if (label) vParts.push(`Site: ${label}`);
           }
           if (newData.note) vParts.push(`Note: ${newData.note}`);
-          return { ...cmd, data: newData, display: vParts.join(', ') || 'Vitals' };
-        }
-        if (type === 'medication_statement') {
-          return { ...cmd, data: newData, display: newData.medication_text || '' };
-        }
-        if (type === 'allergy') {
-          return { ...cmd, data: newData, display: newData.allergy_text || '' };
-        }
-        if (type === 'task') {
+          next = { ...cmd, data: newData, display: vParts.join(', ') || 'Vitals' };
+        } else if (type === 'medication_statement') {
+          next = { ...cmd, data: newData, display: newData.medication_text || '' };
+        } else if (type === 'allergy') {
+          next = { ...cmd, data: newData, display: newData.allergy_text || '' };
+        } else if (type === 'task') {
           const parts = [newData.title || ''];
           if (newData.comment) parts.push(`Comment: ${newData.comment}`);
-          return { ...cmd, data: newData, display: parts.join(' \u2014 ') };
-        }
-        if (type === 'prescribe' || type === 'refill' || type === 'adjust_prescription') {
-          return { ...cmd, command_type: type, data: newData, display: newData.medication_text || '' };
-        }
-        if (type === 'lab_order') {
+          next = { ...cmd, data: newData, display: parts.join(' \u2014 ') };
+        } else if (type === 'prescribe' || type === 'refill' || type === 'adjust_prescription') {
+          next = { ...cmd, command_type: type, data: newData, display: newData.medication_text || '' };
+        } else if (type === 'lab_order') {
           const parts = [];
           if (newData.lab_partner_name) parts.push(newData.lab_partner_name);
           if (newData.test_names && newData.test_names.length) parts.push(newData.test_names.join(', '));
           if (newData.comment) parts.push(newData.comment);
           if (newData.fasting_required) parts.push('Fasting');
-          return { ...cmd, command_type: type, data: newData, display: parts.join(' | ') || '' };
-        }
-        if (type === 'imaging_order') {
+          next = { ...cmd, command_type: type, data: newData, display: parts.join(' | ') || '' };
+        } else if (type === 'imaging_order') {
           const parts = [newData.image_display, newData.additional_details, newData.comment, newData.priority].filter(Boolean);
-          return { ...cmd, command_type: type, data: newData, display: parts.join(' | ') };
-        }
-        if (type === 'refer') {
+          next = { ...cmd, command_type: type, data: newData, display: parts.join(' | ') };
+        } else if (type === 'refer') {
           const parts = [newData.refer_to_display, newData.clinical_question, newData.priority].filter(Boolean);
-          return { ...cmd, command_type: type, data: newData, display: parts.join(' | ') || 'Referral' };
-        }
-        if (type === 'familyHistory') {
+          next = { ...cmd, command_type: type, data: newData, display: parts.join(' | ') || 'Referral' };
+        } else if (type === 'familyHistory') {
           const parts = [newData.condition_display, newData.relative, newData.note].filter(Boolean);
-          return { ...cmd, command_type: type, data: newData, display: parts.join(' — ') || '' };
-        }
-        if (type === 'medicalHistory') {
+          next = { ...cmd, command_type: type, data: newData, display: parts.join(' — ') || '' };
+        } else if (type === 'medicalHistory') {
           const parts = [newData.past_medical_history];
           const dates = [newData.approximate_start_date, newData.approximate_end_date].filter(Boolean);
           if (dates.length) parts.push(dates.join(' – '));
           if (newData.comments) parts.push(newData.comments);
-          return { ...cmd, command_type: type, data: newData, display: parts.filter(Boolean).join(' — ') || '' };
-        }
-        if (type === 'surgicalHistory') {
+          next = { ...cmd, command_type: type, data: newData, display: parts.filter(Boolean).join(' — ') || '' };
+        } else if (type === 'surgicalHistory') {
           const parts = [newData.procedure_display];
           if (newData.approximate_date) parts.push(newData.approximate_date);
           if (newData.comment) parts.push(newData.comment);
-          return { ...cmd, command_type: type, data: newData, display: parts.filter(Boolean).join(' — ') || '' };
-        }
-        if (type === 'questionnaire') {
-          return { ...cmd, command_type: type, data: newData, display: newData.questionnaire_name || '' };
-        }
-        if (type === 'perform') {
+          next = { ...cmd, command_type: type, data: newData, display: parts.filter(Boolean).join(' — ') || '' };
+        } else if (type === 'questionnaire') {
+          next = { ...cmd, command_type: type, data: newData, display: newData.questionnaire_name || '' };
+        } else if (type === 'perform') {
           const display = newData.cpt_code ? `${newData.cpt_code} — ${newData.description || ''}` : '';
-          return { ...cmd, command_type: type, data: newData, display };
-        }
-        if (type === 'stop_medication') {
-          return { ...cmd, command_type: type, data: newData, display: newData.medication_name || '' };
-        }
-        if (type === 'remove_allergy') {
-          return { ...cmd, command_type: type, data: newData, display: newData.allergy_name || '' };
-        }
-        if (type === 'resolve_condition') {
-          return { ...cmd, command_type: type, data: newData, display: newData.condition_name || '' };
-        }
-        if (type === 'diagnose') {
+          next = { ...cmd, command_type: type, data: newData, display };
+        } else if (type === 'stop_medication') {
+          next = { ...cmd, command_type: type, data: newData, display: newData.medication_name || '' };
+        } else if (type === 'remove_allergy') {
+          next = { ...cmd, command_type: type, data: newData, display: newData.allergy_name || '' };
+        } else if (type === 'resolve_condition') {
+          next = { ...cmd, command_type: type, data: newData, display: newData.condition_name || '' };
+        } else if (type === 'diagnose') {
           const display = newData.icd10_display || newData.condition_header || cmd.display;
           const accepted = newData.icd10_code ? (newData.accepted !== undefined ? newData.accepted : true) : false;
           const rejected = newData.rejected || false;
-          return { ...cmd, command_type: type, data: { ...newData, accepted, rejected }, display };
+          next = { ...cmd, command_type: type, data: { ...newData, accepted, rejected }, display };
+        } else if (type === 'assess') {
+          next = { ...cmd, data: newData };
+        } else {
+          // Default path: rfv (chief_complaint), hpi (history_of_present_illness),
+          // lab_results, imaging_results, plan, and any other narrative-shaped
+          // command. rfv uses the `comment` field; everything else uses
+          // `narrative`. Any of these can be amended during the amendment flow.
+          const field = cmd.command_type === 'rfv' ? 'comment' : 'narrative';
+          const text = newData[field] || '';
+          next = { ...cmd, data: newData, display: text };
         }
-        if (type === 'assess') {
-          return { ...cmd, data: newData };
-        }
-        const field = cmd.command_type === 'rfv' ? 'comment' : 'narrative';
-        const text = newData[field] || '';
-        return { ...cmd, data: newData, display: text };
+        // Single tag point (KOALA-5485 silent no-op fix). The gate
+        // `isAmendEdit` filters by section_key allowlist + command_type
+        // denylist + command_uuid presence + amending mode. Without this,
+        // edits to vitals/allergy/task/familyHistory/medicalHistory/
+        // surgicalHistory/diagnose/assess/perform/stop_medication/
+        // remove_allergy/resolve_condition were silently dropped at
+        // handleInsert because `_amend_edited` was never set on those
+        // branches.
+        return isAmendEdit(cmd) ? { ...next, _amend_edited: true } : next;
       });
       saveSummaryToCache(noteData, updated, false, { recommendations, unmatched_conditions: unmatchedConditions, diagnosis_suggestions: diagnosisSuggestions });
       return updated;
     });
-  }, [canEdit, noteData, saveSummaryToCache, recommendations, unmatchedConditions, diagnosisSuggestions]);
+  }, [canEdit, wasFinalized, approved, noteData, saveSummaryToCache, recommendations, unmatchedConditions, diagnosisSuggestions]);
 
   const handleDelete = useCallback((index) => {
     logEvent('DELETE_COMMAND', { index, commandType: commands[index]?.command_type });
@@ -1174,17 +1274,114 @@ export function Scribe({ noteId, patientId, staffId, staffName, providerName, pr
     logEvent('APPROVE_START', { totalCommands: commands.length, commandTypes: commands.map(c => c.command_type) });
     setInserting(true);
 
-    // Persist approved state to cache early so a page reload can't re-submit.
-    saveSummaryToCache(noteData, commands, true, { recommendations, unmatched_conditions: unmatchedConditions, diagnosis_suggestions: diagnosisSuggestions, selected_template_name: selectedTemplate?.name || null, mode });
+    // KOALA-5485: cache flip to approved=true is delayed until AFTER amend
+    // success (amend branch ~1290) AND/OR AFTER /insert-commands success
+    // (cache write ~1450, runs UNCONDITIONALLY on success - see
+    // CACHE_FLIP_UNCONDITIONAL_ON_APPROVE_SUCCESS).
+    // Two cache-flip landing points cover the relevant paths:
+    //   (a) Amend-only path: amend branch writes approved=true after
+    //       /edit-existing-commands success and BEFORE /insert-commands. If
+    //       /insert-commands later fails, the catch block rolls cache back to
+    //       approved=false (so /save-summary holds the latest user-facing state).
+    //   (b) Fresh-approve or amend+insert success: the success branch writes
+    //       approved=true unconditionally. The unconditional write covers the
+    //       amend-mode-with-zero-edits edge case (no `data.attempted` entries
+    //       to gate on) and the empty-note approval crash-recovery case.
+    // If a browser crash happens before either landing point, the cache stays
+    // approved=false and the next page load shows pre-amend state - far safer
+    // than a phantom-approved-but-lost-edit state.
+    // (Original eager flip used to live here pre-amend; removed for KOALA-5485.)
+
+    // KOALA-5485: Amend edits go through /edit-existing-commands FIRST so the
+    // uuid map is available before the verify step. The frontend re-stamps
+    // ScribeSummary.commands with the new uuids returned by the backend.
+    //
+    // Critical ordering: re-stamp happens IMMEDIATELY after amend success,
+    // BEFORE the conditions fetch and /insert-commands POST. The amend POST
+    // is a hard commit point - once those effects landed in home-app, the
+    // plugin's local state MUST reflect it. If /insert-commands later fails,
+    // the user can retry it, but they must not re-submit the (now-voided)
+    // old uuid as an amend - which is what would happen if we kept the
+    // re-stamp inside the /insert-commands success branch.
+    const amendEdits = commands.filter(c => c._amend_edited && c.command_uuid);
+    let amendUuidRemap = new Map(); // old_uuid -> new_uuid
+    let amendAttempted = [];
+    // The commands array we work with from here on. We mutate this in-place
+    // (via reassign) to reflect amend success even if /insert-commands fails.
+    let workingCommands = commands;
+    if (amendEdits.length > 0) {
+      const amendPayload = amendEdits.map(({ _template_inserted, _amend_edited, ...rest }) => rest);
+      logEvent('AMEND_EDIT_SENDING', { count: amendPayload.length, sectionKeys: amendPayload.map(c => c.section_key) });
+      try {
+        const editRes = await fetch(`${API_BASE}/edit-existing-commands`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ note_uuid: noteId, commands: amendPayload }),
+        });
+        const editData = await editRes.json();
+        if (editData.error) {
+          // Backend rejected before any effects were emitted. Pass the
+          // conflict shape through if present so the user can reload a
+          // stale tab; otherwise show the generic error.
+          if (editData.validation_errors) {
+            setValidationError(editData.validation_errors);
+          } else if (editData.conflicts) {
+            setError(`${editData.error}. Reload the page to see the latest state.`);
+          } else {
+            setError(editData.error);
+          }
+          setApproved(false);
+          setConfirming(false);
+          saveSummaryToCache(noteData, commands, false, { recommendations, unmatched_conditions: unmatchedConditions, diagnosis_suggestions: diagnosisSuggestions, selected_template_name: selectedTemplate?.name || null, mode });
+          setInserting(false);
+          logEvent('AMEND_EDIT_ERROR', { error: editData.error, conflicts: editData.conflicts || null });
+          return;
+        }
+        amendAttempted = editData.attempted || [];
+        for (const entry of amendAttempted) {
+          amendUuidRemap.set(entry.old_command_uuid, entry.new_command_uuid);
+        }
+        logEvent('AMEND_EDIT_COMPLETE', { count: amendAttempted.length });
+
+        // Hard commit point: re-stamp commands now. After this point the
+        // home-app has executed EIE+Originate (and Commit for dedicated-class
+        // sections). The local state must mirror that or a retry of
+        // /insert-commands will resend the (now-voided) old uuid as an amend.
+        workingCommands = commands.map(cmd => {
+          if (cmd._amend_edited && cmd.command_uuid && amendUuidRemap.has(cmd.command_uuid)) {
+            const newUuid = amendUuidRemap.get(cmd.command_uuid);
+            const { _amend_edited, ...rest } = cmd;
+            return { ...rest, command_uuid: newUuid, already_documented: true };
+          }
+          return cmd;
+        });
+        setCommands(workingCommands);
+        saveSummaryToCache(noteData, workingCommands, true, {
+          recommendations, unmatched_conditions: unmatchedConditions,
+          diagnosis_suggestions: diagnosisSuggestions,
+          selected_template_name: selectedTemplate?.name || null, mode,
+        });
+      } catch (err) {
+        console.error('Amend edits failed:', err);
+        setError('Failed to apply amendment edits');
+        setApproved(false);
+        setConfirming(false);
+        setInserting(false);
+        logEvent('AMEND_EDIT_ERROR', { error: 'network' });
+        return;
+      }
+    }
 
     const SECTION_TYPES = new Set(['physical_exam', 'ros', 'chart_review', 'history_review']);
-    const insertable = commands.filter(c => {
+    const insertable = workingCommands.filter(c => {
       // Either flag means "already on the note." command_uuid is the
       // authoritative signal (set whenever a command is inserted, whether
       // via full Approve or Add Now). already_documented is the explicit
       // marker. Treat either as exclusionary so pre-existing finalized
       // notes (which have UUIDs but no already_documented flag) don't
       // double-insert on amendment re-Approve.
+      // (Amend-edited commands have been re-stamped above with the new
+      // uuid + already_documented=true, so they naturally filter out here.)
       if (c.already_documented || c.command_uuid) return false;
       if (!c.display && !(SECTION_TYPES.has(c.command_type) && c.data?.sections?.length > 0)) return false;
       if (c.command_type === 'imaging_order' && (!c.data.image_code || !c.data.service_provider || !c.data.ordering_provider_id || !c.data.diagnosis_codes || c.data.diagnosis_codes.length === 0)) return false;
@@ -1195,7 +1392,7 @@ export function Scribe({ noteId, patientId, staffId, staffName, providerName, pr
       if (c.command_type === 'perform' && (!c.data.cpt_code || c.selected === false)) return false;
       return true;
     });
-    const dropped = commands.filter(c => !c.already_documented && !insertable.includes(c));
+    const dropped = workingCommands.filter(c => !c.already_documented && !insertable.includes(c));
     if (dropped.length > 0) {
       logEvent('COMMANDS_FILTERED', { dropped: dropped.map(c => ({
         type: c.command_type, display: (c.display || '').slice(0, 80), sectionKey: c.section_key,
@@ -1255,15 +1452,22 @@ export function Scribe({ noteId, patientId, staffId, staffName, providerName, pr
       });
       const data = await res.json();
       if (data.error) {
+        // If amend already succeeded, the home-app already executed those
+        // EIE+Originate effects. We persist `workingCommands` (which carries
+        // the re-stamped uuids) so a retry of /insert-commands won't re-send
+        // the now-voided old uuid as an amend. The `approved` flag is reset
+        // so the user can fix the insert-commands payload and retry.
         if (data.validation_errors) {
           setValidationError(data.validation_errors);
+        } else if (amendAttempted.length > 0) {
+          setError(`${data.error}. Amendments were saved; retry to complete insertion.`);
         } else {
           setError(data.error);
         }
         setApproved(false);
         setConfirming(false);
-        saveSummaryToCache(noteData, commands, false, { recommendations, unmatched_conditions: unmatchedConditions, diagnosis_suggestions: diagnosisSuggestions, selected_template_name: selectedTemplate?.name || null, mode });
-        logEvent('APPROVE_ERROR', { error: data.error, validation_errors: data.validation_errors });
+        saveSummaryToCache(noteData, workingCommands, false, { recommendations, unmatched_conditions: unmatchedConditions, diagnosis_suggestions: diagnosisSuggestions, selected_template_name: selectedTemplate?.name || null, mode });
+        logEvent('APPROVE_ERROR', { error: data.error, validation_errors: data.validation_errors, amendAttempted: amendAttempted.length });
       } else {
         // Phase 2: Insert metadata if any pending
         if (data.metadata_pending && data.metadata_pending.length > 0) {
@@ -1278,10 +1482,12 @@ export function Scribe({ noteId, patientId, staffId, staffName, providerName, pr
           }
         }
         // Stamp commands with their UUIDs and save immediately (before modal closes).
-        let updatedCommands = commands;
+        // Amend re-stamping happened earlier (right after /edit-existing-commands
+        // succeeded); here we only re-stamp the freshly-inserted commands.
+        let updatedCommands = workingCommands;
         if (data.attempted && data.attempted.length > 0) {
-          const uuidMap = new Map(data.attempted.map(a => [`${a.command_type}:${a.display}`, a.command_uuid]));
-          updatedCommands = commands.map(cmd => {
+          const uuidMap = new Map((data.attempted || []).map(a => [`${a.command_type}:${a.display}`, a.command_uuid]));
+          updatedCommands = workingCommands.map(cmd => {
             const key = `${cmd.command_type}:${(cmd.display || '').slice(0, 80)}`;
             const uuid = uuidMap.get(key);
             // Stamp already_documented=true alongside command_uuid so the existing
@@ -1292,17 +1498,37 @@ export function Scribe({ noteId, patientId, staffId, staffName, providerName, pr
             return uuid ? { ...cmd, command_uuid: uuid, already_documented: true } : cmd;
           });
           setCommands(updatedCommands);
-          saveSummaryToCache(noteData, updatedCommands, true, {
-            recommendations, unmatched_conditions: unmatchedConditions,
-            diagnosis_suggestions: diagnosisSuggestions,
-            selected_template_name: selectedTemplate?.name || null, mode,
-          });
         }
-        const hasPrescriptions = commands.some(c => c.display && RX_SET.has(c.command_type))
+        // CACHE_FLIP_UNCONDITIONAL_ON_APPROVE_SUCCESS - KOALA-5485 cache-flip regression:
+        // the approved=true cache write must fire UNCONDITIONALLY on the success branch,
+        // NOT gated on `data.attempted.length > 0`. Two paths reach here with zero
+        // attempted entries:
+        //   (1) Amend-mode Save with zero edits in any editable section - the amend
+        //       branch already cached approved=true at line ~1294, but if there are
+        //       NO amend edits at all (empty-note approval), neither branch wrote
+        //       approved=true to cache. Without this unconditional write, setApproved(true)
+        //       updates React state in memory but the cache holds approved=false;
+        //       a page reload would revert the UI to pre-approval.
+        //   (2) Fresh approval crash-recovery: if the user crashes before this
+        //       point with a successful insert but empty attempted (rare but possible
+        //       for command types that don't surface attempted entries), the cache
+        //       must reflect approved=true so reload doesn't lose the approval.
+        // Pinned by `test_summary_js_cache_flip_to_approved_true_is_unconditional_on_success`.
+        saveSummaryToCache(noteData, updatedCommands, true, {
+          recommendations, unmatched_conditions: unmatchedConditions,
+          diagnosis_suggestions: diagnosisSuggestions,
+          selected_template_name: selectedTemplate?.name || null, mode,
+        });
+        const hasPrescriptions = workingCommands.some(c => c.display && RX_SET.has(c.command_type))
           || recommendations.some(c => c.display && !c.rejected && RX_SET.has(c.command_type));
-        logEvent('APPROVE_COMPLETE', { insertedCount: allInsertable.length, effectCount: data.inserted, hasPendingMetadata: (data.metadata_pending?.length || 0) > 0 });
-        // Verify commands were actually created (include Add Now items).
-        const allAttempted = [...addNowAttemptedRef.current, ...(data.attempted || [])];
+        logEvent('APPROVE_COMPLETE', { insertedCount: allInsertable.length, effectCount: data.inserted, hasPendingMetadata: (data.metadata_pending?.length || 0) > 0, amendEditCount: amendAttempted.length });
+        // Verify commands were actually created (include Add Now items + amend-edit NEW uuids).
+        const amendVerifyEntries = amendAttempted.map(a => ({
+          command_uuid: a.new_command_uuid,
+          command_type: a.command_type,
+          display: a.display || '',
+        }));
+        const allAttempted = [...addNowAttemptedRef.current, ...(data.attempted || []), ...amendVerifyEntries];
         if (allAttempted.length > 0) {
           try {
             const verifyRes = await fetch(`${API_BASE}/verify-commands`, {
@@ -1343,11 +1569,18 @@ export function Scribe({ noteId, patientId, staffId, staffName, providerName, pr
         if (port) port.postMessage({ type: 'CLOSE_MODAL' });
       }
     } catch (err) {
-      setError('Failed to insert commands');
+      // Network/parsing failure on /insert-commands. If amend already
+      // succeeded we persist the re-stamped state so retry doesn't
+      // re-submit voided uuids as amends.
+      if (amendAttempted.length > 0) {
+        setError('Amendments saved; some commands failed to insert. Retry.');
+      } else {
+        setError('Failed to insert commands');
+      }
       setApproved(false);
       setConfirming(false);
-      saveSummaryToCache(noteData, commands, false, { recommendations, unmatched_conditions: unmatchedConditions, diagnosis_suggestions: diagnosisSuggestions, selected_template_name: selectedTemplate?.name || null, mode });
-      logEvent('APPROVE_ERROR', { error: 'Failed to insert commands' });
+      saveSummaryToCache(noteData, workingCommands, false, { recommendations, unmatched_conditions: unmatchedConditions, diagnosis_suggestions: diagnosisSuggestions, selected_template_name: selectedTemplate?.name || null, mode });
+      logEvent('APPROVE_ERROR', { error: 'Failed to insert commands', amendAttempted: amendAttempted.length });
     } finally {
       setInserting(false);
     }
@@ -1763,6 +1996,7 @@ export function Scribe({ noteId, patientId, staffId, staffName, providerName, pr
           onRemoveChargeByCpt: canEdit ? handleRemoveChargeByCpt : null,
           templateCharges: selectedTemplate ? (selectedTemplate.charges || []) : [],
           readOnly: !canEdit,
+          isAmending: wasFinalized && !approved,
           sectionConditions,
           patientId,
           noteId,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,8 +5,11 @@ description = "add commands based on vocal instructions"
 requires-python = ">=3.11,<3.13"
 readme = "README.md"
 dependencies = [
-    "canvas>=0.58.1",
-    "canvas[test-utils]>=0.58.1",
+    # 0.155.0 ships ENTER_IN_ERROR_CUSTOM_COMMAND_COMMAND in the proto enum,
+    # required by the KOALA-5485 amend path for CustomCommand-routed sections
+    # (_ros, _history_review, _chart_review, physical_exam, lab_results).
+    "canvas>=0.155.0",
+    "canvas[test-utils]>=0.155.0",
     "mypy>=1.15.0",
     "ffmpeg-python>=0.2.0",
 ]

--- a/tests/hyperscribe/scribe/api/test_session_view.py
+++ b/tests/hyperscribe/scribe/api/test_session_view.py
@@ -1135,6 +1135,175 @@ def test_extract_commands_invalid_json() -> None:
 # --- /insert-commands ---
 
 
+def test_summary_js_cache_flip_to_approved_true_is_unconditional_on_success() -> None:
+    """KOALA-5485 cache-flip regression: in ``handleInsert``'s
+    ``/insert-commands`` success branch, the ``saveSummaryToCache(...true...)``
+    call must fire UNCONDITIONALLY - NOT gated on ``data.attempted.length > 0``.
+
+    Edge case: in amend-mode where the user saves with zero edits in any
+    editable section (or empty-note approval), ``data.attempted`` is empty.
+    If the cache write is gated on ``data.attempted.length > 0``,
+    ``setApproved(true)`` updates React state in memory but the cache holds
+    ``approved=false`` - on page reload the UI reverts to pre-approval.
+
+    Pinning approach (structural-static, since this repo has no JS test
+    framework): two assertions, both required:
+      1. The marker comment ``CACHE_FLIP_UNCONDITIONAL_ON_APPROVE_SUCCESS`` is
+         present (intent / trace marker for future maintainers).
+      2. Inside ``handleInsert``'s success branch, a ``saveSummaryToCache(...true...)``
+         call appears AFTER the closing brace of the
+         ``if (data.attempted && data.attempted.length > 0) {...}`` block - i.e.,
+         a sibling, not a child. If the call is moved back inside the gate, this
+         assertion fails.
+
+    Behavioral caveat: this is a structural pin, not a runtime behavioral pin.
+    It does NOT execute the React code. A regression that deletes the comment
+    while keeping the call gets caught by (1); a regression that moves the call
+    back inside the gate while keeping the comment gets caught by (2). A
+    behavioral pin would require a JS test infra, which is out of scope.
+    """
+    from pathlib import Path
+
+    summary_js = Path(__file__).resolve().parents[4] / "hyperscribe" / "scribe" / "static" / "summary.js"
+    src = summary_js.read_text()
+
+    # (1) Marker comment - intent / trace breadcrumb.
+    assert "CACHE_FLIP_UNCONDITIONAL_ON_APPROVE_SUCCESS" in src, (
+        "summary.js handleInsert success branch is missing the "
+        "CACHE_FLIP_UNCONDITIONAL_ON_APPROVE_SUCCESS marker. Without the "
+        "unconditional write, amend-mode Save with zero edits leaves the cache "
+        "at approved=false, so a page reload reverts the UI. Add a "
+        "saveSummaryToCache(..., true, ...) on the success branch, OUTSIDE the "
+        "`if (data.attempted && data.attempted.length > 0)` gate. Mark it with "
+        "the CACHE_FLIP_UNCONDITIONAL_ON_APPROVE_SUCCESS comment."
+    )
+
+    # (2) Structural: the `if (data.attempted && data.attempted.length > 0) {...}`
+    # block must be CLOSED before an unconditional saveSummaryToCache(..., true, ...)
+    # call. If the call moves back inside the gate, the close brace of the gate
+    # comes AFTER the call.
+    gate_marker = "if (data.attempted && data.attempted.length > 0) {"
+    gate_idx = src.find(gate_marker)
+    assert gate_idx != -1, (
+        "Expected to find the `if (data.attempted && data.attempted.length > 0) {` "
+        "guard inside handleInsert. If this gate has been removed entirely, "
+        "that's also a valid fix - update the test."
+    )
+
+    # Walk forward from after the gate's opening brace, counting braces, to find
+    # its matching close.
+    open_brace_pos = gate_idx + len(gate_marker) - 1  # position of the `{`
+    depth = 0
+    close_pos = -1
+    for i in range(open_brace_pos, len(src)):
+        if src[i] == "{":
+            depth += 1
+        elif src[i] == "}":
+            depth -= 1
+            if depth == 0:
+                close_pos = i
+                break
+    assert close_pos != -1, "Could not find matching close brace for the data.attempted gate"
+
+    # Match `saveSummaryToCache(noteData, <any>, true,` with `true` as the third arg.
+    # This is the post-insert success cache flip. The amend-branch cache write is
+    # earlier in the file (before the gate), so it doesn't show up in `after_gate`.
+    after_gate = src[close_pos + 1 :]
+    unconditional_pattern = re.compile(r"saveSummaryToCache\s*\(\s*noteData\s*,[^,]+,\s*true\s*,")
+    assert unconditional_pattern.search(after_gate), (
+        "The unconditional `saveSummaryToCache(noteData, ..., true, ...)` call "
+        "must appear OUTSIDE (after the closing brace of) the "
+        "`if (data.attempted && data.attempted.length > 0) {...}` block in "
+        "handleInsert's success branch. Currently it appears to be missing or "
+        "still nested inside the gate - which leaves amend-mode-zero-edits at "
+        "cache.approved=false."
+    )
+
+
+@patch("hyperscribe.scribe.api.session_view.audit_event")
+@patch("hyperscribe.scribe.api.session_view.build_effects")
+def test_insert_commands_audit_payload_excludes_display_phi(mock_build: MagicMock, mock_audit: MagicMock) -> None:
+    """HIPAA regression: the INSERT_COMMANDS audit payload must NOT carry the
+    ``display`` field. ``display`` is free-text clinical narrative for HPI / ROS /
+    PE / lab_results / current_medications; persisting it into
+    ``ScribeAuditLog.events`` is PHI in a log, even with 80-char truncation.
+    The audit retains structural identifiers (type, section_key) and aggregate
+    counts - enough signal for incident triage without leaking content. Mirrors
+    the AMEND_EXISTING_COMMANDS PHI hardening (KOALA-5485).
+    """
+    mock_effect = MagicMock()
+    attempted = [
+        {"command_uuid": "u1", "command_type": "hpi", "display": "Back pain"},
+    ]
+    mock_build.return_value = ([mock_effect], [], attempted)
+
+    view = _helper_instance()
+    commands = [
+        {
+            "command_type": "hpi",
+            "section_key": "history_of_present_illness",
+            "data": {"narrative": "Patient reports severe headache for 3 days, PHI here"},
+            "display": "Patient reports severe headache for 3 days (clinical narrative)",
+        },
+    ]
+    view.request = SimpleNamespace(body=json.dumps({"note_uuid": "note-uuid-123", "commands": commands}))
+    view.post_insert_commands()
+
+    audit_calls = [c for c in mock_audit.call_args_list if c.args[1] == "INSERT_COMMANDS"]
+    assert len(audit_calls) == 1
+    payload = audit_calls[0].args[2]
+    assert payload["commands"], "expected at least one command entry to assert against"
+    for entry in payload["commands"]:
+        assert "display" not in entry, (
+            f"INSERT_COMMANDS audit payload must not carry 'display' (PHI risk); got: {sorted(entry.keys())}"
+        )
+
+
+@patch("hyperscribe.scribe.api.session_view.audit_event")
+@patch("hyperscribe.scribe.api.session_view.Command")
+def test_verify_commands_audit_payload_excludes_display_phi(mock_command: MagicMock, mock_audit: MagicMock) -> None:
+    """HIPAA regression: the COMMANDS_VERIFIED audit payload must NOT carry the
+    ``display`` field in either the ``verified`` or ``failed`` lists. Same
+    rationale as INSERT_COMMANDS / AMEND_EXISTING_COMMANDS: ``display`` is
+    free-text clinical narrative for many command types; persisting it (even
+    truncated) is PHI in a log. The audit retains structural identifiers
+    (type, command_uuid) and aggregate totals.
+    """
+    # Simulate: 1 verified (anchor present), 1 failed (no anchor).
+    mock_command.objects.filter.return_value.values.return_value = [
+        {"id": "uuid-verified", "anchor_object_type": "X", "anchor_object_dbid": 42},
+        {"id": "uuid-failed", "anchor_object_type": "X", "anchor_object_dbid": None},
+    ]
+
+    view = _helper_instance()
+    attempted = [
+        {
+            "command_uuid": "uuid-verified",
+            "command_type": "hpi",
+            "display": "Patient reports severe headache with photophobia (PHI)",
+        },
+        {
+            "command_uuid": "uuid-failed",
+            "command_type": "ros",
+            "display": "Denies fever, chills; positive cough and shortness of breath (PHI)",
+        },
+    ]
+    view.request = SimpleNamespace(body=json.dumps({"note_uuid": "note-uuid-123", "attempted": attempted}))
+    view.post_verify_commands()
+
+    audit_calls = [c for c in mock_audit.call_args_list if c.args[1] == "COMMANDS_VERIFIED"]
+    assert len(audit_calls) == 1
+    payload = audit_calls[0].args[2]
+    for entry in payload.get("verified", []):
+        assert "display" not in entry, (
+            f"COMMANDS_VERIFIED 'verified' entries must not carry 'display' (PHI risk); got: {sorted(entry.keys())}"
+        )
+    for entry in payload.get("failed", []):
+        assert "display" not in entry, (
+            f"COMMANDS_VERIFIED 'failed' entries must not carry 'display' (PHI risk); got: {sorted(entry.keys())}"
+        )
+
+
 @patch("hyperscribe.scribe.api.session_view.build_effects")
 def test_insert_commands_success(mock_build: MagicMock) -> None:
     mock_effect_1 = MagicMock()
@@ -1224,6 +1393,855 @@ def test_insert_commands_invalid_json() -> None:
 
     assert result[0].status_code == HTTPStatus.BAD_REQUEST
     assert "Invalid JSON" in json.loads(result[0].content)["error"]
+
+
+# --- /edit-existing-commands (KOALA-5485) ---
+
+
+class _StubUUID:
+    """Stand-in for the ``uuid.UUID`` objects returned by
+    ``Command.objects.values_list("id", ...)`` against Postgres.
+
+    The Postgres backend yields ``uuid.UUID`` instances for ``UUIDField``
+    columns, NOT strings. ``hash(UUID(s)) != hash(s)``, so a dict keyed by
+    the raw return values misses every string-keyed lookup - that's the
+    bug that turned every legitimate amendment into a ``command_not_found``
+    409 in UAT (KOALA-5485 iter-4 fix).
+
+    This stub mirrors the salient behavior of ``uuid.UUID`` for the test:
+    string-ish but with a non-string hash, so a faulty implementation that
+    forgets to coerce will fail loudly. We can't use ``uuid.UUID`` directly
+    here because the test fixtures use human-readable identifiers like
+    ``"old-hpi-uuid"`` that aren't valid UUIDs - swapping every fixture to
+    a real UUID would balloon the diff without improving the regression
+    signal this stub already gives.
+    """
+
+    __slots__ = ("_s",)
+
+    def __init__(self, s: str) -> None:
+        self._s = s
+
+    def __str__(self) -> str:
+        return self._s
+
+    def __repr__(self) -> str:
+        return f"_StubUUID({self._s!r})"
+
+    def __hash__(self) -> int:
+        # Critically, the hash MUST differ from ``hash(self._s)`` - that's the
+        # production type-mismatch we're modeling.
+        return hash(("uuid", self._s))
+
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, _StubUUID):
+            return self._s == other._s
+        return NotImplemented
+
+
+@patch("hyperscribe.scribe.api.session_view.audit_event")
+@patch("hyperscribe.scribe.api.session_view.build_amend_edit_effects")
+@patch("hyperscribe.scribe.api.session_view.Command")
+def test_edit_existing_commands_rfv_direct_edit(
+    mock_command: MagicMock, mock_build: MagicMock, mock_audit: MagicMock
+) -> None:
+    """Direct EDIT for chief_complaint surfaces the same uuid for old/new."""
+    mock_effect = MagicMock()
+    attempted = [
+        {
+            "section_key": "chief_complaint",
+            "command_type": "rfv",
+            "old_command_uuid": "rfv-uuid",
+            "new_command_uuid": "rfv-uuid",
+            "mode": "direct_edit",
+            "display": "Headache",
+        },
+    ]
+    mock_build.return_value = ([mock_effect], attempted)
+    # State check: the RFV row is currently 'staged' (the only valid state for direct EDIT).
+    # ``_StubUUID`` mirrors Postgres' return type for ``UUIDField`` columns:
+    # the production query returns ``uuid.UUID`` instances, not strings, and the
+    # session view must coerce them to ``str`` for the string-keyed lookup.
+    mock_command.objects.filter.return_value.values_list.return_value = [
+        (_StubUUID("rfv-uuid"), "staged"),
+    ]
+
+    view = _helper_instance()
+    commands = [
+        {
+            "command_type": "rfv",
+            "command_uuid": "rfv-uuid",
+            "section_key": "chief_complaint",
+            "data": {"comment": "Headache"},
+            "display": "Headache",
+        },
+    ]
+    view.request = SimpleNamespace(body=json.dumps({"note_uuid": "note-uuid-123", "commands": commands}))
+    result = view.post_edit_existing_commands()
+
+    assert result[0].status_code == HTTPStatus.OK
+    data = json.loads(result[0].content)
+    assert data["attempted"] == attempted
+    # KOALA-5485: 'rejected' is no longer surfaced in the response. Silent
+    # drops are logged at WARN inside build_amend_edit_effects instead.
+    assert "rejected" not in data
+    assert len(result) == 2  # JSONResponse + 1 effect
+    assert result[1] is mock_effect
+    mock_build.assert_called_once_with(commands, "note-uuid-123")
+    mock_audit.assert_called_once()
+    audit_call = mock_audit.call_args
+    assert audit_call.args[0] == "note-uuid-123"
+    assert audit_call.args[1] == "AMEND_EXISTING_COMMANDS"
+    assert audit_call.args[2]["edit_count"] == 1
+    assert audit_call.args[2]["effect_count"] == 1
+    assert audit_call.args[2]["entries"][0]["mode"] == "direct_edit"
+
+
+@patch("hyperscribe.scribe.api.session_view.audit_event")
+@patch("hyperscribe.scribe.api.session_view.build_amend_edit_effects")
+@patch("hyperscribe.scribe.api.session_view.Command")
+def test_edit_existing_commands_hpi_void_recreate(
+    mock_command: MagicMock, mock_build: MagicMock, mock_audit: MagicMock
+) -> None:
+    """Void+recreate for HPI surfaces a different uuid for new vs old."""
+    eie_effect = MagicMock()
+    originate_effect = MagicMock()
+    commit_effect = MagicMock()
+    attempted = [
+        {
+            "section_key": "history_of_present_illness",
+            "command_type": "hpi",
+            "old_command_uuid": "old-hpi-uuid",
+            "new_command_uuid": "new-hpi-uuid",
+            "mode": "void_recreate",
+            "display": "Two weeks of headaches",
+        },
+    ]
+    mock_build.return_value = ([eie_effect, originate_effect, commit_effect], attempted)
+    # State check: HPI row is currently 'committed' - valid for void+recreate.
+    # See ``_StubUUID`` docstring: Postgres ``uuid`` columns return ``UUID``
+    # objects, not strings.
+    mock_command.objects.filter.return_value.values_list.return_value = [
+        (_StubUUID("old-hpi-uuid"), "committed"),
+    ]
+
+    view = _helper_instance()
+    commands = [
+        {
+            "command_type": "hpi",
+            "command_uuid": "old-hpi-uuid",
+            "section_key": "history_of_present_illness",
+            "data": {"narrative": "Two weeks of headaches"},
+            "display": "Two weeks of headaches",
+        },
+    ]
+    view.request = SimpleNamespace(body=json.dumps({"note_uuid": "note-uuid-123", "commands": commands}))
+    result = view.post_edit_existing_commands()
+
+    assert result[0].status_code == HTTPStatus.OK
+    data = json.loads(result[0].content)
+    assert data["attempted"] == attempted
+    assert len(result) == 4  # JSONResponse + 3 effects
+    audit_call = mock_audit.call_args
+    assert audit_call.args[1] == "AMEND_EXISTING_COMMANDS"
+    assert audit_call.args[2]["entries"][0]["mode"] == "void_recreate"
+    assert audit_call.args[2]["entries"][0]["old_command_uuid"] == "old-hpi-uuid"
+    assert audit_call.args[2]["entries"][0]["new_command_uuid"] == "new-hpi-uuid"
+
+
+@patch("hyperscribe.scribe.api.session_view.audit_event")
+@patch("hyperscribe.scribe.api.session_view.build_amend_edit_effects")
+def test_edit_existing_commands_silently_drops_disallowed_section(mock_build: MagicMock, mock_audit: MagicMock) -> None:
+    """Sections not in EDITABLE_AMEND_SECTIONS are silently dropped (logged at WARN
+    inside build_amend_edit_effects). The response carries only the attempted
+    list - no parallel `rejected` field. Rationale: defense-in-depth, not UX -
+    the frontend should never send a non-editable section in the first place;
+    surfacing them as a structured response field encourages relying on it.
+    """
+    mock_build.return_value = ([], [])
+
+    view = _helper_instance()
+    commands = [
+        {
+            "command_type": "prescribe",
+            "command_uuid": "rx-uuid",
+            "section_key": "_recommended",  # not in EDITABLE_AMEND_SECTIONS
+            "data": {"sig": "daily"},
+            "display": "Lisinopril",
+        },
+    ]
+    view.request = SimpleNamespace(body=json.dumps({"note_uuid": "note-uuid-123", "commands": commands}))
+    result = view.post_edit_existing_commands()
+
+    assert result[0].status_code == HTTPStatus.OK
+    data = json.loads(result[0].content)
+    assert data["attempted"] == []
+    # No `rejected` parallel field anymore.
+    assert "rejected" not in data
+    # Audit still gets the (empty) entries list under the renamed type.
+    audit_call = mock_audit.call_args
+    assert audit_call.args[1] == "AMEND_EXISTING_COMMANDS"
+    assert audit_call.args[2]["edit_count"] == 0
+    assert audit_call.args[2]["entries"] == []
+
+
+@patch("hyperscribe.scribe.api.session_view.audit_event")
+@patch("hyperscribe.scribe.api.session_view.build_amend_edit_effects")
+def test_edit_existing_commands_silently_drops_missing_command_uuid(
+    mock_build: MagicMock, mock_audit: MagicMock
+) -> None:
+    """An editable section without a command_uuid is silently dropped, not silently
+    turned into a fresh insert. The frontend should never submit this shape; if it
+    does, the drop is logged at WARN inside build_amend_edit_effects.
+    """
+    mock_build.return_value = ([], [])
+
+    view = _helper_instance()
+    commands = [
+        {
+            "command_type": "rfv",
+            "section_key": "chief_complaint",
+            "data": {"comment": "Headache"},
+            "display": "Headache",
+        },
+    ]
+    view.request = SimpleNamespace(body=json.dumps({"note_uuid": "note-uuid-123", "commands": commands}))
+    result = view.post_edit_existing_commands()
+
+    assert result[0].status_code == HTTPStatus.OK
+    data = json.loads(result[0].content)
+    assert data["attempted"] == []
+    assert "rejected" not in data
+
+
+@patch("hyperscribe.scribe.api.session_view.audit_event")
+@patch("hyperscribe.scribe.api.session_view.build_amend_edit_effects")
+def test_edit_existing_commands_validation_error(mock_build: MagicMock, mock_audit: MagicMock) -> None:
+    """Per-field validation runs against amendment edits too - over-long narratives bounce."""
+    view = _helper_instance()
+    commands = [
+        {
+            "command_type": "hpi",
+            "command_uuid": "old-hpi-uuid",
+            "section_key": "history_of_present_illness",
+            "data": {"narrative": "x" * 999999},  # this won't trip current rules but we use a real rule below
+        },
+        # Use a known rule that DOES trip: prescribe sig over 1000 chars.
+        {
+            "command_type": "prescribe",
+            "command_uuid": "old-rx-uuid",
+            "section_key": "chief_complaint",  # ignored when validation fails first
+            "data": {"sig": "x" * 1001},
+            "display": "Rx",
+        },
+    ]
+    view.request = SimpleNamespace(body=json.dumps({"note_uuid": "note-uuid-123", "commands": commands}))
+    result = view.post_edit_existing_commands()
+
+    assert result[0].status_code == HTTPStatus.BAD_REQUEST
+    payload = json.loads(result[0].content)
+    assert "validation_errors" in payload
+    mock_build.assert_not_called()
+    # Validation failure still gets audited.
+    audit_event_types = [c.args[1] for c in mock_audit.call_args_list]
+    assert "VALIDATION_FAILED" in audit_event_types
+
+
+def test_edit_existing_commands_missing_note_uuid() -> None:
+    view = _helper_instance()
+    view.request = SimpleNamespace(body=json.dumps({"commands": []}))
+    result = view.post_edit_existing_commands()
+
+    assert result[0].status_code == HTTPStatus.BAD_REQUEST
+    assert "note_uuid" in json.loads(result[0].content)["error"]
+
+
+def test_edit_existing_commands_invalid_json() -> None:
+    view = _helper_instance()
+    view.request = SimpleNamespace(body="not-json")
+    result = view.post_edit_existing_commands()
+
+    assert result[0].status_code == HTTPStatus.BAD_REQUEST
+    assert "Invalid JSON" in json.loads(result[0].content)["error"]
+
+
+@patch("hyperscribe.scribe.api.session_view.Command")
+@patch("hyperscribe.scribe.api.session_view.ScribeSummary")
+@patch("hyperscribe.scribe.api.session_view.audit_event")
+@patch("hyperscribe.scribe.api.session_view.build_amend_edit_effects")
+def test_edit_existing_commands_does_not_touch_scribe_summary(
+    mock_build: MagicMock,
+    mock_audit: MagicMock,
+    mock_summary: MagicMock,
+    mock_command: MagicMock,
+) -> None:
+    """KOALA-5485: amendment edits must NOT write to ScribeSummary.
+
+    The ``was_finalized`` latch is set by ``/save-summary`` on first approval
+    and is intentionally one-way: any number of amendment edit roundtrips
+    must leave it True. Pinning this at the endpoint level keeps a future
+    refactor from accidentally introducing a write that clears the latch
+    (which would re-show the "Accept and sign" wording and break the
+    distinction between fresh approval and amendment).
+    """
+    mock_effect = MagicMock()
+    mock_build.return_value = (
+        [mock_effect],
+        [
+            {
+                "section_key": "chief_complaint",
+                "command_type": "rfv",
+                "old_command_uuid": "rfv-uuid",
+                "new_command_uuid": "rfv-uuid",
+                "mode": "direct_edit",
+                "display": "Headache",
+            },
+        ],
+    )
+    mock_command.objects.filter.return_value.values_list.return_value = [
+        (_StubUUID("rfv-uuid"), "staged"),
+    ]
+
+    view = _helper_instance()
+    view.request = SimpleNamespace(
+        body=json.dumps(
+            {
+                "note_uuid": "note-uuid-123",
+                "commands": [
+                    {
+                        "command_type": "rfv",
+                        "command_uuid": "rfv-uuid",
+                        "section_key": "chief_complaint",
+                        "data": {"comment": "Headache"},
+                        "display": "Headache",
+                    },
+                ],
+            }
+        )
+    )
+    view.post_edit_existing_commands()
+
+    mock_summary.objects.update_or_create.assert_not_called()
+    mock_summary.objects.create.assert_not_called()
+    mock_summary.objects.filter.assert_not_called()
+    mock_summary.objects.get.assert_not_called()
+
+
+@patch("hyperscribe.scribe.api.session_view.audit_event")
+@patch("hyperscribe.scribe.api.session_view.build_amend_edit_effects")
+@patch("hyperscribe.scribe.api.session_view.Command")
+def test_edit_existing_commands_rejects_stale_amend_on_already_voided_row(
+    mock_command: MagicMock, mock_build: MagicMock, mock_audit: MagicMock
+) -> None:
+    """Cross-tab concurrency: Tab A amends HPI X -> Y (X is now entered_in_error).
+    Tab B (stale, still showing X) submits its own amend against X. The backend
+    must reject Tab B's amend with HTTP 409 so the frontend can prompt reload,
+    not happily emit EIE(X) on an already-voided row.
+    """
+    # Tab B's request: amend HPI against uuid X.
+    # State in DB: X is now 'entered_in_error' (Tab A already voided it).
+    mock_command.objects.filter.return_value.values_list.return_value = [
+        (_StubUUID("old-hpi-uuid"), "entered_in_error"),
+    ]
+
+    view = _helper_instance()
+    commands = [
+        {
+            "command_type": "hpi",
+            "command_uuid": "old-hpi-uuid",
+            "section_key": "history_of_present_illness",
+            "data": {"narrative": "Tab B's stale edit"},
+            "display": "Tab B's stale edit",
+        },
+    ]
+    view.request = SimpleNamespace(body=json.dumps({"note_uuid": "note-uuid-123", "commands": commands}))
+    result = view.post_edit_existing_commands()
+
+    assert result[0].status_code == HTTPStatus.CONFLICT
+    body = json.loads(result[0].content)
+    assert "error" in body
+    assert "conflicts" in body
+    assert len(body["conflicts"]) == 1
+    conflict = body["conflicts"][0]
+    assert conflict["command_uuid"] == "old-hpi-uuid"
+    assert conflict["current_state"] == "entered_in_error"
+    assert conflict["reason"] == "state_mismatch_already_voided"
+
+    # Build must NOT have been called - no effects emitted on conflict.
+    mock_build.assert_not_called()
+    # Conflict audit fired with the renamed audit type.
+    audit_types = [c.args[1] for c in mock_audit.call_args_list]
+    assert "AMEND_CONFLICT" in audit_types
+
+
+@patch("hyperscribe.scribe.api.session_view.audit_event")
+@patch("hyperscribe.scribe.api.session_view.build_amend_edit_effects")
+@patch("hyperscribe.scribe.api.session_view.Command")
+def test_edit_existing_commands_rejects_direct_edit_on_non_staged_rfv(
+    mock_command: MagicMock, mock_build: MagicMock, mock_audit: MagicMock
+) -> None:
+    """RFV (chief_complaint) direct-EDIT requires the row to be 'staged'. If
+    a future home-app change starts committing RFV, the direct EDIT would be
+    rejected with "Command must be staged in order to be edited." The
+    state-check catches this in the plugin first.
+    """
+    mock_command.objects.filter.return_value.values_list.return_value = [
+        (_StubUUID("rfv-uuid"), "committed"),
+    ]
+
+    view = _helper_instance()
+    commands = [
+        {
+            "command_type": "rfv",
+            "command_uuid": "rfv-uuid",
+            "section_key": "chief_complaint",
+            "data": {"comment": "Tab B's stale CC edit"},
+            "display": "Tab B's stale CC edit",
+        },
+    ]
+    view.request = SimpleNamespace(body=json.dumps({"note_uuid": "note-uuid-123", "commands": commands}))
+    result = view.post_edit_existing_commands()
+
+    assert result[0].status_code == HTTPStatus.CONFLICT
+    body = json.loads(result[0].content)
+    assert body["conflicts"][0]["reason"] == "state_mismatch_expected_staged"
+    assert body["conflicts"][0]["current_state"] == "committed"
+    mock_build.assert_not_called()
+
+
+@patch("hyperscribe.scribe.api.session_view.audit_event")
+@patch("hyperscribe.scribe.api.session_view.build_amend_edit_effects")
+@patch("hyperscribe.scribe.api.session_view.Command")
+def test_edit_existing_commands_rejects_when_command_uuid_missing_from_db(
+    mock_command: MagicMock, mock_build: MagicMock, mock_audit: MagicMock
+) -> None:
+    """If a proposal's command_uuid doesn't resolve to any Command row, treat
+    it as a conflict (e.g., stale frontend cache, deleted note). Surface it
+    rather than silently no-op or emit EIE on a non-existent row.
+    """
+    # Filter returns nothing for the requested uuid.
+    mock_command.objects.filter.return_value.values_list.return_value = []
+
+    view = _helper_instance()
+    commands = [
+        {
+            "command_type": "hpi",
+            "command_uuid": "ghost-uuid",
+            "section_key": "history_of_present_illness",
+            "data": {"narrative": "edit"},
+            "display": "edit",
+        },
+    ]
+    view.request = SimpleNamespace(body=json.dumps({"note_uuid": "note-uuid-123", "commands": commands}))
+    result = view.post_edit_existing_commands()
+
+    assert result[0].status_code == HTTPStatus.CONFLICT
+    body = json.loads(result[0].content)
+    assert body["conflicts"][0]["reason"] == "command_not_found"
+    assert body["conflicts"][0]["current_state"] == "missing"
+
+
+@patch("hyperscribe.scribe.api.session_view.audit_event")
+@patch("hyperscribe.scribe.api.session_view.build_amend_edit_effects")
+@patch("hyperscribe.scribe.api.session_view.Command")
+def test_edit_existing_commands_state_lookup_handles_uuid_type_from_postgres(
+    mock_command: MagicMock, mock_build: MagicMock, mock_audit: MagicMock
+) -> None:
+    """KOALA-5485 regression: ``Command.id`` is a UUIDField backed by
+    Postgres ``uuid``, so ``.values_list("id", ...)`` yields ``uuid.UUID``
+    instances, not strings. ``hash(UUID(s)) != hash(s)``, so a dict keyed
+    by the raw return values misses every string-keyed lookup - turning
+    every legitimate amendment into a spurious ``command_not_found`` 409.
+
+    This test pins the type-coercion path: the state-lookup dict MUST be
+    keyed by ``str``, and the ``cmd_uuid`` (a string from JSON) MUST
+    resolve. The other amendment tests use ``_StubUUID`` to enforce this
+    invariant on the type-mismatch axis without relying on a real Postgres
+    cursor. This test isolates the contract.
+    """
+    mock_effect = MagicMock()
+    attempted = [
+        {
+            "section_key": "chief_complaint",
+            "command_type": "rfv",
+            "old_command_uuid": "rfv-uuid",
+            "new_command_uuid": "rfv-uuid",
+            "mode": "direct_edit",
+            "display": "Headache",
+        },
+    ]
+    mock_build.return_value = ([mock_effect], attempted)
+    # Simulate the production query's actual return type: ``UUID``-like
+    # objects whose hash differs from ``hash(str(uid))``. If the session
+    # view ever stops coercing with ``str(...)`` and reverts to ``dict(...)``
+    # of the raw tuples, this test bombs with HTTPStatus.CONFLICT +
+    # ``command_not_found`` - the exact UAT failure mode.
+    mock_command.objects.filter.return_value.values_list.return_value = [
+        (_StubUUID("rfv-uuid"), "staged"),
+    ]
+
+    view = _helper_instance()
+    commands = [
+        {
+            "command_type": "rfv",
+            "command_uuid": "rfv-uuid",
+            "section_key": "chief_complaint",
+            "data": {"comment": "Headache"},
+            "display": "Headache",
+        },
+    ]
+    view.request = SimpleNamespace(body=json.dumps({"note_uuid": "note-uuid-123", "commands": commands}))
+    result = view.post_edit_existing_commands()
+
+    # The happy path must succeed - a regression here means the type
+    # coercion is gone and every UAT amendment will 409 again.
+    assert result[0].status_code == HTTPStatus.OK, (
+        f"State-check must coerce UUID -> str so lookups by string command_uuid succeed; "
+        f"got {result[0].status_code} with body {json.loads(result[0].content)!r}"
+    )
+    body = json.loads(result[0].content)
+    assert "conflicts" not in body
+    mock_build.assert_called_once_with(commands, "note-uuid-123")
+
+
+@patch("hyperscribe.scribe.api.session_view.audit_event")
+@patch("hyperscribe.scribe.api.session_view.build_amend_edit_effects")
+@patch("hyperscribe.scribe.api.session_view.Command")
+def test_edit_existing_commands_audit_payload_excludes_display_phi(
+    mock_command: MagicMock, mock_build: MagicMock, mock_audit: MagicMock
+) -> None:
+    """HIPAA regression: the AMEND_EXISTING_COMMANDS audit payload must NOT
+    carry the ``display`` field. For HPI / ROS / PE / lab_results / current
+    medications, ``display`` is free-text clinical narrative; persisting it
+    into ``ScribeAuditLog.events`` is PHI in a log. Even 80-character truncation
+    still leaks clinical content. The audit keeps only structural identifiers
+    (section_key, command_type, uuids, mode).
+    """
+    mock_effect = MagicMock()
+    attempted = [
+        {
+            "section_key": "history_of_present_illness",
+            "command_type": "hpi",
+            "old_command_uuid": "old-hpi-uuid",
+            "new_command_uuid": "new-hpi-uuid",
+            "mode": "void_recreate",
+            "display": "Patient presents with 2 weeks of frontal headaches, worse with bright light",
+        },
+    ]
+    mock_build.return_value = ([mock_effect], attempted)
+    mock_command.objects.filter.return_value.values_list.return_value = [(_StubUUID("old-hpi-uuid"), "committed")]
+
+    view = _helper_instance()
+    commands = [
+        {
+            "command_type": "hpi",
+            "command_uuid": "old-hpi-uuid",
+            "section_key": "history_of_present_illness",
+            "data": {"narrative": "Patient presents with 2 weeks of frontal headaches"},
+            "display": "Patient presents with 2 weeks of frontal headaches, worse with bright light",
+        },
+    ]
+    view.request = SimpleNamespace(body=json.dumps({"note_uuid": "note-uuid-123", "commands": commands}))
+    view.post_edit_existing_commands()
+
+    audit_calls = [c for c in mock_audit.call_args_list if c.args[1] == "AMEND_EXISTING_COMMANDS"]
+    assert len(audit_calls) == 1
+    payload = audit_calls[0].args[2]
+    assert payload["entries"], "expected at least one entry to assert against"
+    for entry in payload["entries"]:
+        assert "display" not in entry, (
+            f"AMEND_EXISTING_COMMANDS audit payload must not carry 'display' (PHI risk); got: {sorted(entry.keys())}"
+        )
+        assert set(entry.keys()) == {
+            "section_key",
+            "command_type",
+            "old_command_uuid",
+            "new_command_uuid",
+            "mode",
+        }
+
+
+@patch("hyperscribe.scribe.api.session_view.audit_event")
+@patch("hyperscribe.scribe.api.session_view.build_amend_edit_effects")
+@patch("hyperscribe.scribe.api.session_view.Command")
+def test_edit_existing_commands_reads_state_before_emitting_effects(
+    mock_command: MagicMock,
+    mock_build: MagicMock,
+    mock_audit: MagicMock,
+) -> None:
+    """The eligibility check must read Command.state via the plugin's view
+    before deciding whether to emit effects. This pins the check-then-emit
+    pattern - the common stale-tab case (Tab B submits after Tab A's EIE has
+    landed) is caught here.
+
+    There is NO atomic/row-lock guarantee at the plugin level: the sandbox
+    bans ``from django.db import transaction`` (only ``from django.db
+    .transaction import atomic`` is whitelisted), ``select_for_update()`` on
+    the Command view fails at the SQL layer (FOR UPDATE on an outer-joined
+    view), and the EnterInError effect is processed by home-app in its own
+    transaction anyway. See the endpoint docstring for the residual race
+    window and its visible artifact (duplicate Originate on near-simultaneous
+    submits against a still-committed row).
+    """
+    mock_effect = MagicMock()
+    attempted = [
+        {
+            "section_key": "history_of_present_illness",
+            "command_type": "hpi",
+            "old_command_uuid": "old-hpi-uuid",
+            "new_command_uuid": "new-hpi-uuid",
+            "mode": "void_recreate",
+            "display": "narrative",
+        },
+    ]
+    mock_build.return_value = ([mock_effect], attempted)
+
+    mock_command.objects.filter.return_value.values_list.return_value = [(_StubUUID("old-hpi-uuid"), "committed")]
+
+    view = _helper_instance()
+    commands = [
+        {
+            "command_type": "hpi",
+            "command_uuid": "old-hpi-uuid",
+            "section_key": "history_of_present_illness",
+            "data": {"narrative": "edit"},
+            "display": "narrative",
+        },
+    ]
+    view.request = SimpleNamespace(body=json.dumps({"note_uuid": "note-uuid-123", "commands": commands}))
+    view.post_edit_existing_commands()
+
+    # The Command query went through .filter() (the SDK-sandbox-compatible path).
+    mock_command.objects.filter.assert_called_once()
+    # And NOT through the no-longer-supported select_for_update() path.
+    mock_command.objects.select_for_update.assert_not_called()
+    # Happy path: build_amend_edit_effects was invoked (no conflict surfaced).
+    mock_build.assert_called_once_with(commands, "note-uuid-123")
+
+
+@patch("hyperscribe.scribe.api.session_view.audit_event")
+@patch("hyperscribe.scribe.api.session_view.build_amend_edit_effects")
+@patch("hyperscribe.scribe.api.session_view.Command")
+def test_amend_conflict_audit_payload_excludes_display_phi(
+    mock_command: MagicMock, mock_build: MagicMock, mock_audit: MagicMock
+) -> None:
+    """HIPAA regression: the AMEND_CONFLICT audit payload must also not carry
+    free-text clinical narrative. Conflicts are emitted on cross-tab races
+    against committed/voided rows - same PHI surface area as the success path.
+    The structured conflict shape (section_key, command_type, uuid, state,
+    reason) is already PHI-free; this test pins that.
+    """
+    mock_command.objects.filter.return_value.values_list.return_value = [
+        (_StubUUID("old-hpi-uuid"), "entered_in_error"),
+    ]
+
+    view = _helper_instance()
+    commands = [
+        {
+            "command_type": "hpi",
+            "command_uuid": "old-hpi-uuid",
+            "section_key": "history_of_present_illness",
+            "data": {"narrative": "Tab B stale narrative with PHI"},
+            "display": "Patient reports severe abdominal pain radiating to right shoulder",
+        },
+    ]
+    view.request = SimpleNamespace(body=json.dumps({"note_uuid": "note-uuid-123", "commands": commands}))
+    view.post_edit_existing_commands()
+
+    audit_calls = [c for c in mock_audit.call_args_list if c.args[1] == "AMEND_CONFLICT"]
+    assert len(audit_calls) == 1
+    payload = audit_calls[0].args[2]
+    for conflict in payload["conflicts"]:
+        assert "display" not in conflict, (
+            f"AMEND_CONFLICT conflict entry must not carry 'display' (PHI risk); got: {sorted(conflict.keys())}"
+        )
+    # build_amend_edit_effects was not called - no effects emitted on conflict.
+    mock_build.assert_not_called()
+
+
+@patch("hyperscribe.scribe.api.session_view.audit_event")
+@patch("hyperscribe.scribe.api.session_view.build_amend_edit_effects")
+@patch("hyperscribe.scribe.api.session_view.Command")
+def test_amend_audit_payload_does_not_propagate_new_attempted_keys(
+    mock_command: MagicMock, mock_build: MagicMock, mock_audit: MagicMock
+) -> None:
+    """HIPAA defense-in-depth: the AMEND_EXISTING_COMMANDS audit payload is built
+    from a fixed key whitelist. If a future change adds a new key to the
+    ``attempted`` records (e.g., the ``display`` field that was historically
+    surfaced there), it must NOT silently propagate into the audit log.
+
+    This test pins the whitelist mechanism: even when ``attempted`` carries a
+    phantom ``_future_phi`` key (simulating a future record-shape regression),
+    the audit entry only contains the structural identifiers.
+    """
+    mock_effect = MagicMock()
+    attempted = [
+        {
+            "section_key": "history_of_present_illness",
+            "command_type": "hpi",
+            "old_command_uuid": "old-hpi-uuid",
+            "new_command_uuid": "new-hpi-uuid",
+            "mode": "void_recreate",
+            "display": "free-text clinical narrative that must not leak",
+            # Phantom key simulating a future record-shape regression.
+            "_future_phi": "Patient reports severe abdominal pain (PHI)",
+        },
+    ]
+    mock_build.return_value = ([mock_effect], attempted)
+    mock_command.objects.filter.return_value.values_list.return_value = [(_StubUUID("old-hpi-uuid"), "committed")]
+
+    view = _helper_instance()
+    commands = [
+        {
+            "command_type": "hpi",
+            "command_uuid": "old-hpi-uuid",
+            "section_key": "history_of_present_illness",
+            "data": {"narrative": "edit"},
+            "display": "narrative",
+        },
+    ]
+    view.request = SimpleNamespace(body=json.dumps({"note_uuid": "note-uuid-123", "commands": commands}))
+    view.post_edit_existing_commands()
+
+    audit_calls = [c for c in mock_audit.call_args_list if c.args[1] == "AMEND_EXISTING_COMMANDS"]
+    assert len(audit_calls) == 1
+    payload = audit_calls[0].args[2]
+    assert payload["entries"], "expected at least one entry to assert against"
+    expected_keys = {"section_key", "command_type", "old_command_uuid", "new_command_uuid", "mode"}
+    for entry in payload["entries"]:
+        actual_keys = set(entry.keys())
+        assert actual_keys == expected_keys, (
+            f"AMEND_EXISTING_COMMANDS audit entries must be built from the fixed whitelist "
+            f"{sorted(expected_keys)}; got: {sorted(actual_keys)}. The dict comprehension "
+            f"over a whitelist constant prevents new attempted-record keys from silently "
+            f"leaking PHI into the audit log."
+        )
+        assert "_future_phi" not in entry
+        assert "display" not in entry
+
+
+@patch("hyperscribe.scribe.api.session_view.audit_event")
+@patch("hyperscribe.scribe.api.session_view.build_amend_edit_effects")
+@patch("hyperscribe.scribe.api.session_view.Command")
+def test_edit_existing_commands_audit_fires_after_state_check(
+    mock_command: MagicMock,
+    mock_build: MagicMock,
+    mock_audit: MagicMock,
+) -> None:
+    """Ordering invariant: ``audit_event(AMEND_EXISTING_COMMANDS, ...)`` must
+    fire AFTER the Command state read and ``build_amend_edit_effects`` call.
+
+    Why this matters: ``audit_event()`` catches broad ``Exception`` via
+    ``log.exception(...)`` so an audit-write failure cannot suppress the
+    response or short-circuit effect emission. We pin the ordering so a
+    future refactor can't accidentally hoist the audit above the state read
+    (which would let an audit-side DB failure swallow the actual amendment).
+    """
+    mock_effect = MagicMock()
+    attempted = [
+        {
+            "section_key": "history_of_present_illness",
+            "command_type": "hpi",
+            "old_command_uuid": "old-hpi-uuid",
+            "new_command_uuid": "new-hpi-uuid",
+            "mode": "void_recreate",
+        },
+    ]
+    mock_build.return_value = ([mock_effect], attempted)
+    mock_command.objects.filter.return_value.values_list.return_value = [(_StubUUID("old-hpi-uuid"), "committed")]
+
+    # Record the order in which key collaborators are touched.
+    call_log: list[str] = []
+
+    def record_filter(*_args: Any, **_kwargs: Any) -> MagicMock:
+        call_log.append("state_read")
+        # Re-stage the chained mock so the production code keeps working.
+        chained = MagicMock()
+        chained.values_list.return_value = [(_StubUUID("old-hpi-uuid"), "committed")]
+        return chained
+
+    mock_command.objects.filter.side_effect = record_filter
+
+    def record_build(*_args: Any, **_kwargs: Any) -> tuple[list[Any], list[dict[str, Any]]]:
+        call_log.append("build_effects")
+        return ([mock_effect], attempted)
+
+    mock_build.side_effect = record_build
+
+    def record_audit(*args: Any, **_kwargs: Any) -> None:
+        if len(args) >= 2 and args[1] in ("AMEND_EXISTING_COMMANDS", "AMEND_CONFLICT"):
+            call_log.append(f"audit:{args[1]}")
+
+    mock_audit.side_effect = record_audit
+
+    view = _helper_instance()
+    commands = [
+        {
+            "command_type": "hpi",
+            "command_uuid": "old-hpi-uuid",
+            "section_key": "history_of_present_illness",
+            "data": {"narrative": "edit"},
+            "display": "narrative",
+        },
+    ]
+    view.request = SimpleNamespace(body=json.dumps({"note_uuid": "note-uuid-123", "commands": commands}))
+    view.post_edit_existing_commands()
+
+    # State read came first, build_effects came second, audit came last.
+    assert call_log == ["state_read", "build_effects", "audit:AMEND_EXISTING_COMMANDS"], (
+        f"audit_event(AMEND_EXISTING_COMMANDS) must fire after the state read + effect emission step. Got: {call_log}"
+    )
+
+
+@patch("hyperscribe.scribe.api.session_view.audit_event")
+@patch("hyperscribe.scribe.api.session_view.build_amend_edit_effects")
+@patch("hyperscribe.scribe.api.session_view.Command")
+def test_amend_conflict_audit_fires_after_state_check(
+    mock_command: MagicMock,
+    mock_build: MagicMock,
+    mock_audit: MagicMock,
+) -> None:
+    """Same ordering invariant for the AMEND_CONFLICT branch: the conflict
+    audit must fire AFTER the state read decides the row is incompatible.
+    ``build_amend_edit_effects`` must NOT have been called (conflicts short-
+    circuit effect emission).
+    """
+    call_log: list[str] = []
+
+    def record_filter(*_args: Any, **_kwargs: Any) -> MagicMock:
+        call_log.append("state_read")
+        chained = MagicMock()
+        chained.values_list.return_value = [(_StubUUID("old-hpi-uuid"), "entered_in_error")]
+        return chained
+
+    mock_command.objects.filter.side_effect = record_filter
+
+    def record_audit(*args: Any, **_kwargs: Any) -> None:
+        if len(args) >= 2 and args[1] in ("AMEND_EXISTING_COMMANDS", "AMEND_CONFLICT"):
+            call_log.append(f"audit:{args[1]}")
+
+    mock_audit.side_effect = record_audit
+
+    view = _helper_instance()
+    commands = [
+        {
+            "command_type": "hpi",
+            "command_uuid": "old-hpi-uuid",
+            "section_key": "history_of_present_illness",
+            "data": {"narrative": "edit"},
+            "display": "Patient reports severe abdominal pain (PHI)",
+        },
+    ]
+    view.request = SimpleNamespace(body=json.dumps({"note_uuid": "note-uuid-123", "commands": commands}))
+    result = view.post_edit_existing_commands()
+
+    assert result[0].status_code == HTTPStatus.CONFLICT
+    # State read first, then audit. build_amend_edit_effects was not called.
+    assert call_log == ["state_read", "audit:AMEND_CONFLICT"], (
+        f"audit_event(AMEND_CONFLICT) must fire after the state read and conflicts must "
+        f"short-circuit effect emission. Got: {call_log}"
+    )
+    mock_build.assert_not_called()
 
 
 # --- /insert-metadata ---

--- a/tests/hyperscribe/scribe/commands/test_builder.py
+++ b/tests/hyperscribe/scribe/commands/test_builder.py
@@ -2,9 +2,21 @@ import json
 from typing import Any
 from unittest.mock import MagicMock, patch
 
+import pytest
 from canvas_generated.messages.effects_pb2 import EffectType
+from canvas_sdk.commands.commands.custom_command import CustomCommand
 
-from hyperscribe.scribe.commands.builder import build_effects, build_metadata_effects, validate_proposals
+from hyperscribe.scribe.commands.builder import (
+    _BUILDERS,
+    CUSTOM_COMMAND_ROUTED_SECTIONS,
+    DIRECT_EDIT_SECTIONS,
+    EDITABLE_AMEND_SECTIONS,
+    NON_EDITABLE_AMEND_COMMAND_TYPES,
+    build_amend_edit_effects,
+    build_effects,
+    build_metadata_effects,
+    validate_proposals,
+)
 
 
 def test_build_effects_routes_all_types() -> None:
@@ -225,8 +237,6 @@ def test_build_effects_medication_alert_facility_flag_off_no_metadata() -> None:
 
 def test_build_metadata_effects() -> None:
     """Phase 2 builds upsert_metadata effects from pending items."""
-    from hyperscribe.scribe.commands.builder import _BUILDERS
-
     pending: list[dict[str, Any]] = [
         {
             "command_uuid": "d6a96b19-a087-458a-9619-b46537a8c121",
@@ -399,3 +409,919 @@ def test_validate_proposals_refill_and_adjust() -> None:
     ]
     errors = validate_proposals(proposals)
     assert len(errors) == 2
+
+
+# ----------------------------------------------------------------------
+# Amendment edit path (KOALA-5485): editing already-documented commands
+# in the seven sections Alexia listed (plus chart_review by default).
+#
+# Two routes:
+#   - direct edit (RFV/chief_complaint only): single EDIT effect; uuid stays
+#   - void+recreate (everything else): EnterInError(old) + Originate(new)
+#     + Commit(new); uuid changes
+#
+# The direct-edit route exists because home-app does NOT wire either
+# COMMIT_REASON_FOR_VISIT_COMMAND nor ENTER_IN_ERROR_REASON_FOR_VISIT_COMMAND
+# (plugin_io/interpreters/commands/__init__.py:395 and absent EIE entry).
+# Routing RFV through ENTER_IN_ERROR would be a silent no-op and corrupt
+# data. RFV always stays staged, so EDIT_REASON_FOR_VISIT_COMMAND works
+# directly.
+# ----------------------------------------------------------------------
+
+
+def test_build_amend_edit_effects_rfv_emits_edit_only_no_enter_in_error() -> None:
+    """Critical regression: amending chief_complaint MUST NOT emit ENTER_IN_ERROR.
+
+    RFV does not have a wired ENTER_IN_ERROR interpreter in home-app, so
+    routing it through void+recreate would silently no-op and corrupt the
+    plugin's local state. Direct EDIT keeps the same command_uuid and works
+    because RFV is never committed (no COMMIT handler either).
+    """
+    proposals: list[dict[str, Any]] = [
+        {
+            "command_type": "rfv",
+            "command_uuid": "old-rfv-uuid-aaaa-bbbb-cccccccccccc",
+            "section_key": "chief_complaint",
+            "data": {"comment": "Updated chief complaint text"},
+            "display": "Updated chief complaint text",
+        },
+    ]
+    with patch("hyperscribe.scribe.commands.rfv.ReasonForVisitCommand") as mock_rfv:
+        inst = MagicMock()
+        inst.edit.return_value = "rfv_edit_effect"
+        inst.command_uuid = "old-rfv-uuid-aaaa-bbbb-cccccccccccc"
+        inst.note_uuid = "5899e7bf-5ecb-4399-aceb-0e233bd4a8f0"
+        mock_rfv.return_value = inst
+
+        effects, attempted = build_amend_edit_effects(proposals, "5899e7bf-5ecb-4399-aceb-0e233bd4a8f0")
+
+    # Must be exactly one EDIT effect, no originate/commit/enter-in-error.
+    assert effects == ["rfv_edit_effect"]
+    inst.edit.assert_called_once_with()
+    inst.enter_in_error.assert_not_called()
+    inst.originate.assert_not_called()
+    inst.commit.assert_not_called()
+
+    # Attempted entry pins the audit-log fields the API layer surfaces.
+    assert len(attempted) == 1
+    assert attempted[0]["section_key"] == "chief_complaint"
+    assert attempted[0]["command_type"] == "rfv"
+    assert attempted[0]["mode"] == "direct_edit"
+    assert attempted[0]["old_command_uuid"] == "old-rfv-uuid-aaaa-bbbb-cccccccccccc"
+    # For direct edit the uuid does not change, so new == old.
+    assert attempted[0]["new_command_uuid"] == "old-rfv-uuid-aaaa-bbbb-cccccccccccc"
+
+
+def test_build_amend_edit_effects_rfv_command_built_with_existing_uuid() -> None:
+    """The RFV command for direct EDIT must be built with the existing
+    command_uuid, not a fresh one, so the EDIT effect targets the right row."""
+    proposals: list[dict[str, Any]] = [
+        {
+            "command_type": "rfv",
+            "command_uuid": "the-existing-rfv-uuid-1234-5678-90ab-cdef",
+            "section_key": "chief_complaint",
+            "data": {"comment": "x"},
+            "display": "x",
+        },
+    ]
+    with patch("hyperscribe.scribe.commands.rfv.ReasonForVisitCommand") as mock_rfv:
+        inst = MagicMock()
+        inst.edit.return_value = "rfv_edit_effect"
+        inst.command_uuid = "the-existing-rfv-uuid-1234-5678-90ab-cdef"
+        mock_rfv.return_value = inst
+
+        build_amend_edit_effects(proposals, "5899e7bf-5ecb-4399-aceb-0e233bd4a8f0")
+
+    # The builder must reuse the existing command_uuid (third arg position),
+    # not invent a new one.
+    args, kwargs = mock_rfv.call_args
+    assert kwargs.get("command_uuid") == "the-existing-rfv-uuid-1234-5678-90ab-cdef"
+
+
+def test_build_amend_edit_effects_hpi_void_and_recreate() -> None:
+    """HPI in amendment mode emits EnterInError(old) + Originate(new) + Commit(new).
+
+    The new command_uuid is freshly minted by the builder and surfaced via
+    the attempted entry so the frontend can re-stamp ScribeSummary.commands.
+    """
+    proposals: list[dict[str, Any]] = [
+        {
+            "command_type": "hpi",
+            "command_uuid": "old-hpi-uuid-aaaa-bbbb-cccccccccccc",
+            "section_key": "history_of_present_illness",
+            "data": {"narrative": "Updated HPI narrative"},
+            "display": "Updated HPI narrative",
+        },
+    ]
+    minted_uuid = "fresh-hpi-uuid-1111-2222-3333-444444444444"
+    with (
+        patch("hyperscribe.scribe.commands.hpi.HistoryOfPresentIllnessCommand") as mock_hpi,
+        patch("hyperscribe.scribe.commands.builder.uuid.uuid4", return_value=minted_uuid),
+    ):
+        # Two instances are created during this flow:
+        #  - one for the OLD command (to call .enter_in_error())
+        #  - one for the NEW command (to call .originate() and .commit())
+        old_inst = MagicMock()
+        old_inst.enter_in_error.return_value = "hpi_enter_in_error"
+        old_inst.command_uuid = "old-hpi-uuid-aaaa-bbbb-cccccccccccc"
+        new_inst = MagicMock()
+        new_inst.originate.return_value = "hpi_originate"
+        new_inst.commit.return_value = "hpi_commit"
+        new_inst.command_uuid = minted_uuid
+        mock_hpi.side_effect = [old_inst, new_inst]
+
+        effects, attempted = build_amend_edit_effects(proposals, "5899e7bf-5ecb-4399-aceb-0e233bd4a8f0")
+
+    # Order: enter_in_error first, then originate, then commit.
+    assert effects == ["hpi_enter_in_error", "hpi_originate", "hpi_commit"]
+    old_inst.enter_in_error.assert_called_once_with()
+    new_inst.originate.assert_called_once()
+    new_inst.commit.assert_called_once()
+    # Direct-edit shortcut must NOT be taken for HPI.
+    old_inst.edit.assert_not_called()
+    new_inst.edit.assert_not_called()
+
+    # The old command must be constructed with the OLD uuid (so the EIE
+    # effect targets the right row), the new one with the freshly-minted
+    # uuid (so originate creates a new row).
+    construction_calls = mock_hpi.call_args_list
+    assert len(construction_calls) == 2
+    assert construction_calls[0].kwargs.get("command_uuid") == "old-hpi-uuid-aaaa-bbbb-cccccccccccc"
+    assert construction_calls[1].kwargs.get("command_uuid") == minted_uuid
+
+    assert len(attempted) == 1
+    assert attempted[0]["section_key"] == "history_of_present_illness"
+    assert attempted[0]["command_type"] == "hpi"
+    assert attempted[0]["mode"] == "void_recreate"
+    assert attempted[0]["old_command_uuid"] == "old-hpi-uuid-aaaa-bbbb-cccccccccccc"
+    assert attempted[0]["new_command_uuid"] == minted_uuid
+
+
+def test_build_amend_edit_effects_covers_all_void_recreate_sections() -> None:
+    """All non-RFV editable sections route through EnterInError(old) +
+    Originate(new), with an optional Commit(new) for dedicated-SDK-class
+    sections. CustomCommand-routed sections (ros, history_review,
+    chart_review, physical_exam, lab_results, imaging_results) skip the
+    explicit commit because the SDK has no COMMIT_CUSTOM_COMMAND_COMMAND
+    enum (.commit() raises ValueError) and home-app auto-commits after
+    OriginateCustomCommand.
+    """
+    # (section_key, command_type, parser_module, command_class_name, data, expects_commit)
+    cases: list[tuple[str, str, str, str, dict[str, Any], bool]] = [
+        ("history_of_present_illness", "hpi", "hpi", "HistoryOfPresentIllnessCommand", {"narrative": "x"}, True),
+        (
+            "_ros",
+            "ros",
+            "ros",
+            "CustomCommand",
+            {"sections": [{"key": "general", "title": "General", "text": "WNL"}]},
+            False,
+        ),
+        (
+            "_history_review",
+            "history_review",
+            "history_review",
+            "CustomCommand",
+            {"sections": [{"key": "past_medical_history", "title": "PMH", "text": "HTN"}]},
+            False,
+        ),
+        (
+            "_chart_review",
+            "chart_review",
+            "chart_review",
+            "CustomCommand",
+            {"sections": [{"key": "allergies", "title": "Allergies", "text": "NKDA"}]},
+            False,
+        ),
+        (
+            "physical_exam",
+            "physical_exam",
+            "physical_exam",
+            "CustomCommand",
+            {"sections": [{"key": "general", "title": "General", "text": "WNL"}]},
+            False,
+        ),
+        ("lab_results", "lab_results", "lab_results", "CustomCommand", {"narrative": "Labs reviewed"}, False),
+        (
+            "imaging_results",
+            "imaging_results",
+            "image_results",
+            "CustomCommand",
+            {"narrative": "Chest X-ray unremarkable"},
+            False,
+        ),
+        (
+            "current_medications",
+            "medication_statement",
+            "medication_statement",
+            "MedicationStatementCommand",
+            {"medication_text": "Lisinopril 10mg"},
+            True,
+        ),
+    ]
+    proposals: list[dict[str, Any]] = [
+        {
+            "command_type": ct,
+            "command_uuid": f"old-{ct}-uuid",
+            "section_key": sk,
+            "data": data,
+            "display": "x",
+        }
+        for sk, ct, _, _, data, _ in cases
+    ]
+
+    # Pre-mint a deterministic uuid per case so the test can assert the
+    # exact new uuids that come back in `attempted`.
+    minted_uuids = [f"minted-{ct}-uuid-1111-2222-3333-444444444444" for _, ct, _, _, _, _ in cases]
+
+    patches = []
+    instances: list[tuple[MagicMock, MagicMock, str, bool]] = []
+    for case, minted in zip(cases, minted_uuids):
+        sk, ct, mod, cls, _, expects_commit = case
+        p = patch(f"hyperscribe.scribe.commands.{mod}.{cls}")
+        m = p.start()
+        old = MagicMock()
+        old.enter_in_error.return_value = f"{ct}_eie"
+        old.command_uuid = f"old-{ct}-uuid"
+        new = MagicMock()
+        new.originate.return_value = f"{ct}_originate"
+        new.commit.return_value = f"{ct}_commit"
+        new.command_uuid = minted
+        m.side_effect = [old, new]
+        patches.append(p)
+        instances.append((old, new, ct, expects_commit))
+
+    try:
+        with (
+            patch("hyperscribe.scribe.commands.history_review.render_to_string", return_value=""),
+            patch("hyperscribe.scribe.commands.chart_review.render_to_string", return_value=""),
+            patch("hyperscribe.scribe.commands.ros.render_to_string", return_value=""),
+            patch("hyperscribe.scribe.commands.physical_exam.render_to_string", return_value=""),
+            patch("hyperscribe.scribe.commands.builder.uuid.uuid4", side_effect=minted_uuids),
+        ):
+            effects, attempted = build_amend_edit_effects(proposals, "5899e7bf-5ecb-4399-aceb-0e233bd4a8f0")
+    finally:
+        for p in patches:
+            p.stop()
+
+    # Dedicated-class sections contribute 3 effects; CustomCommand sections contribute 2.
+    expected_effect_count = sum(3 if ec else 2 for _, _, _, _, _, ec in cases)
+    assert len(effects) == expected_effect_count
+    # No direct edits anywhere. EIE + Originate always called; Commit only for dedicated classes.
+    for old, new, ct, expects_commit in instances:
+        old.edit.assert_not_called()
+        new.edit.assert_not_called()
+        old.enter_in_error.assert_called_once()
+        new.originate.assert_called_once()
+        if expects_commit:
+            new.commit.assert_called_once()
+        else:
+            new.commit.assert_not_called()
+
+    # Every attempted entry surfaces both uuids. Mode depends on routing.
+    expected_pairs = {(sk, f"old-{ct}-uuid", minted) for (sk, ct, _, _, _, _), minted in zip(cases, minted_uuids)}
+    actual_pairs = {(a["section_key"], a["old_command_uuid"], a["new_command_uuid"]) for a in attempted}
+    assert actual_pairs == expected_pairs
+    mode_by_section = {a["section_key"]: a["mode"] for a in attempted}
+    for sk, _, _, _, _, expects_commit in cases:
+        assert mode_by_section[sk] == ("void_recreate" if expects_commit else "void_recreate_custom")
+    for entry in attempted:
+        assert entry["old_command_uuid"] != entry["new_command_uuid"]
+
+
+def test_build_amend_edit_effects_skips_disallowed_section() -> None:
+    """Sections not in the editable allowlist are silently dropped.
+
+    Defense in depth: even if the frontend sent a stale or hand-crafted
+    payload pointing at, e.g., the recommendation/order buckets, the backend
+    refuses to emit any effects rather than blindly trusting it.
+    """
+    proposals: list[dict[str, Any]] = [
+        {
+            "command_type": "prescribe",
+            "command_uuid": "rx-uuid",
+            "section_key": "_recommended",  # NOT in EDITABLE_AMEND_SECTIONS
+            "data": {"sig": "daily"},
+            "display": "Lisinopril",
+        },
+        {
+            "command_type": "questionnaire",
+            "command_uuid": "q-uuid",
+            "section_key": "_subjective_ad_hoc",  # NOT in EDITABLE_AMEND_SECTIONS
+            "data": {"questionnaire_dbid": 42, "questions": []},
+            "display": "PHQ-9",
+        },
+    ]
+    effects, attempted = build_amend_edit_effects(proposals, "5899e7bf-5ecb-4399-aceb-0e233bd4a8f0")
+    assert effects == []
+    assert attempted == []
+
+
+# ----------------------------------------------------------------------
+# Routing tests for every command_type in _BUILDERS that is in the editable
+# allowlist. One parametrized test per bucket so the mode/effect-shape
+# assertions stay legible per command.
+#
+# Excluded by design (covered by `test_orders_remain_locked...` and
+# `test_build_amend_edit_effects_section_remains_locked`):
+#   * orders: prescribe, refill, adjust_prescription, refer, imaging_order, lab_order
+#   * questionnaire (deferred - needs 4-effect amend route)
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "command_type,section_key,parser_module,sdk_class,data",
+    [
+        # Dedicated SDK class (full ORIGINATE+COMMIT+EIE interpreter wiring).
+        # Each tuple covers a single representative section_key per command_type;
+        # if multiple section_keys land on a command, the additional ones are
+        # tested via `test_void_recreate_routing_per_section_key` below.
+        ("vitals", "vitals", "vitals", "VitalsCommand", {"pulse": 72}),
+        ("allergy", "allergies", "allergy", "AllergyCommand", {"allergy_text": "Penicillin"}),
+        (
+            "medication_statement",
+            "_objective_ad_hoc",
+            "medication_statement",
+            "MedicationStatementCommand",
+            {"medication_text": "Lisinopril 10mg"},
+        ),
+        (
+            "stop_medication",
+            "_objective_ad_hoc",
+            "stop_medication",
+            "StopMedicationCommand",
+            {"medication_id": "med-1", "rationale": "side effect"},
+        ),
+        (
+            "remove_allergy",
+            "_objective_ad_hoc",
+            "remove_allergy",
+            "RemoveAllergyCommand",
+            {"allergy_id": "all-1"},
+        ),
+        (
+            "medicalHistory",
+            "past_medical_history",
+            "medical_history",
+            "MedicalHistoryCommand",
+            {"past_medical_history": "HTN"},
+        ),
+        (
+            "surgicalHistory",
+            "past_surgical_history",
+            "surgical_history",
+            "PastSurgicalHistoryCommand",
+            {"procedure_display": "Appendectomy"},
+        ),
+        (
+            "familyHistory",
+            "family_history",
+            "family_history",
+            "FamilyHistoryCommand",
+            {"condition_display": "CAD"},
+        ),
+        ("plan", "assessment_and_plan", "plan", "PlanCommand", {"narrative": "Continue plan"}),
+        ("plan", "plan", "plan", "PlanCommand", {"narrative": "Plan body"}),
+        ("plan", "_ad_hoc", "plan", "PlanCommand", {"narrative": "Ad-hoc plan"}),
+        (
+            "diagnose",
+            "assessment_and_plan",
+            "diagnose",
+            "DiagnoseCommand",
+            {"icd10_code": "G43.009", "today_assessment": "Migraine"},
+        ),
+        (
+            "assess",
+            "assessment_and_plan",
+            "assess",
+            "AssessCommand",
+            {"condition_id": "cond-1", "narrative": "Stable"},
+        ),
+        (
+            "resolve_condition",
+            "_ad_hoc",
+            "resolve_condition",
+            "ResolveConditionCommand",
+            {"condition_id": "cond-1"},
+        ),
+        (
+            "task",
+            "_ad_hoc",
+            "task",
+            "TaskCommand",
+            {"title": "Follow up next week"},
+        ),
+        (
+            "perform",
+            "_charges_ad_hoc",
+            "perform",
+            "PerformCommand",
+            {"cpt_code": "99213", "notes": ""},
+        ),
+        # Ad-hoc history rows (handleAddHistory ships section_key='_history_ad_hoc'
+        # for any of the history command_types).
+        (
+            "medicalHistory",
+            "_history_ad_hoc",
+            "medical_history",
+            "MedicalHistoryCommand",
+            {"past_medical_history": "Asthma"},
+        ),
+    ],
+)
+def test_void_recreate_routing_per_section_key(
+    command_type: str,
+    section_key: str,
+    parser_module: str,
+    sdk_class: str,
+    data: dict[str, Any],
+) -> None:
+    """Every void+recreate-bucketed (section_key, command_type) emits exactly
+    EIE(old) + Originate(new) + Commit(new) with mode='void_recreate'.
+
+    Pins each newly-classified command_type's routing into the default bucket
+    (dedicated SDK class with full home-app interpreter wiring).
+    """
+    minted = "minted-uuid-1111-2222-3333-444444444444"
+    proposals: list[dict[str, Any]] = [
+        {
+            "command_type": command_type,
+            "command_uuid": "old-uuid-aaaa-bbbb-cccccccccccc",
+            "section_key": section_key,
+            "data": data,
+            "display": "x",
+        },
+    ]
+    with (
+        patch(f"hyperscribe.scribe.commands.{parser_module}.{sdk_class}") as mock_cls,
+        patch("hyperscribe.scribe.commands.builder.uuid.uuid4", return_value=minted),
+    ):
+        old_inst, new_inst = MagicMock(), MagicMock()
+        old_inst.enter_in_error.return_value = f"{command_type}_eie"
+        new_inst.originate.return_value = f"{command_type}_originate"
+        new_inst.commit.return_value = f"{command_type}_commit"
+        mock_cls.side_effect = [old_inst, new_inst]
+
+        effects, attempted = build_amend_edit_effects(proposals, "5899e7bf-5ecb-4399-aceb-0e233bd4a8f0")
+
+    assert effects == [
+        f"{command_type}_eie",
+        f"{command_type}_originate",
+        f"{command_type}_commit",
+    ]
+    old_inst.enter_in_error.assert_called_once_with()
+    new_inst.originate.assert_called_once()
+    new_inst.commit.assert_called_once()
+    # Direct-edit shortcut MUST NOT be used.
+    old_inst.edit.assert_not_called()
+    new_inst.edit.assert_not_called()
+
+    assert len(attempted) == 1
+    assert attempted[0]["section_key"] == section_key
+    assert attempted[0]["command_type"] == command_type
+    assert attempted[0]["mode"] == "void_recreate"
+    assert attempted[0]["old_command_uuid"] == "old-uuid-aaaa-bbbb-cccccccccccc"
+    assert attempted[0]["new_command_uuid"] == minted
+
+
+def test_imaging_results_routes_through_custom_command_bucket() -> None:
+    """imaging_results is the newly-added CustomCommand-routed section.
+
+    Parser builds a ``CustomCommand(schema_key='imageResult')`` instance, so
+    .commit() would raise ValueError. Amend route emits EIE+Originate only.
+    """
+    minted = "fresh-img-uuid-1111-2222-3333-444444444444"
+    proposals: list[dict[str, Any]] = [
+        {
+            "command_type": "imaging_results",
+            "command_uuid": "old-img-uuid-aaaa-bbbb-cccccccccccc",
+            "section_key": "imaging_results",
+            "data": {"narrative": "Chest X-ray unremarkable"},
+            "display": "Chest X-ray unremarkable",
+        },
+    ]
+    with (
+        patch("hyperscribe.scribe.commands.builder.uuid.uuid4", return_value=minted),
+    ):
+        effects, attempted = build_amend_edit_effects(proposals, "5899e7bf-5ecb-4399-aceb-0e233bd4a8f0")
+
+    # CustomCommand path: real EIE + Originate emitted; no .commit() (would raise).
+    assert len(effects) == 2
+    assert EffectType.Name(effects[0].type) == "ENTER_IN_ERROR_CUSTOM_COMMAND_COMMAND"
+    assert EffectType.Name(effects[1].type) == "ORIGINATE_CUSTOM_COMMAND_COMMAND"
+
+    assert len(attempted) == 1
+    assert attempted[0]["section_key"] == "imaging_results"
+    assert attempted[0]["command_type"] == "imaging_results"
+    assert attempted[0]["mode"] == "void_recreate_custom"
+    assert attempted[0]["old_command_uuid"] == "old-img-uuid-aaaa-bbbb-cccccccccccc"
+    assert attempted[0]["new_command_uuid"] == minted
+
+
+@pytest.mark.parametrize(
+    "section_key,command_type",
+    [
+        # Orders: clinical workflow side effects (pharmacy dispatch, lab tickets,
+        # referral letters) make void+recreate unsafe. Explicitly excluded.
+        ("prescription", "prescribe"),
+        ("_recommended", "prescribe"),
+        ("_recommended", "refill"),
+        ("_recommended", "adjust_prescription"),
+        ("_recommended", "refer"),
+        ("_recommended", "imaging_order"),
+        ("_recommended", "lab_order"),
+        ("_ad_hoc", "prescribe"),
+        # Questionnaire: insert flow is originate+edit+commit (the edit applies
+        # responses). Amendment would need a 4-effect EIE+Originate+Edit+Commit
+        # bucket that does not exist yet; deferred to a follow-up ticket.
+        ("_subjective_ad_hoc", "questionnaire"),
+        # Recommended bucket: recommendations get accepted and inserted, not
+        # amended directly. Anything landing here at amend time is a
+        # stale/hand-crafted payload.
+        ("_recommended", "medication_statement"),
+        ("_recommended", "allergy"),
+        ("_recommended", "task"),
+    ],
+)
+def test_build_amend_edit_effects_section_remains_locked(section_key: str, command_type: str) -> None:
+    """Sections outside the editable allowlist stay locked.
+
+    Covers two categories: (a) clinical orders whose downstream workflow
+    side-effects make void+recreate unsafe, (b) command types deferred for
+    structural reasons (questionnaire's 4-effect amend route), (c) the
+    ``_recommended`` pseudo-section that recommendations carry before
+    acceptance/insertion.
+    """
+    proposals: list[dict[str, Any]] = [
+        {
+            "command_type": command_type,
+            "command_uuid": "some-uuid",
+            "section_key": section_key,
+            "data": {},
+            "display": "x",
+        },
+    ]
+    effects, attempted = build_amend_edit_effects(proposals, "5899e7bf-5ecb-4399-aceb-0e233bd4a8f0")
+    assert effects == []
+    assert attempted == []
+
+
+@pytest.mark.parametrize(
+    "command_type,section_key",
+    [
+        ("prescribe", "_ad_hoc"),
+        ("refill", "_recommended"),
+        ("adjust_prescription", "_recommended"),
+        ("refer", "_recommended"),
+        ("imaging_order", "_recommended"),
+        ("lab_order", "_recommended"),
+    ],
+)
+def test_orders_remain_locked_and_return_section_not_editable(command_type: str, section_key: str) -> None:
+    """Pin: clinical orders (prescribe/refill/adjust_prescription/refer/
+    imaging_order/lab_order) must NEVER be amendable, regardless of which
+    section_key they land on.
+
+    Orders trigger external action: pharmacy dispatch (prescribe family),
+    specialist referral letters (refer), imaging-center scheduling
+    (imaging_order), and lab-partner tickets (lab_order). Void+recreate in
+    those flows would either re-fire external dispatch (if home-app is too
+    permissive about replays) or strand the original in a half-cancelled
+    state (if home-app rejects the EIE). The user product call: keep them
+    locked and surface a separate "amend an order" workflow if needed.
+    """
+    proposals: list[dict[str, Any]] = [
+        {
+            "command_type": command_type,
+            "command_uuid": "some-order-uuid",
+            "section_key": section_key,
+            "data": {},
+            "display": "x",
+        },
+    ]
+    effects, attempted = build_amend_edit_effects(proposals, "5899e7bf-5ecb-4399-aceb-0e233bd4a8f0")
+    assert effects == []
+    assert attempted == []
+
+
+def test_build_amend_edit_effects_skips_missing_command_uuid() -> None:
+    """Without an existing command_uuid we cannot target a row to edit/void.
+
+    Dropping the proposal beats inventing a uuid and inserting a fresh
+    command - that would re-introduce the double-insertion bug the
+    amendment flow was specifically built to prevent.
+    """
+    proposals: list[dict[str, Any]] = [
+        {
+            "command_type": "rfv",
+            "section_key": "chief_complaint",
+            "data": {"comment": "no uuid here"},
+            "display": "x",
+        },
+    ]
+    effects, attempted = build_amend_edit_effects(proposals, "5899e7bf-5ecb-4399-aceb-0e233bd4a8f0")
+    assert effects == []
+    assert attempted == []
+
+
+def test_build_amend_edit_effects_empty_list() -> None:
+    effects, attempted = build_amend_edit_effects([], "note-uuid")
+    assert effects == []
+    assert attempted == []
+
+
+def test_editable_amend_sections_contains_expected_keys() -> None:
+    """Pin the editable allowlist so accidental shrinks/expansions trip CI.
+
+    Covers every ``_BUILDERS`` command_type except orders (prescribe, refill,
+    adjust_prescription, refer, imaging_order, lab_order) and questionnaires
+    (deferred: needs a 4-effect amend route).
+    """
+    assert EDITABLE_AMEND_SECTIONS == frozenset(
+        {
+            # DIRECT_EDIT
+            "chief_complaint",
+            # CUSTOM_COMMAND_ROUTED
+            "_ros",
+            "_history_review",
+            "_chart_review",
+            "physical_exam",
+            "lab_results",
+            "imaging_results",
+            # VOID_RECREATE - SOAP-section-anchored
+            "history_of_present_illness",
+            "current_medications",
+            "allergies",
+            "vitals",
+            "past_medical_history",
+            "past_surgical_history",
+            "family_history",
+            "assessment_and_plan",
+            "plan",
+            # VOID_RECREATE - ad-hoc buckets
+            "_ad_hoc",
+            "_objective_ad_hoc",
+            "_history_ad_hoc",
+            "_charges_ad_hoc",
+        }
+    )
+
+
+def test_every_builders_command_type_is_either_editable_or_explicitly_excluded() -> None:
+    """Structural pin: every command_type in ``_BUILDERS`` must be accounted
+    for at amendment time - either by appearing in at least one section_key
+    that's amendable for that command_type, or by being explicitly listed in
+    ``NON_EDITABLE_AMEND_COMMAND_TYPES``.
+
+    This is the user's acceptance criterion: "every command in `_BUILDERS`
+    is EITHER in the allowlist (correctly bucketed) OR explicitly excluded
+    with rationale."
+
+    Adding a new parser to ``_BUILDERS`` without a routing decision will
+    fail this test, forcing the author to either (a) add it to the denylist
+    with a clear "why this can't be amended" rationale, or (b) confirm it
+    has a path through one of the amendable section_keys.
+    """
+    # Command types that can legitimately reach amendment via some section_key.
+    # This list is the structural inverse of NON_EDITABLE_AMEND_COMMAND_TYPES.
+    expected_editable_command_types = {
+        "rfv",
+        "hpi",
+        "ros",
+        "physical_exam",
+        "history_review",
+        "chart_review",
+        "lab_results",
+        "imaging_results",
+        "medication_statement",
+        "vitals",
+        "allergy",
+        "stop_medication",
+        "remove_allergy",
+        "medicalHistory",
+        "surgicalHistory",
+        "familyHistory",
+        "plan",
+        "diagnose",
+        "assess",
+        "resolve_condition",
+        "task",
+        "perform",
+    }
+    all_builders = set(_BUILDERS.keys())
+    accounted_for = expected_editable_command_types | set(NON_EDITABLE_AMEND_COMMAND_TYPES)
+    missing = all_builders - accounted_for
+    assert not missing, (
+        f"command_types in _BUILDERS are unaccounted for at amendment time: {missing}. "
+        f"Add each to either the routing classification (allow amend) or to "
+        f"NON_EDITABLE_AMEND_COMMAND_TYPES (deny amend, with rationale)."
+    )
+    extras = accounted_for - all_builders
+    assert not extras, (
+        f"command_types listed as editable/excluded that are not in _BUILDERS: {extras}. "
+        f"Drop them from the routing classification."
+    )
+
+
+def test_non_editable_amend_command_types_contains_orders_and_questionnaire() -> None:
+    """Pin the command-type denylist so accidentally dropping an order from
+    it (which would re-fire pharmacy/lab/imaging-center dispatch on amend)
+    or adding a non-order to it (silently breaking that feature) trips CI.
+
+    Orders trigger external action; questionnaire needs a 4-effect amend
+    route deferred to a follow-up ticket.
+    """
+    assert NON_EDITABLE_AMEND_COMMAND_TYPES == frozenset(
+        {
+            # Orders
+            "prescribe",
+            "refill",
+            "adjust_prescription",
+            "refer",
+            "imaging_order",
+            "lab_order",
+            # Deferred
+            "questionnaire",
+        }
+    )
+
+
+def test_direct_edit_sections_only_contains_chief_complaint() -> None:
+    """Pin the direct-edit set. Only chief_complaint (RFV) belongs here
+    because RFV is the only section whose home-app interpreter handles
+    EDIT but NOT ENTER_IN_ERROR. Adding any other section here would emit
+    EDIT effects on a committed command, which EditCommandEffectInterpreter
+    rejects with `Command must be staged in order to be edited.`"""
+    assert DIRECT_EDIT_SECTIONS == frozenset({"chief_complaint"})
+
+
+def test_custom_command_routed_sections_literal_pin() -> None:
+    """Literal pin on the CustomCommand-routed set; the structural check is manual.
+
+    These section_keys MUST match exactly the parsers whose ``build()`` returns
+    a ``CustomCommand`` instance. A true introspection test would synthesize
+    each parser's ``build(data, ...)`` and ``isinstance(..., CustomCommand)``
+    against the actual return value - but there is no production
+    ``section_key -> command_type`` mapping (the frontend ships both fields
+    side-by-side), each parser's ``build`` takes parser-specific data shapes
+    (HPI: ``{narrative}``, ROS: ``{sections}``, etc.), and some parsers call
+    ``render_to_string`` at build time which would need mocking. Synthesizing
+    that across 6+ parsers is its own moving target and would re-introduce
+    the same single-sourcing problem this is meant to detect.
+
+    Mismatch means either (a) a CustomCommand section is missing from the set
+    and will crash with ValueError when build_amend_edit_effects emits
+    ``.commit()``, or (b) a dedicated-SDK-class section is wrongly in the set
+    and will silently skip its needed commit effect (home-app would never
+    finalize the row). Reviewers: when adding to EDITABLE_AMEND_SECTIONS,
+    cross-check the parser's ``build()`` return type and update this set
+    accordingly.
+    """
+    assert CUSTOM_COMMAND_ROUTED_SECTIONS == frozenset(
+        {
+            "_ros",
+            "_history_review",
+            "_chart_review",
+            "physical_exam",
+            "lab_results",
+            "imaging_results",
+        }
+    )
+
+
+def test_custom_command_commit_raises_value_error_in_sdk() -> None:
+    """SDK contract: ``CustomCommand.commit()`` raises ``ValueError`` because
+    ``COMMIT_CUSTOM_COMMAND_COMMAND`` is not declared in the protobuf enum.
+
+    This is the load-bearing reason the amend path for CustomCommand-routed
+    sections (ros, physical_exam, chart_review, history_review, lab_results)
+    skips the explicit commit effect. If a future SDK release adds the enum
+    and changes this behavior, this test will fail loudly so build_amend_edit_effects
+    can be revisited.
+
+    No mocks: this asserts the real SDK behavior against the installed canvas
+    package.
+    """
+    cmd = CustomCommand(
+        schema_key="reviewOfSystems",
+        content="dummy",
+        note_uuid="5899e7bf-5ecb-4399-aceb-0e233bd4a8f0",
+        command_uuid="a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+    )
+    # Originate works (the enum is defined).
+    originate_effect = cmd.originate()
+    assert EffectType.Name(originate_effect.type) == "ORIGINATE_CUSTOM_COMMAND_COMMAND"
+    # EnterInError works (the enum is defined as of canvas>=0.155).
+    eie_effect = cmd.enter_in_error()
+    assert EffectType.Name(eie_effect.type) == "ENTER_IN_ERROR_CUSTOM_COMMAND_COMMAND"
+    # Commit raises - this is the contract we depend on.
+    with pytest.raises(ValueError, match=r'unknown enum label "COMMIT_CUSTOM_COMMAND_COMMAND"'):
+        cmd.commit()
+    # Edit also raises (same reason). Confirms why CustomCommand sections
+    # can never use the DIRECT_EDIT path.
+    with pytest.raises(ValueError, match=r'unknown enum label "EDIT_CUSTOM_COMMAND_COMMAND"'):
+        cmd.edit()
+
+
+def test_custom_command_amend_emits_eie_and_originate_only_no_commit() -> None:
+    """Empirical: amending a CustomCommand-routed section (here: ros) emits
+    EnterInError(old) + Originate(new) and stops there. No .commit() call -
+    that would raise ValueError. Uses the real CustomCommand class, not a mock,
+    to pin the integration with the SDK.
+    """
+    proposals: list[dict[str, Any]] = [
+        {
+            "command_type": "ros",
+            "command_uuid": "old-ros-uuid-aaaa-bbbb-cccccccccccc",
+            "section_key": "_ros",
+            "data": {"sections": [{"key": "general", "title": "General", "text": "WNL"}]},
+            "display": "ROS updated",
+        },
+    ]
+    minted = "fresh-ros-uuid-1111-2222-3333-444444444444"
+    with (
+        patch("hyperscribe.scribe.commands.ros.render_to_string", return_value="<p>WNL</p>"),
+        patch("hyperscribe.scribe.commands.builder.uuid.uuid4", return_value=minted),
+    ):
+        effects, attempted = build_amend_edit_effects(proposals, "5899e7bf-5ecb-4399-aceb-0e233bd4a8f0")
+
+    # Two effects only: EIE on the old row, Originate of the new row.
+    assert len(effects) == 2
+    assert EffectType.Name(effects[0].type) == "ENTER_IN_ERROR_CUSTOM_COMMAND_COMMAND"
+    assert EffectType.Name(effects[1].type) == "ORIGINATE_CUSTOM_COMMAND_COMMAND"
+
+    assert len(attempted) == 1
+    assert attempted[0]["section_key"] == "_ros"
+    assert attempted[0]["mode"] == "void_recreate_custom"
+    assert attempted[0]["old_command_uuid"] == "old-ros-uuid-aaaa-bbbb-cccccccccccc"
+    assert attempted[0]["new_command_uuid"] == minted
+
+
+def test_build_amend_edit_effects_double_edit_same_row_uses_new_uuid() -> None:
+    """In-session re-edit: provider amends HPI twice before saving. The
+    second edit must target the new uuid produced by the first amend's
+    re-stamp, not the original (now entered-in-error) uuid.
+
+    This test simulates what the frontend does: after the first amend,
+    `commands[i].command_uuid` is swapped from old -> new, and a second
+    amend re-submits with the new uuid as `command_uuid`. We assert
+    build_amend_edit_effects treats that as a fresh proposal and emits
+    EIE(new) + Originate(newer) - i.e., it doesn't somehow remember the
+    original uuid (which would emit an EIE on an already-voided row).
+    """
+    minted_first = "fresh-hpi-uuid-1111-2222-3333-444444444444"
+    minted_second = "fresher-hpi-uuid-aaaa-bbbb-cccccccccccc"
+
+    proposals_first: list[dict[str, Any]] = [
+        {
+            "command_type": "hpi",
+            "command_uuid": "original-hpi-uuid-1234-5678-90ab-cdef",
+            "section_key": "history_of_present_illness",
+            "data": {"narrative": "First edit"},
+            "display": "First edit",
+        },
+    ]
+    with (
+        patch("hyperscribe.scribe.commands.hpi.HistoryOfPresentIllnessCommand") as mock_hpi,
+        patch("hyperscribe.scribe.commands.builder.uuid.uuid4", return_value=minted_first),
+    ):
+        old_inst, new_inst = MagicMock(), MagicMock()
+        old_inst.enter_in_error.return_value = "hpi_eie_1"
+        new_inst.originate.return_value = "hpi_originate_1"
+        new_inst.commit.return_value = "hpi_commit_1"
+        mock_hpi.side_effect = [old_inst, new_inst]
+        effects_1, attempted_1 = build_amend_edit_effects(proposals_first, "5899e7bf-5ecb-4399-aceb-0e233bd4a8f0")
+    assert attempted_1[0]["old_command_uuid"] == "original-hpi-uuid-1234-5678-90ab-cdef"
+    assert attempted_1[0]["new_command_uuid"] == minted_first
+
+    # Frontend re-stamp: the second proposal carries the uuid from the first attempt.
+    proposals_second: list[dict[str, Any]] = [
+        {
+            "command_type": "hpi",
+            "command_uuid": minted_first,  # the new uuid from amend #1
+            "section_key": "history_of_present_illness",
+            "data": {"narrative": "Second edit"},
+            "display": "Second edit",
+        },
+    ]
+    with (
+        patch("hyperscribe.scribe.commands.hpi.HistoryOfPresentIllnessCommand") as mock_hpi,
+        patch("hyperscribe.scribe.commands.builder.uuid.uuid4", return_value=minted_second),
+    ):
+        old_inst2, new_inst2 = MagicMock(), MagicMock()
+        old_inst2.enter_in_error.return_value = "hpi_eie_2"
+        new_inst2.originate.return_value = "hpi_originate_2"
+        new_inst2.commit.return_value = "hpi_commit_2"
+        mock_hpi.side_effect = [old_inst2, new_inst2]
+        effects_2, attempted_2 = build_amend_edit_effects(proposals_second, "5899e7bf-5ecb-4399-aceb-0e233bd4a8f0")
+    # Second amend's EIE must target minted_first (NOT the original uuid).
+    # We verify via the constructor args.
+    construction_calls = mock_hpi.call_args_list
+    assert len(construction_calls) == 2
+    assert construction_calls[0].kwargs.get("command_uuid") == minted_first, (
+        "Second amend must EIE the FIRST amend's new uuid, not the original. "
+        "Otherwise the second EIE lands on an already-voided row."
+    )
+    assert construction_calls[1].kwargs.get("command_uuid") == minted_second
+    assert attempted_2[0]["old_command_uuid"] == minted_first
+    assert attempted_2[0]["new_command_uuid"] == minted_second

--- a/uv.lock
+++ b/uv.lock
@@ -87,7 +87,7 @@ wheels = [
 
 [[package]]
 name = "canvas"
-version = "0.127.0"
+version = "0.155.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cookiecutter" },
@@ -123,9 +123,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "websocket-client" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ab/b4/f85ae513ab5974844dc847292bad47a8292456ac438797d57a8dd5ec9e2a/canvas-0.127.0.tar.gz", hash = "sha256:dc8f2db4cd39756bfa1f2cfbfdb018efadcec8c22c67a84cb3b2ae12f588b4f9", size = 2366735, upload-time = "2026-03-31T13:45:56.996Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/79/43/afb7367f72a0aeda76ff033f27c78dbe38e5a17908fe0435beefcca67474/canvas-0.155.0.tar.gz", hash = "sha256:fe657702400bb4ceea689679e5d5d4a71d5be9f7989d3a37eee93408a0168413", size = 2392460, upload-time = "2026-05-21T10:16:28.461Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a6/be/a40ccc906f9669914a76d6a785d69cfd5dec97713df4fefe4fd76b9dd721/canvas-0.127.0-py3-none-any.whl", hash = "sha256:af2ca93d0118f51b303a41d92f37634faf95bfa341c00c73a3b428438f8ab1d6", size = 2658768, upload-time = "2026-03-31T13:45:55.068Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/f1/39164185f9fd3f0559cc5d4d398ef906c052f83ec9a592d983d2dd50a06e/canvas-0.155.0-py3-none-any.whl", hash = "sha256:2debd7b29006b27bee7edf94e9b15c02490818c19417a56c049ad6ae4511b3f8", size = 2696570, upload-time = "2026-05-21T10:16:26.647Z" },
 ]
 
 [package.optional-dependencies]
@@ -625,8 +625,8 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "canvas", specifier = ">=0.58.1" },
-    { name = "canvas", extras = ["test-utils"], specifier = ">=0.58.1" },
+    { name = "canvas", specifier = ">=0.155.0" },
+    { name = "canvas", extras = ["test-utils"], specifier = ">=0.155.0" },
     { name = "ffmpeg-python", specifier = ">=0.2.0" },
     { name = "mypy", specifier = ">=1.15.0" },
 ]


### PR DESCRIPTION
[KOALA-5485](https://canvasmedical.atlassian.net/browse/KOALA-5485)

Currently in scribe amendment mode ("Make changes" on a signed note), providers can ADD new commands but cannot EDIT existing ones across most sections (chief complaint, HPI, ROS, history, PE, lab results, vitals, allergies, diagnoses, plan, and more). This change enables editing for every amendable command type except orders (lab_order/imaging_order/prescribe/refill/adjust_prescription/refer) and questionnaire (deferred — needs a 4-effect amend route).

## Implementation

Three routing buckets, determined by SDK class + home-app interpreter wiring:

- **DIRECT_EDIT** (chief_complaint/RFV): row stays staged in home-app; regular `command.edit()` works in place.
- **CustomCommand-routed** (ROS, PE, chart_review, history_review, lab_results, imaging_results): emit `EnterInError + Originate` only. The proto enum lacks `COMMIT_CUSTOM_COMMAND_COMMAND`; home-app's `OriginateCustomCommand` interpreter auto-commits.
- **Void+recreate** (HPI, medication_statement, vitals, allergy, history, plan, diagnose, assess, etc.): emit `EnterInError(old) + Originate(new) + Commit(new)`. Frontend re-stamps the new UUID into local state immediately after the amend POST returns.

A structural `NON_EDITABLE_AMEND_COMMAND_TYPES` denylist gates orders and questionnaire independently of section_key, so command types living in shared ad-hoc sections cannot ride through.

Cross-tab state check returns HTTP 409 with a per-row conflicts payload when a stale tab submits against an already-amended row; frontend shows a reload prompt. Plugin-side `transaction.atomic()` was attempted but is structurally infeasible (sandbox import restrictions, Postgres FOR UPDATE on view-with-outer-joins, plugin/home-app effect-bus boundary); residual race produces a visible duplicate Originate — closing it requires home-app Originate idempotency, tracked as follow-up.

SDK bumped `canvas` 0.127.0 → 0.155.0 (required for `ENTER_IN_ERROR_CUSTOM_COMMAND_COMMAND` proto enum) — see the first commit.

[KOALA-5485]: https://canvasmedical.atlassian.net/browse/KOALA-5485?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ