### PR TITLE
feat: add background carry-forward to Assess Condition

### DIFF
--- a/hyperscribe/scribe/api/session_view.py
+++ b/hyperscribe/scribe/api/session_view.py
@@ -52,8 +52,11 @@ from hyperscribe.scribe.commands.builder import (
     annotate_duplicates,
     build_effects,
     build_metadata_effects,
+    prefill_assess_backgrounds,
+    prefill_assess_backgrounds_for_proposals,
     validate_proposals,
 )
+from hyperscribe.scribe.commands.carry_forward import carry_forward_assess_background
 from hyperscribe.scribe.commands.extractor import extract_commands, parse_ros_subsections
 from hyperscribe.scribe.recommendations import recommend_commands
 from hyperscribe.scribe.recommendations.diagnosis_suggestion import suggest_diagnoses
@@ -747,6 +750,7 @@ class ScribeSessionView(StaffSessionAuthMixin, SimpleAPI):
         note_uuid = str(data.get("note_uuid", ""))
         proposals = extract_commands(note)
         annotate_duplicates(proposals, note_uuid)
+        prefill_assess_backgrounds_for_proposals(proposals, note_uuid)
         commands_list: list[dict[str, Any]] = [
             {
                 "command_type": p.command_type,
@@ -860,6 +864,7 @@ class ScribeSessionView(StaffSessionAuthMixin, SimpleAPI):
                 zip_codes = resolve_zip_codes(patient_id, note_id) or None
                 rec_proposals = recommend_commands(note, api_key, zip_codes=zip_codes, transcript=transcript)
                 annotate_duplicates(rec_proposals, note_uuid)
+                prefill_assess_backgrounds_for_proposals(rec_proposals, note_uuid)
                 recommendations_list = [
                     {
                         "command_type": p.command_type,
@@ -1030,6 +1035,7 @@ class ScribeSessionView(StaffSessionAuthMixin, SimpleAPI):
         proposals = extract_commands(note)
         note_uuid = str(data.get("note_uuid", ""))
         annotate_duplicates(proposals, note_uuid)
+        prefill_assess_backgrounds_for_proposals(proposals, note_uuid)
         return [
             JSONResponse(
                 {
@@ -1081,6 +1087,7 @@ class ScribeSessionView(StaffSessionAuthMixin, SimpleAPI):
             ]
         note_uuid = str(data.get("note_uuid", ""))
         annotate_duplicates(proposals, note_uuid)
+        prefill_assess_backgrounds_for_proposals(proposals, note_uuid)
         return [
             JSONResponse(
                 {
@@ -1178,6 +1185,11 @@ class ScribeSessionView(StaffSessionAuthMixin, SimpleAPI):
                 )
             ]
         feature_flags = {"AlertFacilityEnabled": bool(self.secrets.get("AlertFacilityEnabled"))}
+        # Carry-forward assess backgrounds from prior signed notes BEFORE building
+        # effects, so the SDK command constructor sees the prefilled value. This
+        # mirrors the symmetric placement of ``annotate_duplicates`` (called by
+        # the same callers, parallel to the build/validate pipeline).
+        prefill_assess_backgrounds(commands, note_uuid)
         effects, metadata_pending, attempted, build_errors = build_effects(commands, note_uuid, feature_flags)
         if build_errors:
             audit_event(
@@ -1219,6 +1231,51 @@ class ScribeSessionView(StaffSessionAuthMixin, SimpleAPI):
             ),
             *effects,
         ]
+
+    @api.post("/carry-forward-background")
+    def post_carry_forward_background(self) -> list[Union[Response, Effect]]:
+        """Return the carried-forward ``background`` for one (note, condition).
+
+        Why this exists as its own endpoint (vs. relying on the /insert-commands
+        belt that already prefills): the user needs to SEE the carried value in
+        the assess command's edit drawer BEFORE clicking Approve. The
+        /insert-commands belt fires server-side at approval time, so it never
+        reaches the UI. This endpoint lets the frontend pull the value when the
+        provider creates an assess command client-side (handleAddCondition).
+
+        Read-only — no audit event, no PHI logged. The auth gate matches every
+        other mutating-shaped endpoint in this view because a leak would expose
+        ``has prior assessment for this condition``-shaped metadata about
+        another provider's patient.
+        """
+        try:
+            data: dict[str, Any] = json.loads(self.request.body)
+        except (json.JSONDecodeError, ValueError) as exc:
+            return [JSONResponse({"error": f"Invalid JSON: {exc}"}, status_code=HTTPStatus.BAD_REQUEST)]
+        note_uuid = str(data.get("note_uuid", ""))
+        if not note_uuid:
+            return [JSONResponse({"error": "note_uuid is required"}, status_code=HTTPStatus.BAD_REQUEST)]
+        condition_id = str(data.get("condition_id", "")).strip()
+        if not condition_id:
+            return [JSONResponse({"error": "condition_id is required"}, status_code=HTTPStatus.BAD_REQUEST)]
+        if denial := _authorize_edit(note_uuid, self.request):
+            return [denial]
+        try:
+            # ``ValueError`` covers a malformed UUID that slips past _authorize_edit
+            # (unlikely — auth's ``Note.objects.values().get(id=...)`` catches it
+            # first — but keep the defensive net so a future auth refactor doesn't
+            # turn this into a 500). Mirrors ``prefill_assess_backgrounds``.
+            note = Note.objects.select_related("patient").get(id=note_uuid)
+        except (Note.DoesNotExist, ValueError):
+            return [JSONResponse({"error": "Note not found"}, status_code=HTTPStatus.NOT_FOUND)]
+        # Reuse the same helper /insert-commands uses, so the carry-forward
+        # contract is single-sourced (changes to scoping rules land in one place).
+        # The helper mutates the dict in place when a prior is found and leaves
+        # it untouched otherwise — read the result via ``.get`` rather than
+        # branching on a separate return value.
+        scratch: dict[str, Any] = {"condition_id": condition_id}
+        carry_forward_assess_background(scratch, note)
+        return [JSONResponse({"background": scratch.get("background")}, status_code=HTTPStatus.OK)]
 
     @api.post("/insert-metadata")
     def post_insert_metadata(self) -> list[Union[Response, Effect]]:

--- a/hyperscribe/scribe/commands/builder.py
+++ b/hyperscribe/scribe/commands/builder.py
@@ -14,6 +14,7 @@ from hyperscribe.scribe.commands.adjust_prescription import AdjustPrescriptionPa
 from hyperscribe.scribe.commands.allergy import AllergyParser
 from hyperscribe.scribe.commands.assess import AssessParser
 from hyperscribe.scribe.commands.base import CommandParser
+from hyperscribe.scribe.commands.carry_forward import carry_forward_assess_background
 from hyperscribe.scribe.commands.chart_review import ChartReviewParser
 from hyperscribe.scribe.commands.diagnose import DiagnoseParser
 from hyperscribe.scribe.commands.family_history import FamilyHistoryParser
@@ -85,6 +86,74 @@ def annotate_duplicates(proposals: list[CommandProposal], note_uuid: str) -> Non
         return
     for builder in _BUILDERS.values():
         builder.annotate_duplicates(proposals, note)
+
+
+def prefill_assess_backgrounds(proposals: list[dict[str, Any]], note_uuid: str) -> None:
+    """Pre-fill ``background`` on assess proposals from the most recent prior
+    signed Assessment for the same (patient, condition).
+
+    Mutates ``proposals[i]["data"]["background"]`` in place. Skips silently
+    when the note can't be loaded, when no assess proposals are present, or
+    when the lookup fails — the carry-forward is a convenience, not a
+    correctness gate; a missing background just means the provider types it
+    fresh.
+
+    Called from ``session_view`` parallel to ``annotate_duplicates`` rather
+    than from inside ``build_effects`` so that the side-effect (mutating
+    ``proposals``) is visible at the same layer as the other proposal
+    transformations. See ``carry_forward_assess_background`` for the
+    per-(patient, condition) scoping rationale.
+    """
+    if not note_uuid:
+        return
+    assess_proposals = [p for p in proposals if p.get("command_type") == "assess"]
+    if not assess_proposals:
+        return
+    try:
+        # ``ValueError`` covers a malformed UUID passed as ``note_uuid`` (e.g.
+        # an LLM-injected non-uuid string). Django raises before reaching the
+        # SQL layer, and the carry-forward contract is best-effort — silently
+        # skip rather than propagate up into the request handler.
+        note = Note.objects.select_related("patient").get(id=note_uuid)
+    except (Note.DoesNotExist, ValueError):
+        return
+    for proposal in assess_proposals:
+        data = proposal.get("data")
+        if not isinstance(data, dict):
+            continue
+        carry_forward_assess_background(data, note)
+
+
+def prefill_assess_backgrounds_for_proposals(proposals: list[CommandProposal], note_uuid: str) -> None:
+    """``CommandProposal``-shaped variant of :func:`prefill_assess_backgrounds`.
+
+    Identical contract and side effect: mutates ``proposal.data["background"]``
+    in place for every assess proposal whose (patient, condition) has a prior
+    signed Assessment. Exists as a parallel callable because the upstream
+    callers in ``session_view`` (``/extract-commands``, ``/recommend-commands``,
+    ``post_generate_summary`` step 2, and the recommend branch within it) hold
+    ``list[CommandProposal]`` at the same point ``annotate_duplicates`` is
+    invoked. Hoisting the dict conversion just to call the dict-shaped helper
+    would break the symmetric placement (parallel to ``annotate_duplicates``)
+    the carry-forward design relies on.
+
+    Same defensive skips: empty ``note_uuid``, no assess proposals, note lookup
+    failure, malformed UUID.
+    """
+    if not note_uuid:
+        return
+    assess_proposals = [p for p in proposals if p.command_type == "assess"]
+    if not assess_proposals:
+        return
+    try:
+        note = Note.objects.select_related("patient").get(id=note_uuid)
+    except (Note.DoesNotExist, ValueError):
+        return
+    for proposal in assess_proposals:
+        # CommandProposal.data is typed dict[str, Any] (see backend/models.py),
+        # so we skip the isinstance guard that the dict-shaped sibling uses for
+        # defensive parsing of untrusted JSON.
+        carry_forward_assess_background(proposal.data, note)
 
 
 def validate_proposals(proposals: list[dict[str, Any]]) -> list[dict[str, Any]]:

--- a/hyperscribe/scribe/commands/carry_forward.py
+++ b/hyperscribe/scribe/commands/carry_forward.py
@@ -1,0 +1,112 @@
+"""Carry-forward helpers for Scribe command proposals.
+
+This module pre-fills fields on new command proposals using values from the
+patient's most recent prior signed note, scoped to a structural identifier
+(currently: assess.background scoped by condition).
+
+The provider can always edit/clear the carried value before signing; the saved
+value is whatever is in the field at sign time.
+
+Why this lives in the Scribe layer (not the canvas-core ``carry_forward``
+action): canvas-core's built-in carry-forward returns the most recent commands
+of the same schema_key for the same patient (regardless of which condition the
+assessment was for). For Assess Condition, the clinically useful behavior is
+per-(patient, condition): the *background* for hypertension follows the
+hypertension assessment over time, not whichever assess was authored most
+recently.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from canvas_sdk.v1.data.assessment import Assessment
+from canvas_sdk.v1.data.note import Note
+from logger import log
+
+
+def carry_forward_assess_background(
+    proposal_data: dict[str, Any],
+    note: Note,
+) -> None:
+    """Mutate ``proposal_data["background"]`` if a prior signed Assessment exists.
+
+    Behavior:
+    - Skips entirely if the proposal already has a non-empty ``background``
+      (the provider already typed something, or upstream logic already filled
+      it). Empty/None counts as "unset"; a literal empty string at this layer
+      is treated as not-yet-populated rather than "explicitly cleared" — at
+      proposal-build time we have no signal that distinguishes the two, and
+      the conservative choice is to favor carry-forward.
+    - Skips if ``condition_id`` is missing or empty (no condition to match against).
+    - Skips if ``note.patient`` is unset (defensive — should not happen in practice).
+    - Looks up the most recent prior committed, non-entered-in-error
+      ``Assessment`` for the same (patient, condition). The committed gate
+      (``committer`` set, no ``entered_in_error``) is sufficient to scope to
+      finalized assessments — we previously also filtered on
+      ``note.current_state.state == SIGNED`` but that excluded prior notes
+      that progressed past SIGNED into LOCKED / RELOCKED / etc. The current
+      note is excluded by uuid.
+    - If found, sets ``proposal_data["background"]`` to the prior value
+      (``""`` if the prior background was empty). The provider can still
+      edit/clear before insert.
+
+    Why a single helper (not a class hook on the parser): the carry-forward
+    needs the ``Note`` and patient context, which the parser doesn't have. The
+    helper is invoked from ``session_view`` via ``prefill_assess_backgrounds``,
+    parallel to ``annotate_duplicates`` — both are proposal transformations the
+    endpoint runs before ``build_effects``.
+
+    Why per-(patient, condition) here rather than reusing canvas-core's
+    carry-forward action: canvas-core scopes carry-forward by (patient,
+    schema_key) and would surface whichever assess was authored most recently,
+    regardless of which condition it documented. Assess Condition is the only
+    command where per-condition scoping is clinically meaningful today; if a
+    future command needs per-(patient, X) scoping with a different ``X``,
+    generalize this helper to take the scoping field as a parameter instead of
+    copying the body.
+    """
+    if proposal_data.get("background"):
+        # Provider already populated this field; preserve their input.
+        return
+
+    condition_id = proposal_data.get("condition_id")
+    if not condition_id:
+        # No structural identifier — can't scope carry-forward.
+        return
+
+    patient = note.patient
+    if patient is None:
+        return
+
+    try:
+        # The carry-forward is best-effort: an ORM error (transient connection
+        # blip, schema drift, etc.) must NOT kill the calling endpoint. The
+        # docstring promises "missing background just means the provider types
+        # it fresh"; honor that by swallowing the error and bailing.
+        # ``note.id`` is internal-only and PHI-safe; do NOT log ``condition_id``,
+        # ``background``, patient identifiers, or any other clinical content.
+        prior = (
+            Assessment.objects.filter(
+                patient=patient,
+                condition__id=condition_id,
+                committer_id__isnull=False,
+                entered_in_error_id__isnull=True,
+            )
+            .exclude(note__id=str(note.id))
+            .order_by("-note__datetime_of_service", "-modified")
+            .values_list("background", flat=True)
+            .first()
+        )
+    except Exception:
+        log.exception("carry-forward assess background query failed for note %s", note.id)
+        return
+
+    if prior is None:
+        # No prior signed assessment for this (patient, condition).
+        return
+
+    # ``prior`` is the carried background. An empty string is still a valid
+    # carry-forward value (the provider may have explicitly cleared it last
+    # time), so we propagate ``""`` rather than skipping.
+    proposal_data["background"] = prior

--- a/hyperscribe/scribe/static/soap-group.js
+++ b/hyperscribe/scribe/static/soap-group.js
@@ -382,27 +382,54 @@ function AssessNarrative({ command, commandIndex, onEdit, readOnly, onEditingCha
     return () => onEditingChange?.(commandIndex, false);
   }, [editing, commandIndex]);
   const [narrative, setNarrative] = useState(data.narrative || '');
-  const textareaRef = useRef(null);
+  const [background, setBackground] = useState(data.background || '');
+  const backgroundRef = useRef(null);
+  const narrativeRef = useRef(null);
+
+  // Sync local state when ``data`` changes from outside (e.g. carry-forward
+  // fetch returning AFTER first render of this row). useState initializes
+  // only once at mount, so without this effect a provider opening the edit
+  // view before the fetch lands sees an empty textarea. We only sync when
+  // not editing, so an in-progress edit isn't clobbered by a late prop change.
+  useEffect(() => {
+    if (!editing) {
+      setNarrative(data.narrative || '');
+      setBackground(data.background || '');
+    }
+  }, [data.narrative, data.background, editing]);
 
   useEffect(() => {
-    if (editing && textareaRef.current) textareaRef.current.focus({ preventScroll: true });
+    if (editing && narrativeRef.current) narrativeRef.current.focus({ preventScroll: true });
   }, [editing]);
 
   const handleSave = () => {
-    onEdit(commandIndex, { ...data, narrative }, 'assess');
+    onEdit(commandIndex, { ...data, narrative, background }, 'assess');
     setEditing(false);
   };
 
   const handleCancel = () => {
     setNarrative(data.narrative || '');
+    setBackground(data.background || '');
     setEditing(false);
   };
 
   if (editing && !readOnly) {
+    const saveDisabled = narrative.length > 2048 || background.length > 2048;
     return html`
       <div class="diagnose-edit-area editing">
+        <div class="diagnose-body-label">Background</div>
         <textarea
-          ref=${textareaRef}
+          ref=${backgroundRef}
+          class="command-row-textarea"
+          maxLength=${2048}
+          value=${background}
+          onInput=${(e) => setBackground(e.target.value)}
+          onKeyDown=${(e) => e.key === 'Escape' && handleCancel()}
+        />
+        <div class="char-counter${background.length > 1900 ? background.length > 2048 ? ' over-limit' : ' near-limit' : ''}">${background.length} / 2048</div>
+        <div class="diagnose-body-label">Today's assessment</div>
+        <textarea
+          ref=${narrativeRef}
           class="command-row-textarea"
           maxLength=${2048}
           value=${narrative}
@@ -412,23 +439,38 @@ function AssessNarrative({ command, commandIndex, onEdit, readOnly, onEditingCha
         <div class="char-counter${narrative.length > 1900 ? narrative.length > 2048 ? ' over-limit' : ' near-limit' : ''}">${narrative.length} / 2048</div>
         <div class="command-row-actions">
           <button type="button" class="form-btn form-btn-cancel" onClick=${handleCancel}>Cancel</button>
-          <button type="button" class="form-btn form-btn-save" disabled=${narrative.length > 2048} onClick=${handleSave}>Save</button>
+          <button type="button" class="form-btn form-btn-save" disabled=${saveDisabled} onClick=${handleSave}>Save</button>
         </div>
       </div>
     `;
   }
 
-  const overLimit = (data.narrative || '').length > 2048;
+  const narrativeText = data.narrative || '';
+  const backgroundText = data.background || '';
+  const hasBackground = backgroundText.length > 0;
+  const hasNarrative = narrativeText.length > 0;
+  const narrativeOverLimit = narrativeText.length > 2048;
+  const backgroundOverLimit = backgroundText.length > 2048;
   return html`
     <div
       class="diagnose-row-body${readOnly ? '' : ' editable'}"
       onClick=${() => !readOnly && setEditing(true)}
     >
-      ${data.narrative
-        ? (data.narrative).split('\n').map((line, i) => html`<div key=${i} class="diagnose-body-line">${line}</div>`)
-        : html`<div class="diagnose-body-empty">No assessment text</div>`
+      ${!hasBackground && !hasNarrative
+        ? html`<div class="diagnose-body-empty">No assessment text</div>`
+        : html`
+          ${hasBackground && html`
+            <div class="diagnose-body-label">Background</div>
+            ${backgroundText.split('\n').map((line, i) => html`<div key=${'b' + i} class="diagnose-body-line">${line}</div>`)}
+            ${backgroundOverLimit && html`<div class="char-counter over-limit">${backgroundText.length} / 2048 — text must be shortened before approving</div>`}
+          `}
+          ${hasNarrative && html`
+            <div class="diagnose-body-label">Today's assessment</div>
+            ${narrativeText.split('\n').map((line, i) => html`<div key=${'n' + i} class="diagnose-body-line">${line}</div>`)}
+            ${narrativeOverLimit && html`<div class="char-counter over-limit">${narrativeText.length} / 2048 — text must be shortened before approving</div>`}
+          `}
+        `
       }
-      ${overLimit && html`<div class="char-counter over-limit">${data.narrative.length} / 2048 — text must be shortened before approving</div>`}
     </div>
   `;
 }

--- a/hyperscribe/scribe/static/styles.css
+++ b/hyperscribe/scribe/static/styles.css
@@ -977,6 +977,8 @@ h2 { margin-bottom: 4px; }
 .diagnose-row-body.editable:hover { background: #f0f0f0; }
 .diagnose-body-line { min-height: 1.4em; }
 .diagnose-body-empty { color: #aaa; font-style: italic; }
+.diagnose-body-label { font-size: 11px; font-weight: 600; color: #6b7280; text-transform: uppercase; letter-spacing: 0.5px; margin-top: 6px; }
+.diagnose-body-label:first-child { margin-top: 0; }
 .diagnose-edit-area { display: flex; flex-direction: column; align-items: flex-start; gap: 12px; margin-top: 4px; }
 .diagnose-edit-area .command-row-textarea { width: 100%; }
 .diagnose-edit-area .command-row-actions { align-self: flex-end; }

--- a/hyperscribe/scribe/static/summary.js
+++ b/hyperscribe/scribe/static/summary.js
@@ -1139,7 +1139,32 @@ export function Scribe({ noteId, patientId, staffId, staffName, providerName, pr
     if (icd10Code) {
       setUnmatchedConditions(prev => prev.filter(c => !(c.coding || []).some(cd => cd.code === icd10Code)));
     }
-  }, [canEdit, commands]);
+
+    // Carry-forward the background from the most recent prior signed assessment
+    // for the same (patient, condition). Non-blocking: the user can start
+    // typing immediately; the fetch may race. If it lands AFTER the user has
+    // typed something, we MUST NOT overwrite their input — guard with
+    // ``!c.data.background``. The /insert-commands belt is a safety net for
+    // approval, but this fetch is what makes the carry-forward visible in the
+    // assess edit drawer BEFORE the provider approves.
+    if (conditionId) {
+      fetch(`${API_BASE}/carry-forward-background`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ note_uuid: noteId, condition_id: conditionId }),
+      })
+        .then(r => r.ok ? r.json() : null)
+        .then(data => {
+          if (!data || !data.background) return;
+          setCommands(prev => prev.map(c =>
+            c.command_type === 'assess' && c.data.condition_id === conditionId && !c.data.background
+              ? { ...c, data: { ...c.data, background: data.background } }
+              : c
+          ));
+        })
+        .catch(err => console.error('Carry-forward background fetch failed:', err));
+    }
+  }, [canEdit, commands, noteId]);
 
   const handleInsert = useCallback(async () => {
     if (!canEdit || inserting) return;

--- a/pytest.ini
+++ b/pytest.ini
@@ -5,5 +5,7 @@ norecursedirs =
   .pytest_cache
   __pycache__
 python_files = test_*.py
+markers =
+  no_authorize_bypass: opt out of the autouse _authorize_edit bypass fixture (use the real auth helper for this test)
 filterwarnings =
   ignore::DeprecationWarning

--- a/tests/hyperscribe/scribe/api/test_session_view.py
+++ b/tests/hyperscribe/scribe/api/test_session_view.py
@@ -1085,6 +1085,46 @@ def test_insert_commands_success(mock_build: MagicMock) -> None:
 
 
 @patch("hyperscribe.scribe.api.session_view.build_effects")
+@patch("hyperscribe.scribe.api.session_view.prefill_assess_backgrounds")
+def test_insert_commands_calls_prefill_assess_backgrounds_before_build(
+    mock_prefill: MagicMock, mock_build: MagicMock
+) -> None:
+    """The endpoint must invoke ``prefill_assess_backgrounds`` before
+    ``build_effects`` so the assess proposal's ``background`` is populated
+    by the time the SDK command is constructed.
+
+    This pins the new symmetric placement (parallel to ``annotate_duplicates``)
+    — without it, a refactor could delete the callsite and every other
+    insert_commands test would still pass (the helper short-circuits on bad
+    UUIDs and never raises).
+    """
+    mock_build.return_value = ([], [], [], [])
+
+    view = _helper_instance()
+    commands = [
+        {"command_type": "assess", "data": {"condition_id": "cond-1", "narrative": "Stable"}},
+    ]
+    view.request = SimpleNamespace(
+        body=json.dumps({"note_uuid": "5899e7bf-5ecb-4399-aceb-0e233bd4a8f0", "commands": commands})
+    )
+    view.post_insert_commands()
+
+    # The view re-parses the JSON, so the list it passes is NOT the same object
+    # as the ``commands`` we constructed here — assert on shape, not identity.
+    prefill_call_commands = mock_prefill.call_args.args[0]
+    assert prefill_call_commands == commands
+    assert mock_prefill.call_args.args[1] == "5899e7bf-5ecb-4399-aceb-0e233bd4a8f0"
+    # Order: prefill must run BEFORE build_effects, and BOTH must see the SAME
+    # in-memory list so the mutation lands. Compare identity between the two
+    # call arg lists (the view's own ``commands`` local).
+    build_call_commands = mock_build.call_args.args[0]
+    assert prefill_call_commands is build_call_commands, (
+        "prefill_assess_backgrounds and build_effects must share the same commands "
+        "list so the in-place mutation by prefill is visible to build"
+    )
+
+
+@patch("hyperscribe.scribe.api.session_view.build_effects")
 def test_insert_commands_with_metadata_pending(mock_build: MagicMock) -> None:
     mock_effect = MagicMock()
     pending = [
@@ -1305,6 +1345,79 @@ def test_extract_commands_without_note_uuid_calls_annotate_with_empty(mock_annot
     view.post_extract_commands()
     mock_annotate.assert_called_once()
     assert mock_annotate.call_args.args[1] == ""
+
+
+# --- prefill_assess_backgrounds delegation (carry-forward in UI proposal paths) ---
+
+
+@patch("hyperscribe.scribe.api.session_view.annotate_duplicates")
+@patch("hyperscribe.scribe.api.session_view.prefill_assess_backgrounds_for_proposals")
+def test_extract_commands_calls_prefill_assess_backgrounds(mock_prefill: MagicMock, _mock_annotate: MagicMock) -> None:
+    """The ``/extract-commands`` endpoint must invoke
+    ``prefill_assess_backgrounds_for_proposals`` so the UI sees prior signed-note
+    backgrounds pre-filled on the assess proposal BEFORE the provider opens the
+    edit view. This is the primary site that fixes KOALA-5598 — without it, the
+    textarea is empty at proposal time and any edit the provider makes wins over
+    the carry-forward applied later at Approve time.
+
+    ``annotate_duplicates`` is patched only to prevent its real DB query from
+    firing in the unit test environment (it doesn't need to participate in the
+    assertion).
+    """
+    view = _helper_instance()
+    view.request = SimpleNamespace(
+        body=json.dumps(
+            {
+                "note": {
+                    "title": "Note",
+                    "sections": [{"key": "chief_complaint", "title": "CC", "text": "Pain."}],
+                },
+                "note_uuid": "5899e7bf-5ecb-4399-aceb-0e233bd4a8f0",
+            }
+        )
+    )
+    view.post_extract_commands()
+    mock_prefill.assert_called_once()
+    assert mock_prefill.call_args.args[1] == "5899e7bf-5ecb-4399-aceb-0e233bd4a8f0"
+
+
+@patch("hyperscribe.scribe.contacts.resolve_zip_codes", return_value=[])
+@patch("hyperscribe.scribe.api.session_view.annotate_duplicates")
+@patch("hyperscribe.scribe.api.session_view.prefill_assess_backgrounds_for_proposals")
+@patch("hyperscribe.scribe.api.session_view.recommend_commands")
+def test_recommend_commands_calls_prefill_assess_backgrounds(
+    mock_recommend: MagicMock,
+    mock_prefill: MagicMock,
+    _mock_annotate: MagicMock,
+    _mock_zip: MagicMock,
+) -> None:
+    """The ``/recommend-commands`` endpoint must invoke
+    ``prefill_assess_backgrounds_for_proposals`` on recommended proposals so
+    background carry-forward applies symmetrically to AI-recommended assess
+    commands, not just extracted ones.
+    """
+    mock_recommend.return_value = [
+        CommandProposal(
+            command_type="assess",
+            display="Hypertension",
+            data={"condition_id": "cond-1", "narrative": ""},
+            section_key="_recommended",
+        ),
+    ]
+
+    view = _helper_instance()
+    view.secrets["AnthropicAPIKey"] = "test-key"
+    view.request = SimpleNamespace(
+        body=json.dumps(
+            {
+                "note": {"title": "Note", "sections": []},
+                "note_uuid": "5899e7bf-5ecb-4399-aceb-0e233bd4a8f1",
+            }
+        )
+    )
+    view.post_recommend_commands()
+    mock_prefill.assert_called_once()
+    assert mock_prefill.call_args.args[1] == "5899e7bf-5ecb-4399-aceb-0e233bd4a8f1"
 
 
 # --- /search-medications ---
@@ -2173,3 +2286,151 @@ def test_generate_summary_writes_progress(
     progress = json.loads(cache._store[progress_key])
     assert progress["step"] == len(SUMMARY_STEPS) - 1
     assert progress["total"] == len(SUMMARY_STEPS)
+
+
+# --- /carry-forward-background ---
+#
+# Focused read endpoint the frontend hits when a new ``assess`` command is
+# created client-side (handleAddCondition: manual "+ Add Condition"). The
+# already-existing /insert-commands belt covers the convert-at-approve path,
+# but the user needs to SEE the carry-forward in the edit drawer BEFORE
+# approving, so this endpoint exists to populate the background text in the UI.
+
+
+@patch("hyperscribe.scribe.api.session_view.carry_forward_assess_background")
+@patch("hyperscribe.scribe.api.session_view.Note")
+def test_carry_forward_background_success(mock_note: MagicMock, mock_helper: MagicMock) -> None:
+    """Happy path: a prior signed assessment exists for the (patient, condition).
+
+    The endpoint reuses ``carry_forward_assess_background`` (the same helper
+    /insert-commands runs server-side), so we mock the helper and assert the
+    endpoint propagates the mutation it makes to the throwaway dict.
+    """
+    mock_note.objects.select_related.return_value.get.return_value = MagicMock()
+
+    # Snapshot the dict at call time — ``mock.call_args`` holds a reference, so
+    # by the time we inspect it the side_effect's mutation would have already
+    # landed. Capture the pre-mutation state inside the side_effect itself.
+    captured_initial_state: dict[str, Any] = {}
+
+    def _set_background(data: dict[str, Any], _note: Any) -> None:
+        captured_initial_state.update(data)
+        data["background"] = "This is zee background"
+
+    mock_helper.side_effect = _set_background
+
+    view = _helper_instance()
+    view.request = SimpleNamespace(
+        body=json.dumps({"note_uuid": "5899e7bf-5ecb-4399-aceb-0e233bd4a8f0", "condition_id": "cond-1"})
+    )
+    result = view.post_carry_forward_background()
+
+    assert result[0].status_code == HTTPStatus.OK
+    assert json.loads(result[0].content) == {"background": "This is zee background"}
+
+    # The throwaway dict the endpoint passes to the helper must carry the
+    # condition_id (the helper short-circuits on missing condition_id), and
+    # must NOT pre-set ``background`` (the helper short-circuits on a
+    # populated background — that would defeat the lookup).
+    assert captured_initial_state["condition_id"] == "cond-1"
+    assert "background" not in captured_initial_state or not captured_initial_state.get("background")
+
+
+@patch("hyperscribe.scribe.api.session_view.carry_forward_assess_background")
+@patch("hyperscribe.scribe.api.session_view.Note")
+def test_carry_forward_background_no_prior(mock_note: MagicMock, mock_helper: MagicMock) -> None:
+    """No prior signed assessment: helper leaves the throwaway dict untouched.
+
+    The endpoint returns 200 with ``{"background": null}`` so the frontend can
+    distinguish "no carry-forward to apply" from a network/server error.
+    """
+    mock_note.objects.select_related.return_value.get.return_value = MagicMock()
+    # Helper short-circuits and does not set ``background`` — simulate by no-op.
+    mock_helper.side_effect = lambda _data, _note: None
+
+    view = _helper_instance()
+    view.request = SimpleNamespace(
+        body=json.dumps({"note_uuid": "5899e7bf-5ecb-4399-aceb-0e233bd4a8f0", "condition_id": "cond-1"})
+    )
+    result = view.post_carry_forward_background()
+
+    assert result[0].status_code == HTTPStatus.OK
+    assert json.loads(result[0].content) == {"background": None}
+
+
+def test_carry_forward_background_missing_note_uuid() -> None:
+    """Missing or empty note_uuid in the body returns 400. The auth helper
+    enforces the same check — but we surface the error before auth too, so a
+    malformed payload doesn't hit the DB."""
+    view = _helper_instance()
+    view.request = SimpleNamespace(body=json.dumps({"condition_id": "cond-1"}))
+    result = view.post_carry_forward_background()
+
+    assert result[0].status_code == HTTPStatus.BAD_REQUEST
+    assert "note_uuid" in json.loads(result[0].content)["error"]
+
+
+def test_carry_forward_background_missing_condition_id() -> None:
+    """Missing or empty condition_id returns 400. Without a condition_id the
+    helper has nothing to scope by; surface the error explicitly rather than
+    silently returning null (which would mask a frontend bug)."""
+    view = _helper_instance()
+    view.request = SimpleNamespace(body=json.dumps({"note_uuid": "5899e7bf-5ecb-4399-aceb-0e233bd4a8f0"}))
+    result = view.post_carry_forward_background()
+
+    assert result[0].status_code == HTTPStatus.BAD_REQUEST
+    assert "condition_id" in json.loads(result[0].content)["error"]
+
+
+def test_carry_forward_background_invalid_json() -> None:
+    """Non-JSON body returns 400 — same shape as every other POST endpoint."""
+    view = _helper_instance()
+    view.request = SimpleNamespace(body="not-json")
+    result = view.post_carry_forward_background()
+
+    assert result[0].status_code == HTTPStatus.BAD_REQUEST
+    assert "Invalid JSON" in json.loads(result[0].content)["error"]
+
+
+@patch("hyperscribe.scribe.api.session_view.Note")
+def test_carry_forward_background_note_not_found(mock_note: MagicMock) -> None:
+    """If the auth helper passes but the select_related lookup raises (e.g.
+    malformed UUID that reached the SQL layer, or a race where the note was
+    deleted between auth and lookup), return 404 rather than 500.
+
+    Note: in normal flow, ``_authorize_edit`` short-circuits with 404 first.
+    This test specifically pins the defensive try/except inside the endpoint.
+    """
+    from canvas_sdk.v1.data.note import Note as RealNote
+
+    mock_note.objects.select_related.return_value.get.side_effect = RealNote.DoesNotExist
+    mock_note.DoesNotExist = RealNote.DoesNotExist
+
+    view = _helper_instance()
+    view.request = SimpleNamespace(
+        body=json.dumps({"note_uuid": "5899e7bf-5ecb-4399-aceb-0e233bd4a8f0", "condition_id": "cond-1"})
+    )
+    result = view.post_carry_forward_background()
+
+    assert result[0].status_code == HTTPStatus.NOT_FOUND
+
+
+@pytest.mark.no_authorize_bypass
+@patch("hyperscribe.scribe.api.session_view.Helper.editable_note", return_value=True)
+@patch("hyperscribe.scribe.api.session_view.Note")
+def test_carry_forward_background_unauthorized(mock_note: MagicMock, _editable: MagicMock) -> None:
+    """The real auth helper (no bypass): a request from a staff who is NOT the
+    note's provider returns 403. Pins that the new endpoint is gated identically
+    to every other mutating endpoint (defense in depth — the endpoint is
+    technically read-only, but it leaks ``has a prior assessment``-shaped
+    metadata about another provider's patient if left open)."""
+    mock_note.objects.values.return_value.get.return_value = {"dbid": 42, "provider__id": "other-staff"}
+
+    view = _helper_instance(staff_id="staff-key-abc")
+    view.request = SimpleNamespace(
+        headers={"canvas-logged-in-user-id": "staff-key-abc"},
+        body=json.dumps({"note_uuid": "5899e7bf-5ecb-4399-aceb-0e233bd4a8f0", "condition_id": "cond-1"}),
+    )
+    result = view.post_carry_forward_background()
+
+    assert result[0].status_code == HTTPStatus.FORBIDDEN

--- a/tests/hyperscribe/scribe/api/test_session_view_templates.py
+++ b/tests/hyperscribe/scribe/api/test_session_view_templates.py
@@ -251,7 +251,12 @@ def test_get_visit_templates_preserves_integer_zero_score_value(
                                         "label": "Little interest?",
                                         "type": ResponseOption.TYPE_RADIO,
                                         "options": [
-                                            {"dbid": 101, "value": "Not at all", "code": "LA6568-5", "score_value": "0"},
+                                            {
+                                                "dbid": 101,
+                                                "value": "Not at all",
+                                                "code": "LA6568-5",
+                                                "score_value": "0",
+                                            },
                                             {"dbid": 102, "value": "Unknown", "code": "", "score_value": ""},
                                         ],
                                     }

--- a/tests/hyperscribe/scribe/commands/test_builder.py
+++ b/tests/hyperscribe/scribe/commands/test_builder.py
@@ -11,6 +11,7 @@ from hyperscribe.scribe.commands.builder import (
     _format_pydantic_errors,
     build_effects,
     build_metadata_effects,
+    prefill_assess_backgrounds,
     validate_proposals,
 )
 
@@ -185,6 +186,107 @@ def test_build_effects_empty_list() -> None:
     assert effects == []
     assert metadata_pending == []
     assert attempted == []
+
+
+def test_prefill_assess_backgrounds_filters_assess_only_and_loads_note() -> None:
+    """``prefill_assess_backgrounds`` filters to assess proposals, loads the
+    ``Note``, and delegates to ``carry_forward_assess_background`` per
+    proposal.
+
+    This pins the public-function contract: non-assess proposals are skipped
+    (no DB lookup chain runs for them), and proposals with non-dict ``data``
+    are tolerated without raising.
+    """
+    proposals: list[dict[str, Any]] = [
+        {"command_type": "assess", "data": {"condition_id": "cond-1", "background": None}},
+        {"command_type": "plan", "data": {"narrative": "Start naproxen"}},
+        # Defensive: malformed proposal must not crash the loop.
+        {"command_type": "assess", "data": None},
+    ]
+    fake_note = MagicMock()
+    fake_note.id = "note-uuid-1"
+    with (
+        patch("hyperscribe.scribe.commands.builder.Note.objects") as mock_note_qs,
+        patch("hyperscribe.scribe.commands.builder.carry_forward_assess_background") as mock_carry,
+    ):
+        mock_note_qs.select_related.return_value.get.return_value = fake_note
+        prefill_assess_backgrounds(proposals, "note-uuid-1")
+    # Only one valid assess proposal (the one with a dict ``data``) is delegated.
+    mock_carry.assert_called_once_with(proposals[0]["data"], fake_note)
+
+
+def test_prefill_assess_backgrounds_silent_on_malformed_note_uuid() -> None:
+    """A non-UUID ``note_uuid`` must NOT raise — the carry-forward is
+    best-effort and a malformed identifier should silently skip the
+    convenience, not blow up the calling endpoint.
+
+    Django raises ``ValueError`` (not ``Note.DoesNotExist``) for a malformed
+    UUID before reaching the SQL layer; both must be swallowed.
+    """
+    proposals: list[dict[str, Any]] = [
+        {"command_type": "assess", "data": {"condition_id": "cond-1", "background": None}},
+    ]
+    with (
+        patch("hyperscribe.scribe.commands.builder.Note.objects") as mock_note_qs,
+        patch("hyperscribe.scribe.commands.builder.carry_forward_assess_background") as mock_carry,
+    ):
+        mock_note_qs.select_related.return_value.get.side_effect = ValueError(
+            "badly formed hexadecimal UUID string",
+        )
+        # Must not raise.
+        prefill_assess_backgrounds(proposals, "not-a-uuid")
+    mock_carry.assert_not_called()
+    # The background on the proposal is left untouched.
+    assert proposals[0]["data"]["background"] is None
+
+
+def test_prefill_assess_backgrounds_no_assess_proposals_short_circuits() -> None:
+    """If there are no assess proposals, skip the Note lookup entirely.
+
+    This is an N+1 / latency guard: a request with only non-assess commands
+    should not pay for the ``Note.objects.select_related("patient").get(...)``
+    query.
+    """
+    proposals: list[dict[str, Any]] = [
+        {"command_type": "plan", "data": {"narrative": "Start naproxen"}},
+    ]
+    with patch("hyperscribe.scribe.commands.builder.Note.objects") as mock_note_qs:
+        prefill_assess_backgrounds(proposals, "note-uuid-1")
+    mock_note_qs.select_related.assert_not_called()
+
+
+def test_build_effects_no_longer_calls_prefill_assess_backgrounds() -> None:
+    """``build_effects`` is symmetric with ``annotate_duplicates`` — both
+    are called by ``session_view`` at the same layer, NOT from inside
+    ``build_effects``. This test pins that placement so a future refactor
+    can't silently re-hide the carry-forward inside ``build_effects``.
+    """
+    proposals: list[dict[str, Any]] = [
+        {
+            "command_type": "assess",
+            "data": {
+                "condition_id": "cond-uuid-abc",
+                "narrative": "Stable today",
+                "background": "Provider-typed",
+            },
+        },
+    ]
+    with (
+        patch("hyperscribe.scribe.commands.builder.prefill_assess_backgrounds") as mock_prefill,
+        patch("hyperscribe.scribe.commands.assess.AssessCommand") as mock_assess,
+    ):
+        inst = MagicMock()
+        inst.originate.return_value = "assess_originate"
+        inst.commit.return_value = "assess_commit"
+        inst.command_uuid = "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+        inst.note_uuid = "5899e7bf-5ecb-4399-aceb-0e233bd4a8f0"
+        mock_assess.return_value = inst
+
+        build_effects(proposals, "5899e7bf-5ecb-4399-aceb-0e233bd4a8f0")
+
+        # Symmetry guard: ``build_effects`` does not call the carry-forward.
+        # The caller (session_view) is responsible.
+        mock_prefill.assert_not_called()
 
 
 def test_build_effects_medication_with_alert_facility_emits_yes_inline() -> None:

--- a/tests/hyperscribe/scribe/commands/test_carry_forward.py
+++ b/tests/hyperscribe/scribe/commands/test_carry_forward.py
@@ -1,0 +1,396 @@
+"""Tests for the Assess Condition background carry-forward.
+
+The helper under test, ``carry_forward_assess_background``, pre-fills the
+``background`` field on a new assess proposal using the value from the
+patient's most recent prior signed Assessment for the same condition.
+
+These tests pin the six scenarios required by KOALA-5598:
+1. Happy path — prior signed note with non-empty background carries forward.
+2. No prior note — proposal's background stays empty/unset.
+3. Prior background was empty-string — still carried forward as "".
+4. Multiple prior signed notes — most recent wins.
+5. Different patient with same condition_id — no carry-forward.
+6. Voided (entered_in_error) prior — falls back to the most recent
+   non-voided prior; if none, no carry-forward.
+
+Plus structural safety tests:
+- Provider already typed a background — preserve it.
+- Proposal has no condition_id — skip the lookup.
+- Note has no patient — skip the lookup.
+"""
+
+from __future__ import annotations
+
+import datetime
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+from canvas_sdk.test_utils import factories
+from canvas_sdk.v1.data.assessment import Assessment
+from canvas_sdk.v1.data.condition import Condition
+from canvas_sdk.v1.data.note import CurrentNoteStateEvent, NoteStates
+
+from hyperscribe.scribe.commands.carry_forward import (
+    carry_forward_assess_background,
+)
+
+
+_UNSET = object()
+
+
+def _make_note(*, patient: Any = _UNSET, note_id: str = "current-note-uuid") -> MagicMock:
+    """Build a Note-like double with a patient attribute and id.
+
+    Use ``patient=None`` to force the missing-patient branch; the default
+    sentinel gives a fresh MagicMock so the helper proceeds with the lookup.
+    """
+    note = MagicMock()
+    note.patient = MagicMock() if patient is _UNSET else patient
+    note.id = note_id
+    return note
+
+
+def _patch_assessment_queryset(prior_background: Any) -> Any:
+    """Patch ``Assessment.objects`` to short-circuit the lookup chain.
+
+    The helper builds the queryset:
+        Assessment.objects
+            .filter(...)
+            .exclude(...)
+            .order_by(...)
+            .values_list("background", flat=True)
+            .first()
+    so we mock that whole chain to return ``prior_background``. ``None``
+    means "no prior row found".
+    """
+    qs = MagicMock()
+    qs.filter.return_value = qs
+    qs.exclude.return_value = qs
+    qs.order_by.return_value = qs
+    qs.values_list.return_value = qs
+    qs.first.return_value = prior_background
+    return patch(
+        "hyperscribe.scribe.commands.carry_forward.Assessment.objects",
+        qs,
+    )
+
+
+def test_carry_forward_happy_path_fills_background() -> None:
+    """Prior signed note with non-empty background populates the proposal."""
+    data: dict[str, Any] = {"condition_id": "cond-uuid-1", "background": None}
+    note = _make_note()
+    with _patch_assessment_queryset("Diagnosed 2020-05-12; controlled on metformin"):
+        carry_forward_assess_background(data, note)
+    assert data["background"] == "Diagnosed 2020-05-12; controlled on metformin"
+
+
+def test_carry_forward_no_prior_leaves_background_empty() -> None:
+    """No prior signed assessment exists for this (patient, condition); proposal stays unset."""
+    data: dict[str, Any] = {"condition_id": "cond-uuid-1", "background": None}
+    note = _make_note()
+    with _patch_assessment_queryset(None):
+        carry_forward_assess_background(data, note)
+    # We intentionally leave the original value (None) untouched when no
+    # prior is found — the parser will coerce None to "" downstream.
+    assert data["background"] is None
+
+
+def test_carry_forward_prior_empty_string_still_carried() -> None:
+    """If the prior assessment's background was empty, we still propagate "".
+
+    Rationale: empty-string is a valid carried value (the provider may have
+    explicitly cleared it in the prior note); skipping it would let stale
+    state from earlier notes leak forward through inaction.
+    """
+    data: dict[str, Any] = {"condition_id": "cond-uuid-1", "background": None}
+    note = _make_note()
+    with _patch_assessment_queryset(""):
+        carry_forward_assess_background(data, note)
+    assert data["background"] == ""
+
+
+def test_carry_forward_most_recent_wins() -> None:
+    """The query orders by ``-note__datetime_of_service``, so ``.first()``
+    is the most recent. This test pins that contract by inspecting the
+    actual ``order_by`` call rather than re-mocking a multi-row fixture.
+    """
+    data: dict[str, Any] = {"condition_id": "cond-uuid-1", "background": None}
+    note = _make_note()
+    qs = MagicMock()
+    qs.filter.return_value = qs
+    qs.exclude.return_value = qs
+    qs.order_by.return_value = qs
+    qs.values_list.return_value = qs
+    qs.first.return_value = "Most recent background"
+    with patch(
+        "hyperscribe.scribe.commands.carry_forward.Assessment.objects",
+        qs,
+    ):
+        carry_forward_assess_background(data, note)
+    assert data["background"] == "Most recent background"
+    # Pin the ordering so a refactor can't silently reverse it.
+    qs.order_by.assert_called_once_with("-note__datetime_of_service", "-modified")
+
+
+def test_carry_forward_filters_by_patient_and_condition() -> None:
+    """The filter is scoped by (patient, condition, signed, committed, not-voided).
+
+    A different patient with the same condition_id must NOT carry forward.
+    We assert this structurally by inspecting the filter kwargs — if the
+    scope ever loosens (e.g. dropping ``patient=`` from the filter) this
+    test fails.
+    """
+    patient = MagicMock(name="current-patient")
+    data: dict[str, Any] = {"condition_id": "cond-uuid-X", "background": None}
+    note = _make_note(patient=patient, note_id="note-uuid-current")
+    qs = MagicMock()
+    qs.filter.return_value = qs
+    qs.exclude.return_value = qs
+    qs.order_by.return_value = qs
+    qs.values_list.return_value = qs
+    qs.first.return_value = "Background from prior"
+    with patch(
+        "hyperscribe.scribe.commands.carry_forward.Assessment.objects",
+        qs,
+    ):
+        carry_forward_assess_background(data, note)
+    filter_kwargs = qs.filter.call_args.kwargs
+    assert filter_kwargs["patient"] is patient
+    assert filter_kwargs["condition__id"] == "cond-uuid-X"
+    assert filter_kwargs["committer_id__isnull"] is False
+    assert filter_kwargs["entered_in_error_id__isnull"] is True
+    # We DO NOT filter by note state. The committed gate (committer set, no
+    # entered_in_error) is sufficient to scope to finalized assessments — a
+    # previous iteration filtered on ``note__current_state__state == SIGNED``
+    # which excluded prior notes that progressed past SIGNED to LOCKED /
+    # RELOCKED / etc. Pin the absence to catch a re-introduction.
+    assert "note__current_state__state" not in filter_kwargs
+    # The current note must be excluded (so an in-progress STAGED command on
+    # the same note for the same condition can't self-poison the lookup).
+    exclude_kwargs = qs.exclude.call_args.kwargs
+    assert exclude_kwargs == {"note__id": "note-uuid-current"}
+
+
+def test_carry_forward_voided_filter_excludes_entered_in_error() -> None:
+    """``entered_in_error_id__isnull=True`` excludes voided prior rows.
+
+    Amendment workflow (KOALA-5485) voids the old command and recreates it;
+    the void leaves ``entered_in_error_id`` non-null on the original row.
+    Our filter must skip those so we land on the most-recent NON-voided row.
+
+    This test pins the filter kwarg directly; if a refactor drops it, the
+    helper would silently start picking up voided values.
+    """
+    data: dict[str, Any] = {"condition_id": "cond-uuid-1", "background": None}
+    note = _make_note()
+    qs = MagicMock()
+    qs.filter.return_value = qs
+    qs.exclude.return_value = qs
+    qs.order_by.return_value = qs
+    qs.values_list.return_value = qs
+    qs.first.return_value = "Non-voided value"
+    with patch(
+        "hyperscribe.scribe.commands.carry_forward.Assessment.objects",
+        qs,
+    ):
+        carry_forward_assess_background(data, note)
+    filter_kwargs = qs.filter.call_args.kwargs
+    assert filter_kwargs["entered_in_error_id__isnull"] is True
+
+
+def test_carry_forward_preserves_provider_typed_background() -> None:
+    """If the proposal already has a non-empty background, do not overwrite.
+
+    This protects the case where the provider clicked into the field and
+    typed something before approving the assess — we must not stomp it.
+    """
+    data: dict[str, Any] = {"condition_id": "cond-uuid-1", "background": "Provider notes"}
+    note = _make_note()
+    with _patch_assessment_queryset("Carried-forward value (should not be used)") as mock_qs:
+        carry_forward_assess_background(data, note)
+    assert data["background"] == "Provider notes"
+    # The lookup must short-circuit before issuing the query.
+    mock_qs.filter.assert_not_called()  # type: ignore[attr-defined]
+
+
+def test_carry_forward_skipped_when_condition_id_missing() -> None:
+    """No condition_id => no carry-forward (we have nothing to scope to).
+
+    This is the unmatched-diagnose path: a diagnose command without an
+    ICD-10 match never becomes an assess, so we don't normally hit this
+    branch — but defensively the helper must not query a global by-patient
+    fallback.
+    """
+    data: dict[str, Any] = {"condition_id": "", "background": None}
+    note = _make_note()
+    with _patch_assessment_queryset("Should not be used") as mock_qs:
+        carry_forward_assess_background(data, note)
+    assert data["background"] is None
+    mock_qs.filter.assert_not_called()  # type: ignore[attr-defined]
+
+
+def test_carry_forward_skipped_when_patient_missing() -> None:
+    """Note without a patient => skip (defensive; should not happen in practice)."""
+    data: dict[str, Any] = {"condition_id": "cond-uuid-1", "background": None}
+    note = _make_note(patient=None)
+    with _patch_assessment_queryset("Should not be used") as mock_qs:
+        carry_forward_assess_background(data, note)
+    assert data["background"] is None
+    mock_qs.filter.assert_not_called()  # type: ignore[attr-defined]
+
+
+def test_carry_forward_runs_when_proposal_background_is_empty_string() -> None:
+    """Empty-string background on the proposal is treated as 'not yet set'.
+
+    At proposal-build time we have no signal that distinguishes
+    'provider explicitly cleared this' from 'never populated', so the
+    conservative choice is to attempt carry-forward whenever the value is
+    falsy. The provider can still clear it in the UI before insert.
+    """
+    data: dict[str, Any] = {"condition_id": "cond-uuid-1", "background": ""}
+    note = _make_note()
+    with _patch_assessment_queryset("Prior background"):
+        carry_forward_assess_background(data, note)
+    assert data["background"] == "Prior background"
+
+
+# --- Integration test (real ORM) ---
+#
+# Per the project's testing convention (global CLAUDE.md):
+#   "At least one test per feature should use the test database (with Factories)."
+#
+# This repo doesn't use a separate ``@pytest.mark.integration`` marker — the
+# ``pytest_canvas`` plugin already autouses the ``db`` fixture for every test —
+# so this test is a plain function. It exercises the actual Django ORM chain
+# against a real (SQLite test) database, which catches mistakes that
+# MagicMock-based tests can't:
+#
+#   - Filter-kwarg typos (``patient_id=`` vs ``patient=``, ``condition__id`` vs
+#     ``condition_id``).
+#   - Relation traversal errors (``note__current_state__state`` resolves through
+#     a ``OneToOneField`` view-backed model — a refactor breaking the relation
+#     would fail here but pass every mock-based test).
+#   - The ``str(note.id)`` coercion in ``exclude(note__id=...)`` against a
+#     ``UUIDField`` (UUID round-trips that look fine in mocks but mismatch in
+#     real SQL).
+
+
+def test_carry_forward_integration_happy_path() -> None:
+    """Integration: a prior signed assessment carries forward via the real ORM.
+
+    Setup:
+      - One patient with two notes:
+        * ``prior_note``: state SIGNED, with a committed Assessment whose
+          ``background`` is a known string.
+        * ``current_note``: the "in-progress" note where the new assess
+          proposal lives.
+      - Both notes reference the same Condition.
+
+    Expectation: ``carry_forward_assess_background`` resolves the prior
+    signed Assessment by (patient, condition) and writes its ``background``
+    onto the new proposal.
+
+    Why this matters: this is the only test that proves the filter chain
+    actually returns the right row from a real DB. Every other test mocks
+    ``Assessment.objects``, which means a typo in the filter kwargs would
+    pass them all but fail in production.
+    """
+    patient = factories.PatientFactory.create()
+    user = factories.CanvasUserFactory.create()
+    prior_note = factories.NoteFactory.create(patient=patient)
+    current_note = factories.NoteFactory.create(patient=patient)
+
+    # Advance prior_note to SIGNED via the view-backed CurrentNoteStateEvent.
+    # In Postgres this row is materialized by a view; in the SQLite test DB the
+    # ``managed=True`` Meta still creates a regular table that we can write
+    # directly (verified empirically — see commit message).
+    CurrentNoteStateEvent.objects.create(note=prior_note, state=NoteStates.SIGNED)
+
+    condition = Condition.objects.create(
+        patient=patient,
+        deleted=False,
+        onset_date=datetime.date(2024, 1, 1),
+        resolution_date=datetime.date(2024, 12, 31),
+        clinical_status="active",
+        surgical=False,
+        committer=user,
+    )
+    Assessment.objects.create(
+        patient=patient,
+        note=prior_note,
+        condition=condition,
+        status="stable",
+        narrative="Stable on metformin",
+        background="Diagnosed 2020-05-12; controlled on metformin",
+        care_team="",
+        # ``committer_id`` is the DB pk (``dbid``), per the ID-mapping convention
+        # documented in global CLAUDE.md: FK ``_id`` suffix always targets the
+        # database primary key, not the externally-exposable id.
+        committer_id=user.dbid,
+    )
+
+    proposal_data: dict[str, Any] = {
+        "condition_id": str(condition.id),
+        "background": None,
+    }
+    carry_forward_assess_background(proposal_data, current_note)
+
+    assert proposal_data["background"] == "Diagnosed 2020-05-12; controlled on metformin"
+
+
+def test_carry_forward_integration_different_patient_does_not_leak() -> None:
+    """Integration: a prior signed assessment for a DIFFERENT patient with the
+    SAME ``condition_id`` MUST NOT carry forward.
+
+    Patient cross-pollination would be a hard HIPAA violation: a proposal on
+    patient B would pre-fill with patient A's clinical text. This test
+    exercises the (patient, condition) scoping against the real ORM so a
+    refactor dropping the ``patient=`` filter kwarg can't slip through.
+    """
+    # Patient A has the prior signed assessment.
+    patient_a = factories.PatientFactory.create()
+    # Patient B is the one we're building a new proposal for.
+    patient_b = factories.PatientFactory.create()
+    user = factories.CanvasUserFactory.create()
+
+    prior_note_a = factories.NoteFactory.create(patient=patient_a)
+    current_note_b = factories.NoteFactory.create(patient=patient_b)
+
+    CurrentNoteStateEvent.objects.create(note=prior_note_a, state=NoteStates.SIGNED)
+
+    # Shared Condition between the two patients would not normally happen in
+    # production (Condition is per-patient), but the carry-forward query
+    # filters by ``condition__id`` plus ``patient``. We attach the Condition
+    # to patient_a; the ``condition__id`` will resolve, but the ``patient=``
+    # scope must reject it for patient_b.
+    condition = Condition.objects.create(
+        patient=patient_a,
+        deleted=False,
+        onset_date=datetime.date(2024, 1, 1),
+        resolution_date=datetime.date(2024, 12, 31),
+        clinical_status="active",
+        surgical=False,
+        committer=user,
+    )
+    Assessment.objects.create(
+        patient=patient_a,
+        note=prior_note_a,
+        condition=condition,
+        status="stable",
+        narrative="Stable",
+        # ``background`` is intentionally non-empty so a leak would be visible
+        # in the assertion. The content here is fake test data, not PHI — see
+        # global CLAUDE.md guidance.
+        background="LEAK_CANARY: should never appear on patient B's proposal",
+        care_team="",
+        committer_id=user.dbid,
+    )
+
+    proposal_data: dict[str, Any] = {
+        "condition_id": str(condition.id),
+        "background": None,
+    }
+    carry_forward_assess_background(proposal_data, current_note_b)
+
+    # No cross-patient leak: the proposal stays unset.
+    assert proposal_data["background"] is None


### PR DESCRIPTION
[KOALA-5598](https://canvasmedical.atlassian.net/browse/KOALA-5598)

## Feature

A provider charting an Assess Condition for a patient who has a prior committed assessment for the same condition now sees that prior `background` carried forward into the assess edit drawer. The carry-forward is visible BEFORE approval — the provider can edit, clear, or accept it. When no prior assessment exists for the (patient, condition) pair, the field is empty (same as today). The `AssessCommand` SDK field has existed for a while; previously the Scribe UI only exposed a `narrative` textarea, so providers had no way to enter or see the background. Both fields are now rendered with labels in both the edit view and the read-only view.

## Implementation

Backend: a new `carry_forward_assess_background` helper queries `Assessment.objects` for the most recent prior committed, non-entered-in-error assessment for `(patient, condition)` and copies its `background` onto the proposal data. It's invoked after every `annotate_duplicates` callsite in `session_view.py` so the carry-forward fires at proposal-render time. A sibling endpoint `POST /carry-forward-background` is hit by the frontend when a provider manually selects a condition via "+ Add Condition" (the LLM path goes through the proposal-time hook, but that path delivers the command as `diagnose` until a condition match converts it client-side — so the manual hook handles the convert-time gap).

Frontend: `AssessNarrative` now renders both `background` (above) and `narrative` (below) textareas with labels. On `handleAddCondition`, the frontend fetches the carry-forward value and populates the just-added assess command's `data.background`, race-guarded so provider typing isn't overwritten. Local state syncs to `data` props on change so a fetch arriving after first render still surfaces in the edit drawer.

There are two helpers, `prefill_assess_backgrounds` (dict-shape proposals, insert path) and `prefill_assess_backgrounds_for_proposals` (`CommandProposal`-shape, extract/recommend paths). The duplication is intentional pending a future shared shape; both share the underlying `carry_forward_assess_background` helper.

[KOALA-5598]: https://canvasmedical.atlassian.net/browse/KOALA-5598?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ