### PR TITLE
scribe: rewrite Nabla unspecified parent codes to patient-specific child

### DIFF
--- a/hyperscribe/scribe/api/session_view.py
+++ b/hyperscribe/scribe/api/session_view.py
@@ -65,6 +65,10 @@ from hyperscribe.scribe.commands.builder import (
 )
 from hyperscribe.scribe.commands.carry_forward import carry_forward_assess_background
 from hyperscribe.scribe.commands.extractor import extract_commands, parse_ros_subsections
+from hyperscribe.scribe.commands.problem_list_match import (
+    ActivePatientCondition,
+    prefer_patient_specific_codes,
+)
 from hyperscribe.scribe.recommendations import recommend_commands
 from hyperscribe.scribe.recommendations.diagnosis_suggestion import suggest_diagnoses
 from hyperscribe.scribe.recommendations.reconciliation import reconcile_sections
@@ -178,6 +182,47 @@ def _serialize_condition(condition: Condition) -> dict[str, Any]:
     if condition.corresponding_note_problem is not None:
         result["corresponding_note_problem"] = condition.corresponding_note_problem
     return result
+
+
+def _load_active_patient_conditions(patient_id: str) -> list[ActivePatientCondition]:
+    """Return the patient's active problem-list entries, narrowed to the
+    fields :func:`prefer_patient_specific_codes` needs.
+
+    Used by :func:`post_generate_summary` (to hint Nabla codes toward the
+    patient-specific code already on file) AND by :meth:`get_patient_conditions`
+    (the endpoint the frontend's diagnose -> assess belt fetches against).
+    Both call sites go through this helper so a problem-list selection
+    change can never be visible to one and invisible to the other; without
+    that constraint the rewrite hint and the frontend belt would drift and
+    a patient's specific code would silently stop landing in their chart.
+
+    PHI note: the returned ``ActivePatientCondition`` carries clinical data;
+    callers must not log codes or display strings beyond aggregate counts.
+    """
+    if not patient_id:
+        return []
+    conditions = (
+        ConditionModel.objects.active().for_patient(patient_id).prefetch_related("codings").order_by("-onset_date")
+    )
+    results: list[ActivePatientCondition] = []
+    for c in conditions:
+        codings = list(c.codings.all())
+        if not codings:
+            continue
+        icd10 = next(
+            (coding for coding in codings if "icd" in (coding.system or "").lower()),
+            None,
+        )
+        chosen = icd10 or codings[0]
+        results.append(
+            ActivePatientCondition(
+                condition_id=str(c.id),
+                code=chosen.code,
+                display=chosen.display or c.clinical_status,
+                system=chosen.system or "",
+            )
+        )
+    return results
 
 
 def _match_conditions_to_sections(
@@ -776,6 +821,17 @@ class ScribeSessionView(StaffSessionAuthMixin, SimpleAPI):
         section_conditions: dict[str, list[dict[str, Any]]] = {}
         try:
             normalized = backend.generate_normalized_data(note)
+            # KOALA-5603: prefer the patient's specific active-problem-list code
+            # when Nabla emitted an unspecified-parent (e.g. E11.9 -> E11.65).
+            # The downstream frontend belt converts a diagnose to an assess
+            # only on EXACT ICD-10 match, so the rewrite has to land before
+            # _match_conditions_to_sections / split_plan_into_diagnoses run.
+            patient_id_for_hint = str(data.get("patient_id", ""))
+            active_conditions = _load_active_patient_conditions(patient_id_for_hint)
+            normalized.conditions = prefer_patient_specific_codes(
+                normalized.conditions,
+                active_conditions,
+            )
             section_conditions = _match_conditions_to_sections(note, normalized.conditions)
         except Exception:
             log.exception("generate_normalized_data failed (non-critical)")
@@ -1872,32 +1928,27 @@ class ScribeSessionView(StaffSessionAuthMixin, SimpleAPI):
 
     @api.get("/patient-conditions")
     def get_patient_conditions(self) -> list[Union[Response, Effect]]:
-        """Return committed, non-entered-in-error conditions for a patient."""
+        """Return committed, non-entered-in-error conditions for a patient.
+
+        Shape: ``{"conditions": [{condition_id, code, formatted_code, display, system}, ...]}``.
+        The frontend's diagnose -> assess belt fetches against this endpoint
+        and matches on ``code``; share :func:`_load_active_patient_conditions`
+        with ``post_generate_summary`` so any change to "what counts as an
+        active problem-list entry" lands in both places simultaneously."""
         patient_id = self.request.query_params.get("patient_id", "").strip()
         if not patient_id:
             return [JSONResponse({"error": "patient_id is required"}, status_code=HTTPStatus.BAD_REQUEST)]
-        conditions = (
-            ConditionModel.objects.active().for_patient(patient_id).prefetch_related("codings").order_by("-onset_date")
-        )
-        results = []
-        for c in conditions:
-            codings = list(c.codings.all())
-            if not codings:
-                continue
-            icd10 = next(
-                (coding for coding in codings if "icd" in (coding.system or "").lower()),
-                None,
-            )
-            chosen = icd10 or codings[0]
-            results.append(
-                {
-                    "condition_id": str(c.id),
-                    "code": chosen.code,
-                    "formatted_code": _format_icd10_code(chosen.code),
-                    "display": chosen.display or c.clinical_status,
-                    "system": chosen.system,
-                }
-            )
+        active = _load_active_patient_conditions(patient_id)
+        results = [
+            {
+                "condition_id": a.condition_id,
+                "code": a.code,
+                "formatted_code": _format_icd10_code(a.code),
+                "display": a.display,
+                "system": a.system,
+            }
+            for a in active
+        ]
         return [JSONResponse({"conditions": results}, status_code=HTTPStatus.OK)]
 
     @api.get("/patient-medications")

--- a/hyperscribe/scribe/commands/problem_list_match.py
+++ b/hyperscribe/scribe/commands/problem_list_match.py
@@ -1,0 +1,221 @@
+"""Problem-list-aware refinement of Nabla normalization output (KOALA-5603).
+
+Nabla's ``/generate-normalized-data`` sometimes emits the unspecified parent
+code within an ICD-10 family (e.g. ``E11.9`` for Type 2 diabetes without
+complications) when the patient already has a more specific active condition
+on file (e.g. ``E11.65`` Type 2 diabetes with hyperglycemia). The frontend's
+diagnose -> assess belt requires an exact code match against the patient's
+active conditions; the unspecified-parent code falls through that belt and
+surfaces as a stand-alone diagnose suggestion that the provider must then
+manually swap.
+
+This module rewrites the unspecified-parent code on the Nabla side BEFORE
+the frontend belt runs, so the belt's exact-match path becomes the success
+path. The Nabla client and the frontend belt are deliberately untouched --
+this is the narrowest hook point that fixes the bug.
+
+PHI: callers must not log condition codes or display strings emitted by this
+module beyond aggregate counts; the values are clinical data.
+"""
+
+from __future__ import annotations
+
+from typing import NamedTuple
+
+from hyperscribe.scribe.backend.models import CodingEntry, Condition
+
+
+_ICD10_SYSTEM_TOKEN = "icd"
+
+
+# NamedTuple instead of @dataclass: the plugin-runner sandbox can't evaluate
+# the `@dataclass` decorator at module-load time because its module-loading
+# strategy leaves ``cls.__module__`` outside ``sys.modules``, which trips
+# dataclasses' internal ``_is_type`` check. NamedTuple from ``typing`` is
+# safe (it's used elsewhere in this plugin — medication_detail, json_extract).
+class ActivePatientCondition(NamedTuple):
+    """A patient's active problem-list entry, narrowed to the fields we need
+    for code-preference matching.
+
+    :param condition_id: The patient-condition externally-exposable id. Not
+        used by this module directly but threaded through so downstream
+        callers (and tests) can correlate a rewrite with a specific entry.
+    :param code: The ICD-10 code on the active problem list. May be either
+        dotted (``"E11.65"``) or dotless (``"E1165"``); normalised on use.
+        Empty string means "no ICD-10 coding" and disqualifies the entry
+        from being used as a hint.
+    :param display: The patient-condition display string. Used to populate
+        the rewritten coding's display so the chart text matches the active
+        problem-list entry rather than Nabla's parent display.
+    :param system: The coding system that produced ``code`` (e.g. ``"ICD-10"``
+        or ``"http://snomed.info/sct"``). Carried so the
+        ``get_patient_conditions`` endpoint can serialize the same shape it
+        always has; this module itself only uses entries whose code looks
+        like ICD-10 (3-char family root match).
+    """
+
+    condition_id: str
+    code: str
+    display: str
+    system: str = ""
+
+
+def icd10_normalize(code: str) -> str:
+    """Return the dotless, uppercase, whitespace-stripped form of an ICD-10
+    code. We normalise consistently across both Nabla and patient sources so
+    string comparisons don't trip on cosmetic differences (``e11.65`` vs
+    ``E1165`` vs ``  E11.65 ``)."""
+    return code.strip().replace(".", "").upper()
+
+
+def _icd10_family_root(code: str) -> str:
+    """Return the 3-character family root of a normalised ICD-10 code
+    (``E1165`` -> ``E11``). The root is the canonical key for grouping codes
+    that share a parent within the ICD-10 hierarchy."""
+    return icd10_normalize(code)[:3]
+
+
+def icd10_is_unspecified_parent_of(parent: str, child: str) -> bool:
+    """Return ``True`` iff ``parent`` is an unspecified-parent of ``child``.
+
+    Two parent shapes qualify as "unspecified":
+      1. The bare 3-char root (``E11`` with no sub-classification at all).
+      2. The 3-char root followed by ``9`` and optionally one more digit
+         (``E11.9`` or ``E11.90``), which is the conventional ICD-10 bucket
+         for "type 2 diabetes mellitus, without complications / unspecified".
+
+    Ending in ``.89`` (e.g. ``Z99.89`` "other dependence") is NOT treated as
+    unspecified -- it carries its own clinical meaning.
+
+    "Of ``child``" requires ``child`` to be in the same family AND strictly
+    more specific than ``parent`` -- otherwise nothing's gained by the
+    rewrite. ``E11.9`` is NOT a parent of ``E11`` (would be a loss of
+    specificity); ``E11.36`` is NOT a parent of ``E11.65`` (sibling codes).
+    """
+    p = icd10_normalize(parent)
+    c = icd10_normalize(child)
+    if not p or not c or p == c:
+        return False
+    if _icd10_family_root(p) != _icd10_family_root(c):
+        return False
+    if len(c) <= len(p):
+        # Child is not strictly more specific -- don't claim parenthood.
+        return False
+    # Case 1: bare 3-char root (E11) -- parent of any longer code in family.
+    if len(p) == 3:
+        return True
+    # Case 2: root + "9" optionally followed by another digit
+    # ("E119" or "E1190" both qualify; "E1189" does NOT).
+    tail = p[3:]
+    if tail == "9":
+        return True
+    if len(tail) == 2 and tail[0] == "9" and tail[1].isdigit():
+        return True
+    return False
+
+
+def _find_specific_active_match(
+    nabla_code: str,
+    active_conditions: list[ActivePatientCondition],
+) -> ActivePatientCondition | None:
+    """Return the first active condition that Nabla's ``nabla_code`` is the
+    unspecified-parent of, or ``None`` when no such hint applies.
+
+    First-match-wins is documented in the test suite -- the caller does not
+    need to sort the active list; we accept whatever order the queryset
+    produced (typically ``-onset_date`` from ``get_patient_conditions``)."""
+    for active in active_conditions:
+        if not active.code:
+            continue
+        if icd10_is_unspecified_parent_of(nabla_code, active.code):
+            return active
+    return None
+
+
+def _rewrite_icd10_coding(
+    coding: CodingEntry,
+    active_match: ActivePatientCondition,
+) -> CodingEntry:
+    """Return a NEW ``CodingEntry`` with the active match's code and display.
+
+    The system field is preserved as-is so downstream code that filters by
+    ``"ICD-10"`` keeps working. The display is rewritten so the chart text
+    matches the active problem-list entry rather than Nabla's parent label."""
+    return CodingEntry(
+        system=coding.system,
+        code=active_match.code,
+        display=active_match.display or coding.display,
+    )
+
+
+def prefer_patient_specific_codes(
+    nabla_conditions: list[Condition],
+    active_conditions: list[ActivePatientCondition],
+) -> list[Condition]:
+    """Rewrite ICD-10 codings on ``nabla_conditions`` to prefer the patient's
+    more specific active problem-list code when Nabla emitted an unspecified
+    parent.
+
+    Pure function: input lists and ``Condition`` / ``CodingEntry`` instances
+    are not mutated. The returned list contains fresh ``Condition`` objects
+    when any coding is rewritten; identity-stable entries are reused when no
+    rewrite applies.
+
+    :param nabla_conditions: ``NormalizedData.conditions`` from Nabla.
+    :param active_conditions: The patient's active problem-list entries,
+        narrowed to ``ActivePatientCondition``. Pass an empty list when the
+        patient has no problem list -- the function returns input unchanged.
+    """
+    if not active_conditions or not nabla_conditions:
+        return nabla_conditions
+
+    out: list[Condition] = []
+    for condition in nabla_conditions:
+        new_coding: list[CodingEntry] = []
+        rewritten = False
+        for coding in condition.coding:
+            if _ICD10_SYSTEM_TOKEN in (coding.system or "").lower():
+                active_match = _find_specific_active_match(coding.code, active_conditions)
+                if active_match is not None:
+                    new_coding.append(_rewrite_icd10_coding(coding, active_match))
+                    rewritten = True
+                    continue
+            new_coding.append(coding)
+        if rewritten:
+            out.append(_to_view(condition)._replace(coding=new_coding).to_condition())
+        else:
+            out.append(condition)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Internal: ``Condition`` is a hand-written class (not a dataclass), so to
+# stay pure we copy fields explicitly via this small helper rather than
+# mutating in-place. Keeping the helper private avoids leaking the
+# bookkeeping detail into the module's public surface. NamedTuple instead
+# of dataclass for plugin-sandbox compatibility (see ActivePatientCondition).
+# ---------------------------------------------------------------------------
+
+
+class _ConditionView(NamedTuple):
+    display: str
+    clinical_status: str
+    coding: list[CodingEntry]
+    corresponding_note_problem: str | None
+
+    def to_condition(self) -> Condition:
+        return Condition(
+            display=self.display,
+            clinical_status=self.clinical_status,
+            coding=self.coding,
+            corresponding_note_problem=self.corresponding_note_problem,
+        )
+
+
+def _to_view(condition: Condition) -> _ConditionView:
+    return _ConditionView(
+        display=condition.display,
+        clinical_status=condition.clinical_status,
+        coding=list(condition.coding),
+        corresponding_note_problem=condition.corresponding_note_problem,
+    )

--- a/tests/hyperscribe/scribe/api/test_session_view.py
+++ b/tests/hyperscribe/scribe/api/test_session_view.py
@@ -1073,6 +1073,172 @@ def test_match_conditions_no_conditions() -> None:
     assert result == {}
 
 
+# --- _load_active_patient_conditions ---
+
+
+def _stub_condition_queryset(mock_condition: MagicMock, conditions: list[Any]) -> None:
+    """Wire a mocked ConditionModel so its active/for_patient/prefetch/order_by
+    chain returns the given list of condition rows. Keeps the test bodies
+    focused on the assertion rather than mock plumbing."""
+    chain = mock_condition.objects.active.return_value.for_patient.return_value
+    chain.prefetch_related.return_value.order_by.return_value = conditions
+
+
+@patch("hyperscribe.scribe.api.session_view.ConditionModel")
+def test_load_active_patient_conditions_returns_icd10_coding(mock_condition: MagicMock) -> None:
+    """The helper picks the ICD-10 coding when both ICD-10 and SNOMED are
+    present on an active condition. The frontend belt matches on ICD-10, so
+    the hint must carry the same system."""
+    from hyperscribe.scribe.api.session_view import _load_active_patient_conditions
+
+    cond = MagicMock()
+    cond.id = "active-uuid-1"
+    cond.clinical_status = "active"
+    icd_coding = MagicMock(system="ICD-10", code="E1165", display="Type 2 DM w/ hyperglycemia")
+    snomed_coding = MagicMock(system="http://snomed.info/sct", code="44054006", display="DM type 2")
+    cond.codings.all.return_value = [snomed_coding, icd_coding]
+    _stub_condition_queryset(mock_condition, [cond])
+
+    result = _load_active_patient_conditions("patient-key-1")
+
+    assert len(result) == 1
+    assert result[0].condition_id == "active-uuid-1"
+    assert result[0].code == "E1165"
+    assert result[0].display == "Type 2 DM w/ hyperglycemia"
+
+
+@patch("hyperscribe.scribe.api.session_view.ConditionModel")
+def test_load_active_patient_conditions_skips_conditions_with_no_codings(mock_condition: MagicMock) -> None:
+    """An active condition with no codings at all is skipped -- it has nothing
+    we can use as a hint. This mirrors the existing get_patient_conditions
+    endpoint's behavior."""
+    from hyperscribe.scribe.api.session_view import _load_active_patient_conditions
+
+    cond_no_codings = MagicMock()
+    cond_no_codings.id = "active-uuid-1"
+    cond_no_codings.clinical_status = "active"
+    cond_no_codings.codings.all.return_value = []
+    _stub_condition_queryset(mock_condition, [cond_no_codings])
+
+    result = _load_active_patient_conditions("patient-key-1")
+
+    assert result == []
+
+
+@patch("hyperscribe.scribe.api.session_view.ConditionModel")
+def test_load_active_patient_conditions_falls_back_to_first_coding_when_no_icd10(
+    mock_condition: MagicMock,
+) -> None:
+    """When only SNOMED is present (no ICD-10), we still return the entry but
+    with the SNOMED code. The downstream matcher will filter it out (its rule
+    requires same 3-char ICD-10 root) -- but we don't drop it here, to mirror
+    the existing get_patient_conditions endpoint exactly."""
+    from hyperscribe.scribe.api.session_view import _load_active_patient_conditions
+
+    cond = MagicMock()
+    cond.id = "active-uuid-1"
+    cond.clinical_status = "active"
+    snomed_coding = MagicMock(system="http://snomed.info/sct", code="44054006", display="DM type 2")
+    cond.codings.all.return_value = [snomed_coding]
+    _stub_condition_queryset(mock_condition, [cond])
+
+    result = _load_active_patient_conditions("patient-key-1")
+
+    assert len(result) == 1
+    assert result[0].code == "44054006"
+    assert result[0].display == "DM type 2"
+
+
+@patch("hyperscribe.scribe.api.session_view.ConditionModel")
+def test_load_active_patient_conditions_empty_patient_id(mock_condition: MagicMock) -> None:
+    """An empty patient_id returns empty without touching the ORM. This is
+    the post_generate_summary defensive path -- some callers (e.g. ad-hoc
+    flows) may not have a patient_id in the request body."""
+    from hyperscribe.scribe.api.session_view import _load_active_patient_conditions
+
+    result = _load_active_patient_conditions("")
+
+    assert result == []
+    mock_condition.objects.active.assert_not_called()
+
+
+@patch("hyperscribe.scribe.api.session_view.ConditionModel")
+def test_load_active_patient_conditions_carries_system(mock_condition: MagicMock) -> None:
+    """The ``system`` field on the chosen coding rides along on the result.
+
+    ``get_patient_conditions`` (the public endpoint the frontend's belt
+    fetches against) shapes the response with a ``system`` key, so the
+    helper must thread it through. Without this guard a refactor dropping
+    ``system`` from the dataclass would silently strip the field from the
+    endpoint's JSON shape."""
+    from hyperscribe.scribe.api.session_view import _load_active_patient_conditions
+
+    cond = MagicMock()
+    cond.id = "active-uuid-1"
+    cond.clinical_status = "active"
+    icd_coding = MagicMock(system="ICD-10", code="E1165", display="Type 2 DM")
+    cond.codings.all.return_value = [icd_coding]
+    _stub_condition_queryset(mock_condition, [cond])
+
+    result = _load_active_patient_conditions("patient-key-1")
+
+    assert result[0].system == "ICD-10"
+
+
+# --- /patient-conditions ---
+
+
+@patch("hyperscribe.scribe.api.session_view._load_active_patient_conditions")
+def test_get_patient_conditions_uses_shared_loader(mock_load: MagicMock) -> None:
+    """The ``/patient-conditions`` endpoint and ``post_generate_summary`` must
+    fetch the patient's active problem list through the same helper, so a
+    schema change can't be visible to one and invisible to the other.
+
+    This test pins the wiring: it stubs ``_load_active_patient_conditions``
+    and asserts the endpoint's JSON shape matches the previous response
+    (``condition_id``, ``code``, ``formatted_code``, ``display``, ``system``).
+    A regression that bypassed the helper would have to also bypass this
+    assertion to ship."""
+    from hyperscribe.scribe.commands.problem_list_match import ActivePatientCondition
+
+    mock_load.return_value = [
+        ActivePatientCondition(
+            condition_id="active-1",
+            code="E1165",
+            display="Type 2 DM w/ hyperglycemia",
+            system="ICD-10",
+        )
+    ]
+
+    view = _helper_instance()
+    view.request = SimpleNamespace(query_params={"patient_id": "patient-key-1"}, headers={}, body=b"")
+    result = view.get_patient_conditions()
+
+    assert result[0].status_code == HTTPStatus.OK
+    data = json.loads(result[0].content)
+    assert data["conditions"] == [
+        {
+            "condition_id": "active-1",
+            "code": "E1165",
+            "formatted_code": "E11.65",
+            "display": "Type 2 DM w/ hyperglycemia",
+            "system": "ICD-10",
+        }
+    ]
+    mock_load.assert_called_once_with("patient-key-1")
+
+
+def test_get_patient_conditions_missing_patient_id() -> None:
+    """Without ``patient_id`` the endpoint returns 400 -- preserved from the
+    pre-refactor implementation."""
+    view = _helper_instance()
+    view.request = SimpleNamespace(query_params={}, headers={}, body=b"")
+    result = view.get_patient_conditions()
+
+    assert result[0].status_code == HTTPStatus.BAD_REQUEST
+    assert "patient_id is required" in json.loads(result[0].content)["error"]
+
+
 # --- /extract-commands ---
 
 
@@ -3006,6 +3172,173 @@ def test_generate_summary_success(
     assert data["recommendations"][0]["command_type"] == "medication_statement"
     # Summary should be saved to database.
     mock_summary.objects.update_or_create.assert_called_once()
+
+
+@patch("hyperscribe.scribe.contacts.resolve_zip_codes", return_value=[])
+@patch("hyperscribe.scribe.api.session_view.annotate_duplicates")
+@patch("hyperscribe.scribe.api.session_view.suggest_diagnoses")
+@patch("hyperscribe.scribe.api.session_view.recommend_commands")
+@patch("hyperscribe.scribe.api.session_view.ScribeSummary")
+@patch("hyperscribe.scribe.api.session_view.ScribeTranscript")
+@patch("hyperscribe.scribe.api.session_view.Note")
+@patch("hyperscribe.scribe.api.session_view._load_active_patient_conditions")
+@patch("hyperscribe.scribe.api.session_view.get_cache")
+@patch("hyperscribe.scribe.api.session_view.get_backend_from_secrets")
+def test_generate_summary_prefers_patient_specific_icd10_over_nabla_parent(
+    get_backend: MagicMock,
+    mock_get_cache: MagicMock,
+    mock_load_active: MagicMock,
+    mock_note: MagicMock,
+    mock_transcript: MagicMock,
+    mock_summary: MagicMock,
+    mock_recommend: MagicMock,
+    mock_suggest: MagicMock,
+    _mock_annotate: MagicMock,
+    _mock_zip: MagicMock,
+) -> None:
+    """KOALA-5603: when Nabla emits an unspecified-parent ICD-10 (E11.9) but
+    the patient has a more specific active condition (E11.65) on the problem
+    list, the diagnose command surfaced in the summary must carry the
+    patient's specific code -- so the frontend's diagnose -> assess belt
+    can convert it to an assess linked to the existing condition_id.
+
+    This pins the load-bearing wiring: post_generate_summary must call
+    _load_active_patient_conditions and feed the result through the
+    problem-list-match helper between generate_normalized_data and
+    _match_conditions_to_sections."""
+    from hyperscribe.scribe.commands.problem_list_match import ActivePatientCondition
+
+    cache = _mock_cache()
+    mock_get_cache.return_value = cache
+    mock_note.objects.values_list.return_value.get.return_value = 55
+    mock_transcript.objects.filter.return_value.values.return_value.first.return_value = {
+        "items": [{"text": "discuss diabetes", "speaker": "patient", "start_offset_ms": 0, "end_offset_ms": 2000}],
+        "finalized": True,
+    }
+
+    mock_backend = MagicMock()
+    mock_backend.generate_note.return_value = ClinicalNote(
+        title="SOAP Note",
+        sections=[
+            NoteSection(
+                key="assessment_and_plan",
+                title="A&P",
+                text="Type 2 diabetes\n- Continue metformin",
+            ),
+        ],
+    )
+    # Nabla emits the unspecified parent code.
+    mock_backend.generate_normalized_data.return_value = NormalizedData(
+        conditions=[
+            Condition(
+                display="Type 2 diabetes mellitus without complications",
+                clinical_status="active",
+                coding=[CodingEntry(system="ICD-10", code="E11.9", display="Type 2 DM unspecified")],
+            )
+        ],
+        observations=[],
+    )
+    mock_backend._last_raw_note_response = None
+    get_backend.return_value = mock_backend
+
+    # Patient has E11.65 (the more specific code) on the active problem list.
+    mock_load_active.return_value = [
+        ActivePatientCondition(
+            condition_id="active-condition-uuid",
+            code="E1165",
+            display="Type 2 diabetes mellitus with hyperglycemia",
+        )
+    ]
+
+    mock_recommend.return_value = []
+    mock_suggest.return_value = {}
+
+    view = _helper_instance()
+    view.secrets["AnthropicAPIKey"] = "test-key"
+    view.request = SimpleNamespace(body=json.dumps({"note_id": "55", "note_uuid": "55", "patient_id": "patient-key-1"}))
+    result = view.post_generate_summary()
+
+    assert result[0].status_code == HTTPStatus.OK
+    data = json.loads(result[0].content)
+    diagnose_cmds = [c for c in data["commands"] if c["command_type"] == "diagnose"]
+    assert len(diagnose_cmds) == 1, "Expected exactly one diagnose command from the A&P split."
+    # The Nabla-emitted E11.9 must have been rewritten to the patient-specific E11.65
+    # so the frontend belt can match against the active condition and convert to assess.
+    assert diagnose_cmds[0]["data"]["icd10_code"] == "E1165", (
+        "Expected the diagnose command to carry the patient-specific E11.65 code, "
+        f"got {diagnose_cmds[0]['data']['icd10_code']!r}. The Nabla E11.9 parent code "
+        "should have been rewritten before the A&P split picked it up."
+    )
+
+    # _load_active_patient_conditions must be called with the patient_id from the request,
+    # not the note_id or any other identifier.
+    mock_load_active.assert_called_once_with("patient-key-1")
+
+
+@patch("hyperscribe.scribe.contacts.resolve_zip_codes", return_value=[])
+@patch("hyperscribe.scribe.api.session_view.annotate_duplicates")
+@patch("hyperscribe.scribe.api.session_view.suggest_diagnoses")
+@patch("hyperscribe.scribe.api.session_view.recommend_commands")
+@patch("hyperscribe.scribe.api.session_view.ScribeSummary")
+@patch("hyperscribe.scribe.api.session_view.ScribeTranscript")
+@patch("hyperscribe.scribe.api.session_view.Note")
+@patch("hyperscribe.scribe.api.session_view._load_active_patient_conditions")
+@patch("hyperscribe.scribe.api.session_view.get_cache")
+@patch("hyperscribe.scribe.api.session_view.get_backend_from_secrets")
+def test_generate_summary_empty_active_problem_list_leaves_nabla_code_intact(
+    get_backend: MagicMock,
+    mock_get_cache: MagicMock,
+    mock_load_active: MagicMock,
+    mock_note: MagicMock,
+    mock_transcript: MagicMock,
+    mock_summary: MagicMock,
+    mock_recommend: MagicMock,
+    mock_suggest: MagicMock,
+    _mock_annotate: MagicMock,
+    _mock_zip: MagicMock,
+) -> None:
+    """Regression guard: a patient with an empty active problem list still
+    gets Nabla's best-guess code. This is the "new patient, no history" path
+    and must not regress -- previously Nabla's code went through untouched."""
+    cache = _mock_cache()
+    mock_get_cache.return_value = cache
+    mock_note.objects.values_list.return_value.get.return_value = 55
+    mock_transcript.objects.filter.return_value.values.return_value.first.return_value = {
+        "items": [{"text": "headache", "speaker": "patient", "start_offset_ms": 0, "end_offset_ms": 1000}],
+        "finalized": True,
+    }
+
+    mock_backend = MagicMock()
+    mock_backend.generate_note.return_value = ClinicalNote(
+        title="Note",
+        sections=[NoteSection(key="assessment_and_plan", title="A&P", text="Headache\n- Rest")],
+    )
+    mock_backend.generate_normalized_data.return_value = NormalizedData(
+        conditions=[
+            Condition(
+                display="Headache",
+                clinical_status="active",
+                coding=[CodingEntry(system="ICD-10", code="R51", display="Headache")],
+            )
+        ],
+        observations=[],
+    )
+    mock_backend._last_raw_note_response = None
+    get_backend.return_value = mock_backend
+    mock_load_active.return_value = []
+    mock_recommend.return_value = []
+    mock_suggest.return_value = {}
+
+    view = _helper_instance()
+    view.secrets["AnthropicAPIKey"] = "test-key"
+    view.request = SimpleNamespace(body=json.dumps({"note_id": "55", "note_uuid": "55", "patient_id": "patient-key-1"}))
+    result = view.post_generate_summary()
+
+    assert result[0].status_code == HTTPStatus.OK
+    data = json.loads(result[0].content)
+    diagnose_cmds = [c for c in data["commands"] if c["command_type"] == "diagnose"]
+    assert len(diagnose_cmds) == 1
+    assert diagnose_cmds[0]["data"]["icd10_code"] == "R51"
 
 
 @patch("hyperscribe.scribe.contacts.resolve_zip_codes", return_value=[])

--- a/tests/hyperscribe/scribe/commands/test_problem_list_match.py
+++ b/tests/hyperscribe/scribe/commands/test_problem_list_match.py
@@ -1,0 +1,420 @@
+"""Tests for problem-list-aware code refinement in Scribe normalization output.
+
+Background (KOALA-5603): Nabla's ``/generate-normalized-data`` endpoint
+sometimes emits the unspecified parent code (e.g. ``E11.9`` Type 2 DM without
+complications) when the patient already has a more specific active condition
+on file (e.g. ``E11.65`` Type 2 DM with hyperglycemia). The frontend's existing
+diagnose -> assess "belt" only converts when the diagnose's ICD-10 matches a
+patient's active condition *exactly*, so the unspecified-parent code from Nabla
+slips through as a stand-alone diagnose. Provider must then manually swap.
+
+The helper under test, ``prefer_patient_specific_codes``, post-processes the
+``NormalizedData.conditions`` list by rewriting any Nabla coding whose ICD-10
+code is the unspecified-parent of a more specific active condition on the
+patient's problem list. The frontend belt then sees the specific code and
+performs the diagnose -> assess conversion automatically.
+
+Algorithm constraint: only rewrite when Nabla's code is LESS specific than
+the patient's. This is conservative on purpose -- if Nabla emits a specific
+code that doesn't match the patient's (e.g. patient has E11.65, provider
+dictates ophthalmic complications, Nabla emits E11.36), we leave Nabla's
+code alone; that's a genuinely different sub-condition, not a less-specific
+parent.
+
+PHI: this module receives clinical condition data. The helper itself returns
+data; the caller is responsible for never logging condition codes or display
+strings beyond aggregate counts.
+"""
+
+from __future__ import annotations
+
+from hyperscribe.scribe.backend.models import CodingEntry, Condition
+from hyperscribe.scribe.commands.problem_list_match import (
+    ActivePatientCondition,
+    icd10_normalize,
+    icd10_is_unspecified_parent_of,
+    prefer_patient_specific_codes,
+)
+
+
+# --- icd10_normalize ---
+
+
+def test_icd10_normalize_removes_dot_and_uppercases() -> None:
+    """A dotted lowercase ICD-10 string normalises to the dotless uppercase form
+    we use as the comparison key throughout this module."""
+    assert icd10_normalize("e11.65") == "E1165"
+
+
+def test_icd10_normalize_already_dotless() -> None:
+    """An already-dotless code is preserved (only case is normalised)."""
+    assert icd10_normalize("e1165") == "E1165"
+
+
+def test_icd10_normalize_strips_surrounding_whitespace() -> None:
+    """Whitespace from carriage returns / pasted text is stripped."""
+    assert icd10_normalize("  E11.65 ") == "E1165"
+
+
+def test_icd10_normalize_empty_string() -> None:
+    """An empty input produces an empty output (no crash)."""
+    assert icd10_normalize("") == ""
+
+
+# --- icd10_is_unspecified_parent_of ---
+
+
+def test_unspecified_parent_e119_vs_e1165() -> None:
+    """E11.9 (unspecified Type 2 DM) IS an unspecified parent of E11.65
+    (Type 2 DM with hyperglycemia). This is the ticket's named case."""
+    assert icd10_is_unspecified_parent_of("E11.9", "E11.65") is True
+
+
+def test_unspecified_parent_dotless_codes() -> None:
+    """Comparison works on dotless codes too -- inputs are normalised first."""
+    assert icd10_is_unspecified_parent_of("E119", "E1165") is True
+
+
+def test_unspecified_parent_different_family_rejected() -> None:
+    """E11.9 (DM family) is NOT a parent of I10 (hypertension family)."""
+    assert icd10_is_unspecified_parent_of("E11.9", "I10") is False
+
+
+def test_unspecified_parent_specific_code_not_parent_of_specific() -> None:
+    """E11.36 (DM w/ ophthalmic complications) is NOT a parent of E11.65
+    (DM w/ hyperglycemia). Both are specific, sibling codes."""
+    assert icd10_is_unspecified_parent_of("E11.36", "E11.65") is False
+
+
+def test_unspecified_parent_same_code_rejected() -> None:
+    """An identical code is not its own parent -- nothing to rewrite."""
+    assert icd10_is_unspecified_parent_of("E11.65", "E11.65") is False
+
+
+def test_unspecified_parent_root_only_e11() -> None:
+    """A 3-char root code (e.g. E11 with no sub-classification) is the
+    parent of any specific code in the family."""
+    assert icd10_is_unspecified_parent_of("E11", "E11.65") is True
+
+
+def test_unspecified_parent_z9989_unspecified_z_code() -> None:
+    """Z99.89 (other dependence on enabling machines) ending in .89 is NOT
+    treated as 'unspecified' -- only .9 / .9X / single-3-char-root qualify.
+
+    Why this test exists: the algorithm cares about Nabla's tendency to emit
+    .9 (the unspecified bucket within a 3-char family). Other endings carry
+    their own clinical meaning and must not be rewritten."""
+    assert icd10_is_unspecified_parent_of("Z99.89", "Z99.81") is False
+
+
+def test_unspecified_parent_e119_vs_e11_root_rejected() -> None:
+    """E11.9 is not 'more specific' than E11, so don't claim it as a parent
+    of E11 itself. This rule prevents rewriting a Nabla E11.9 down to a
+    patient-stored bare E11 (which would be a LOSS of specificity)."""
+    assert icd10_is_unspecified_parent_of("E11.9", "E11") is False
+
+
+# --- prefer_patient_specific_codes ---
+
+
+def _icd(code: str, display: str = "") -> CodingEntry:
+    return CodingEntry(system="ICD-10", code=code, display=display)
+
+
+def _condition(code: str, display: str = "") -> Condition:
+    return Condition(
+        display=display or f"Condition {code}",
+        clinical_status="active",
+        coding=[_icd(code, display)],
+    )
+
+
+def _active(code: str, condition_id: str = "active-1", display: str = "") -> ActivePatientCondition:
+    return ActivePatientCondition(
+        condition_id=condition_id,
+        code=code,
+        display=display or f"Active {code}",
+    )
+
+
+def test_prefer_codes_rewrites_unspecified_parent_to_specific() -> None:
+    """Ticket happy path: Nabla emitted E11.9 (unspecified DM), patient has
+    E11.65 on the active problem list. The Nabla coding is rewritten to
+    E11.65 so the frontend belt converts the diagnose to an assess linked
+    to the existing condition."""
+    nabla_conditions = [_condition("E11.9", "Type 2 diabetes mellitus without complications")]
+    active = [_active("E11.65", "active-uuid-1", "Type 2 diabetes with hyperglycemia")]
+
+    result = prefer_patient_specific_codes(nabla_conditions, active)
+
+    assert len(result) == 1
+    assert len(result[0].coding) == 1
+    assert result[0].coding[0].code == "E11.65"
+    assert result[0].coding[0].display == "Type 2 diabetes with hyperglycemia"
+
+
+def test_prefer_codes_no_rewrite_when_nabla_specific_and_different() -> None:
+    """Nabla emits E11.36 (DM w/ ophthalmic complications), patient has E11.65
+    (DM w/ hyperglycemia) -- these are sibling specific codes, not parent/
+    child. No rewrite: Nabla's code is the correct clinical answer."""
+    nabla_conditions = [_condition("E11.36", "Type 2 diabetes w/ ophthalmic complications")]
+    active = [_active("E11.65", "active-uuid-1", "Type 2 diabetes w/ hyperglycemia")]
+
+    result = prefer_patient_specific_codes(nabla_conditions, active)
+
+    assert result[0].coding[0].code == "E11.36"
+
+
+def test_prefer_codes_no_rewrite_when_already_exact_match() -> None:
+    """If Nabla already emitted the exact code on the active list, leave it
+    alone -- the frontend belt handles diagnose -> assess from there."""
+    nabla_conditions = [_condition("E11.65", "Type 2 DM w/ hyperglycemia")]
+    active = [_active("E11.65", "active-uuid-1", "Type 2 DM w/ hyperglycemia")]
+
+    result = prefer_patient_specific_codes(nabla_conditions, active)
+
+    assert result[0].coding[0].code == "E11.65"
+
+
+def test_prefer_codes_no_rewrite_when_no_family_match() -> None:
+    """Nabla emits I10 (hypertension unspecified), patient only has E11.65
+    (DM). No family overlap -- leave Nabla's code alone."""
+    nabla_conditions = [_condition("I10", "Essential hypertension")]
+    active = [_active("E11.65", "active-uuid-1", "Type 2 DM w/ hyperglycemia")]
+
+    result = prefer_patient_specific_codes(nabla_conditions, active)
+
+    assert result[0].coding[0].code == "I10"
+
+
+def test_prefer_codes_empty_active_list_returns_input_unchanged() -> None:
+    """Patient has no active conditions -- nothing to prefer. Input passes
+    through unchanged. Regression guard for the empty-problem-list path."""
+    nabla_conditions = [_condition("E11.9", "Type 2 DM unspecified")]
+
+    result = prefer_patient_specific_codes(nabla_conditions, [])
+
+    assert result is nabla_conditions or result[0].coding[0].code == "E11.9"
+
+
+def test_prefer_codes_empty_nabla_conditions_returns_empty() -> None:
+    """No Nabla conditions -- nothing to rewrite, result is empty.
+    Regression guard for the silent-Nabla-response path."""
+    active = [_active("E11.65", "active-uuid-1")]
+
+    result = prefer_patient_specific_codes([], active)
+
+    assert result == []
+
+
+def test_prefer_codes_only_touches_icd10_codings() -> None:
+    """A Nabla condition can carry multiple codings (ICD-10 + SNOMED, etc.).
+    We only inspect/rewrite the ICD-10 coding; SNOMED and other systems are
+    left alone."""
+    nabla_conditions = [
+        Condition(
+            display="Type 2 diabetes",
+            clinical_status="active",
+            coding=[
+                _icd("E11.9", "Type 2 DM unspecified"),
+                CodingEntry(system="SNOMED", code="44054006", display="Diabetes mellitus type 2"),
+            ],
+        )
+    ]
+    active = [_active("E11.65", "active-uuid-1", "Type 2 DM w/ hyperglycemia")]
+
+    result = prefer_patient_specific_codes(nabla_conditions, active)
+
+    icd_codings = [c for c in result[0].coding if c.system == "ICD-10"]
+    snomed_codings = [c for c in result[0].coding if c.system == "SNOMED"]
+    assert icd_codings[0].code == "E11.65"
+    assert snomed_codings[0].code == "44054006"
+    assert snomed_codings[0].display == "Diabetes mellitus type 2"
+
+
+def test_prefer_codes_multiple_patient_matches_picks_first_deterministically() -> None:
+    """Patient has TWO active conditions in the same family (E11.65 AND E11.21),
+    Nabla emits E11.9. The helper picks the first match deterministically --
+    we do NOT silently pick at random. The ticket scope doesn't require
+    sophisticated tie-breaking; document the first-wins rule and move on."""
+    nabla_conditions = [_condition("E11.9", "Type 2 DM unspecified")]
+    active = [
+        _active("E11.65", "active-uuid-1", "Type 2 DM w/ hyperglycemia"),
+        _active("E11.21", "active-uuid-2", "Type 2 DM w/ nephropathy"),
+    ]
+
+    result = prefer_patient_specific_codes(nabla_conditions, active)
+
+    # First active condition in the family wins. Test pins this so a refactor
+    # changing the order doesn't silently swap which code lands in the chart.
+    assert result[0].coding[0].code == "E11.65"
+
+
+def test_prefer_codes_active_condition_non_icd10_system_ignored() -> None:
+    """An active condition coded only in SNOMED (no ICD-10) cannot be used
+    as a hint -- the frontend belt matches on ICD-10. Treat it as if the
+    condition were not on the active list for hint purposes."""
+    nabla_conditions = [_condition("E11.9", "Type 2 DM unspecified")]
+    active = [
+        ActivePatientCondition(
+            condition_id="active-uuid-1",
+            code="",  # No ICD-10 code on this active condition
+            display="Diabetes mellitus type 2",
+        )
+    ]
+
+    result = prefer_patient_specific_codes(nabla_conditions, active)
+
+    assert result[0].coding[0].code == "E11.9"
+
+
+def test_prefer_codes_preserves_condition_display_and_clinical_status() -> None:
+    """Rewriting the coding must not lose the parent Condition's display or
+    clinical_status -- those drive the section-matching logic downstream."""
+    nabla_conditions = [
+        Condition(
+            display="Type 2 diabetes",
+            clinical_status="active",
+            coding=[_icd("E11.9", "Type 2 DM unspecified")],
+            corresponding_note_problem="Diabetes",
+        )
+    ]
+    active = [_active("E11.65", "active-uuid-1", "Type 2 DM w/ hyperglycemia")]
+
+    result = prefer_patient_specific_codes(nabla_conditions, active)
+
+    assert result[0].display == "Type 2 diabetes"
+    assert result[0].clinical_status == "active"
+    assert result[0].corresponding_note_problem == "Diabetes"
+
+
+def test_prefer_codes_does_not_mutate_input_list() -> None:
+    """Pure function: the input list and its Condition objects must not be
+    mutated. A caller relying on the original Nabla output for telemetry
+    (raw response cached separately) shouldn't be surprised."""
+    original = _condition("E11.9", "Type 2 DM unspecified")
+    nabla_conditions = [original]
+    active = [_active("E11.65", "active-uuid-1", "Type 2 DM w/ hyperglycemia")]
+
+    prefer_patient_specific_codes(nabla_conditions, active)
+
+    assert original.coding[0].code == "E11.9"
+    assert original.coding[0].display == "Type 2 DM unspecified"
+
+
+# --- DB-backed: _load_active_patient_conditions against the real ORM ---
+
+
+def test_load_active_patient_conditions_real_orm_picks_icd10_active() -> None:
+    """Integration: an active condition with both ICD-10 and SNOMED codings
+    resolves through the real ORM to an ``ActivePatientCondition`` carrying
+    the ICD-10 code.
+
+    Why this matters: every other test for ``_load_active_patient_conditions``
+    mocks ``ConditionModel.objects``. A typo in the filter chain
+    (``.active().for_patient().prefetch_related().order_by()``) would pass
+    those mocks but fail in production. This test pins the chain against
+    a factory-backed real DB row.
+
+    Also verifies the patient-scope filter (``for_patient``) actually
+    rejects a condition on a *different* patient -- a HIPAA-relevant guard.
+    """
+    import datetime
+
+    from canvas_sdk.test_utils import factories
+    from canvas_sdk.v1.data.condition import Condition, ConditionCoding
+
+    from hyperscribe.scribe.api.session_view import _load_active_patient_conditions
+
+    patient_target = factories.PatientFactory.create()
+    patient_other = factories.PatientFactory.create()
+    user = factories.CanvasUserFactory.create()
+
+    target_condition = Condition.objects.create(
+        patient=patient_target,
+        deleted=False,
+        onset_date=datetime.date(2024, 6, 1),
+        resolution_date=datetime.date(2099, 12, 31),
+        clinical_status="active",
+        surgical=False,
+        committer=user,
+    )
+    # SNOMED first, ICD-10 second -- the helper must still pick the ICD-10
+    # coding regardless of insertion order.
+    ConditionCoding.objects.create(
+        condition=target_condition,
+        system="http://snomed.info/sct",
+        code="44054006",
+        display="Diabetes mellitus type 2",
+    )
+    ConditionCoding.objects.create(
+        condition=target_condition,
+        system="ICD-10",
+        code="E1165",
+        display="Type 2 diabetes mellitus with hyperglycemia",
+    )
+
+    # A condition on a different patient -- must not appear in the result.
+    other_condition = Condition.objects.create(
+        patient=patient_other,
+        deleted=False,
+        onset_date=datetime.date(2023, 1, 1),
+        resolution_date=datetime.date(2099, 12, 31),
+        clinical_status="active",
+        surgical=False,
+        committer=user,
+    )
+    ConditionCoding.objects.create(
+        condition=other_condition,
+        system="ICD-10",
+        code="I10",
+        display="Essential hypertension",
+    )
+
+    result = _load_active_patient_conditions(patient_target.id)
+
+    assert len(result) == 1, (
+        "Expected exactly one entry for the target patient -- "
+        "the other patient's condition must be filtered out by for_patient()."
+    )
+    assert result[0].condition_id == str(target_condition.id)
+    assert result[0].code == "E1165"
+    assert result[0].display == "Type 2 diabetes mellitus with hyperglycemia"
+
+
+def test_load_active_patient_conditions_real_orm_excludes_resolved() -> None:
+    """Integration: a resolved condition (clinical_status != "active") is
+    excluded by the ``.active()`` queryset chain.
+
+    Without this guard, a patient whose Type 2 DM was resolved would still
+    get their old E11.65 used as a hint to rewrite the next encounter's
+    Nabla code -- which would be a clinical regression."""
+    import datetime
+
+    from canvas_sdk.test_utils import factories
+    from canvas_sdk.v1.data.condition import Condition, ConditionCoding
+
+    from hyperscribe.scribe.api.session_view import _load_active_patient_conditions
+
+    patient = factories.PatientFactory.create()
+    user = factories.CanvasUserFactory.create()
+
+    resolved = Condition.objects.create(
+        patient=patient,
+        deleted=False,
+        onset_date=datetime.date(2020, 1, 1),
+        resolution_date=datetime.date(2023, 12, 31),
+        clinical_status="resolved",
+        surgical=False,
+        committer=user,
+    )
+    ConditionCoding.objects.create(
+        condition=resolved,
+        system="ICD-10",
+        code="E1165",
+        display="Type 2 diabetes mellitus with hyperglycemia",
+    )
+
+    result = _load_active_patient_conditions(patient.id)
+
+    assert result == [], "Resolved conditions must not be returned by the active() chain."


### PR DESCRIPTION
[KOALA-5603](https://canvasmedical.atlassian.net/browse/KOALA-5603)

## Feature

When Nabla's normalized output emits an ICD-10 unspecified parent (e.g. `E11.9` "Type 2 diabetes mellitus without complications") for a condition where the patient already has a more specific active child on file (e.g. `E11.65` "Type 2 DM with hyperglycemia"), Scribe now rewrites Nabla's coding to the patient-specific code before the frontend's diagnose → assess belt runs. The belt requires an exact ICD-10 string match against the active problem list, so the unspecified parent currently falls through that belt and surfaces as a stand-alone Diagnose suggestion the provider has to manually swap. Post-rewrite the assess card lands directly on the existing problem-list row.

## Implementation

A new pure module `hyperscribe/scribe/commands/problem_list_match.py` exposes `prefer_patient_specific_codes(nabla_conditions, active_conditions)`. The "unspecified-parent-of" predicate accepts (a) the bare 3-char root (`E11`) or (b) the root followed by `9` / `9N` (`E11.9`, `E11.90`); `.89` tails are deliberately not treated as unspecified since those carry distinct clinical meaning. Same 3-char family and a strictly-longer child are required, so siblings (`E11.9` vs `E11.36`) are not collapsed.

The hook lands in `post_generate_summary` step 1 between Nabla's response and `_match_conditions_to_sections`; `_load_active_patient_conditions` is shared with `GET /patient-conditions` so the rewrite hint and the frontend belt can never drift apart. Non-ICD codings on the same condition pass through untouched. Inputs and `Condition` / `CodingEntry` instances are never mutated; new objects are constructed only when a rewrite actually fires. `ActivePatientCondition` and the internal `_ConditionView` use `typing.NamedTuple` rather than `@dataclass` because the plugin-runner sandbox can't evaluate `@dataclass` at module-load time.

[KOALA-5603]: https://canvasmedical.atlassian.net/browse/KOALA-5603?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ