### PR TITLE
scribe: add Alert Facility toggle to prescribe/refill/adjust orders

### DIFF
--- a/hyperscribe/scribe/commands/adjust_prescription.py
+++ b/hyperscribe/scribe/commands/adjust_prescription.py
@@ -10,10 +10,10 @@ from canvas_sdk.commands.constants import ClinicalQuantity
 from canvas_sdk.effects import Effect
 from canvas_sdk.v1.data.note import Note
 
-from hyperscribe.scribe.commands.base import CommandParser
+from hyperscribe.scribe.commands.base import AlertFacilityMetadataMixin, CommandParser
 
 
-class AdjustPrescriptionParser(CommandParser):
+class AdjustPrescriptionParser(AlertFacilityMetadataMixin, CommandParser):
     """Parser for adjust prescription commands — uses AdjustPrescriptionCommand."""
 
     command_type = "adjust_prescription"

--- a/hyperscribe/scribe/commands/base.py
+++ b/hyperscribe/scribe/commands/base.py
@@ -91,3 +91,31 @@ class CommandParser(ABC):
     def build_stub(self, command_uuid: str, note_uuid: str) -> _BaseCommand:
         """Build a minimal command for phase 2 metadata operations."""
         raise NotImplementedError
+
+
+class AlertFacilityMetadataMixin:
+    """Emit the ``alert_facility`` command metadata when the feature flag is on.
+
+    Mix in *before* ``CommandParser`` so this ``pending_metadata`` overrides the
+    base no-op. When ``AlertFacilityEnabled`` is set, the command always carries
+    the metadata ("Yes" when the user toggled it, "No" otherwise); when the flag
+    is off, no metadata is emitted.
+    """
+
+    command_type: str
+
+    def pending_metadata(
+        self,
+        command: _BaseCommand,
+        proposal: dict[str, Any] | None = None,
+        feature_flags: dict[str, bool] | None = None,
+    ) -> dict[str, Any] | None:
+        if not (feature_flags or {}).get("AlertFacilityEnabled"):
+            return None
+        truthy = bool(proposal and proposal.get("data", {}).get("alert_facility"))
+        return {
+            "command_uuid": command.command_uuid,
+            "command_type": self.command_type,
+            "note_uuid": command.note_uuid,
+            "metadata": {"alert_facility": "Yes" if truthy else "No"},
+        }

--- a/hyperscribe/scribe/commands/medication_statement.py
+++ b/hyperscribe/scribe/commands/medication_statement.py
@@ -10,7 +10,7 @@ from canvas_sdk.v1.data.medication import MedicationCoding
 from canvas_sdk.v1.data.note import Note
 
 from hyperscribe.scribe.backend.models import CommandProposal
-from hyperscribe.scribe.commands.base import CommandParser
+from hyperscribe.scribe.commands.base import AlertFacilityMetadataMixin, CommandParser
 
 _BULLET_RE = re.compile(r"^(?:\d+[.)]\s*|[-*]\s+)")
 
@@ -33,7 +33,7 @@ def _unstructured_coding(medication_text: str) -> dict[str, str]:
     }
 
 
-class MedicationParser(CommandParser):
+class MedicationParser(AlertFacilityMetadataMixin, CommandParser):
     command_type = "medication_statement"
 
     def extract(self, text: str) -> CommandProposal | None:
@@ -115,22 +115,6 @@ class MedicationParser(CommandParser):
             note_uuid=note_uuid,
             command_uuid=command_uuid,
         )
-
-    def pending_metadata(
-        self,
-        command: _BaseCommand,
-        proposal: dict[str, Any] | None = None,
-        feature_flags: dict[str, bool] | None = None,
-    ) -> dict[str, Any] | None:
-        if not (feature_flags or {}).get("AlertFacilityEnabled"):
-            return None
-        truthy = bool(proposal and proposal.get("data", {}).get("alert_facility"))
-        return {
-            "command_uuid": command.command_uuid,
-            "command_type": self.command_type,
-            "note_uuid": command.note_uuid,
-            "metadata": {"alert_facility": "Yes" if truthy else "No"},
-        }
 
     def build_stub(self, command_uuid: str, note_uuid: str) -> _BaseCommand:
         return MedicationStatementCommand(command_uuid=command_uuid, note_uuid=note_uuid)

--- a/hyperscribe/scribe/commands/prescription.py
+++ b/hyperscribe/scribe/commands/prescription.py
@@ -9,10 +9,10 @@ from canvas_sdk.commands.constants import ClinicalQuantity
 from canvas_sdk.effects import Effect
 from canvas_sdk.v1.data.note import Note
 
-from hyperscribe.scribe.commands.base import CommandParser
+from hyperscribe.scribe.commands.base import AlertFacilityMetadataMixin, CommandParser
 
 
-class PrescriptionParser(CommandParser):
+class PrescriptionParser(AlertFacilityMetadataMixin, CommandParser):
     command_type = "prescribe"
     data_field = None
 

--- a/hyperscribe/scribe/commands/refill.py
+++ b/hyperscribe/scribe/commands/refill.py
@@ -10,10 +10,10 @@ from canvas_sdk.commands.constants import ClinicalQuantity
 from canvas_sdk.effects import Effect
 from canvas_sdk.v1.data.note import Note
 
-from hyperscribe.scribe.commands.base import CommandParser
+from hyperscribe.scribe.commands.base import AlertFacilityMetadataMixin, CommandParser
 
 
-class RefillParser(CommandParser):
+class RefillParser(AlertFacilityMetadataMixin, CommandParser):
     """Parser for refill commands — uses RefillCommand (validates FDB against active meds)."""
 
     command_type = "refill"

--- a/hyperscribe/scribe/commands/stop_medication.py
+++ b/hyperscribe/scribe/commands/stop_medication.py
@@ -5,10 +5,10 @@ from typing import Any
 from canvas_sdk.commands.base import _BaseCommand
 from canvas_sdk.commands.commands.stop_medication import StopMedicationCommand
 
-from hyperscribe.scribe.commands.base import CommandParser
+from hyperscribe.scribe.commands.base import AlertFacilityMetadataMixin, CommandParser
 
 
-class StopMedicationParser(CommandParser):
+class StopMedicationParser(AlertFacilityMetadataMixin, CommandParser):
     """Parser for stop medication commands created by the frontend."""
 
     command_type = "stop_medication"
@@ -30,22 +30,6 @@ class StopMedicationParser(CommandParser):
             note_uuid=note_uuid,
             command_uuid=command_uuid,
         )
-
-    def pending_metadata(
-        self,
-        command: _BaseCommand,
-        proposal: dict[str, Any] | None = None,
-        feature_flags: dict[str, bool] | None = None,
-    ) -> dict[str, Any] | None:
-        if not (feature_flags or {}).get("AlertFacilityEnabled"):
-            return None
-        truthy = bool(proposal and proposal.get("data", {}).get("alert_facility"))
-        return {
-            "command_uuid": command.command_uuid,
-            "command_type": self.command_type,
-            "note_uuid": command.note_uuid,
-            "metadata": {"alert_facility": "Yes" if truthy else "No"},
-        }
 
     def build_stub(self, command_uuid: str, note_uuid: str) -> _BaseCommand:
         return StopMedicationCommand(command_uuid=command_uuid, note_uuid=note_uuid)

--- a/hyperscribe/scribe/static/medication-row.js
+++ b/hyperscribe/scribe/static/medication-row.js
@@ -224,7 +224,7 @@ export function MedicationRow({ command, commandIndex, onEdit, onDelete, readOnl
       <div class="order-view">
         <div class="order-view-name">${command.display}</div>
         ${command.data.sig && html`<div class="order-view-sig">${command.data.sig}</div>`}
-        ${alertFacilityEnabled && command.data.alert_facility && html`<span class="badge badge-alert">Alert Facility</span>`}
+        ${alertFacilityEnabled && command.data.alert_facility && html`<span class="badge-alert">Alert Facility</span>`}
       </div>
     </div>
   `;

--- a/hyperscribe/scribe/static/order-row.js
+++ b/hyperscribe/scribe/static/order-row.js
@@ -278,7 +278,7 @@ function InteractionWarningInline({ warning }) {
   `;
 }
 
-export function OrderRow({ command, commandIndex, onEdit, onDelete, readOnly, patientId, noteId, staffId, staffName, isRecommendation, onEditingChange }) {
+export function OrderRow({ command, commandIndex, onEdit, onDelete, readOnly, patientId, noteId, staffId, staffName, isRecommendation, alertFacilityEnabled, onEditingChange }) {
   const isNew = !command.display;
   const [editing, setEditing] = useState(isNew);
   useEffect(() => {
@@ -294,6 +294,7 @@ export function OrderRow({ command, commandIndex, onEdit, onDelete, readOnly, pa
     medQuery: '', selectedFdb: null, selectedMedDisplay: '', medQuantities: buildTypeToDispenseOptions([]),
     sig: '', daysSupply: '', quantity: '', typeToDispense: '', refills: '',
     substitutions: true, noteToPharmacist: '', interactionWarning: null, selectedPharmacy: '', pharmacyQuery: '',
+    alertFacility: false,
   });
 
   // Rx state
@@ -310,6 +311,7 @@ export function OrderRow({ command, commandIndex, onEdit, onDelete, readOnly, pa
   const [typeToDispense, setTypeToDispense] = useState(command.data.type_to_dispense || '');
   const [refills, setRefills] = useState(command.data.refills != null ? String(command.data.refills) : '');
   const [substitutions, setSubstitutions] = useState(command.data.substitutions !== 'not_allowed');
+  const [alertFacility, setAlertFacility] = useState(!!command.data.alert_facility);
   const [noteToPharmacist, setNoteToPharmacist] = useState(command.data.note_to_pharmacist || '');
   const [selectedPharmacy, setSelectedPharmacy] = useState(command.data.pharmacy || '');
   const [pharmacyQuery, setPharmacyQuery] = useState(command.data.pharmacy_name || '');
@@ -358,6 +360,7 @@ export function OrderRow({ command, commandIndex, onEdit, onDelete, readOnly, pa
     medQuery, selectedFdb, selectedMedDisplay, medQuantities,
     sig, daysSupply, quantity, typeToDispense, refills,
     substitutions, noteToPharmacist, interactionWarning, selectedPharmacy, pharmacyQuery,
+    alertFacility,
   });
 
   const restoreRxSnapshot = (snap) => {
@@ -371,6 +374,7 @@ export function OrderRow({ command, commandIndex, onEdit, onDelete, readOnly, pa
     setTypeToDispense(snap.typeToDispense);
     setRefills(snap.refills);
     setSubstitutions(snap.substitutions);
+    setAlertFacility(snap.alertFacility);
     setNoteToPharmacist(snap.noteToPharmacist);
     setSelectedPharmacy(snap.selectedPharmacy);
     setPharmacyQuery(snap.pharmacyQuery);
@@ -1074,6 +1078,7 @@ export function OrderRow({ command, commandIndex, onEdit, onDelete, readOnly, pa
         note_to_pharmacist: noteToPharmacist || null,
         pharmacy: selectedPharmacy || null,
         pharmacy_name: selectedPharmacy ? pharmacyQuery : null,
+        alert_facility: alertFacility,
         quantities: medQuantities.map(q => ({ representative_ndc: q.representative_ndc, ncpdp_quantity_qualifier_code: q.ncpdp_quantity_qualifier_code, clinical_quantity_description: q.label, quantity: 1 })),
       };
       // Include "change to" medication for adjust_prescription.
@@ -1303,6 +1308,16 @@ export function OrderRow({ command, commandIndex, onEdit, onDelete, readOnly, pa
                     <button type="button" class="task-quick-btn${!substitutions ? ' active' : ''}" onClick=${() => setSubstitutions(false)}>Not Allowed</button>
                   </div>
                 </div>
+                ${alertFacilityEnabled && html`
+                <div class="history-form-field">
+                  <label class="alert-facility-toggle" onClick=${() => setAlertFacility(prev => !prev)}>
+                    <div class="toggle-switch${alertFacility ? ' on' : ''}">
+                      <div class="toggle-knob" />
+                    </div>
+                    Alert Facility
+                  </label>
+                </div>
+                `}
               </div>
             `;})()}
             ${REFILL_TABS.has(activeTab) && !selectedFdb && html`
@@ -1700,6 +1715,7 @@ export function OrderRow({ command, commandIndex, onEdit, onDelete, readOnly, pa
             <div class="order-view-name">${command.display}</div>
             ${d.sig && html`<div class="order-view-sig">Sig: ${d.sig}</div>`}
             ${detailParts.length > 0 && html`<div class="order-view-details">${detailParts.join(' · ')}</div>`}
+            ${alertFacilityEnabled && d.alert_facility && html`<span class="badge-alert">Alert Facility</span>`}
           </div>
         </div>
         ${interactionWarning && html`<${InteractionWarningInline} warning=${interactionWarning} />`}
@@ -1747,6 +1763,7 @@ export function OrderRow({ command, commandIndex, onEdit, onDelete, readOnly, pa
       <div class="order-view">
         <span class="command-type-label">${badgeLabel}</span>
         <div class="order-view-name">${command.display}</div>
+        ${alertFacilityEnabled && command.data.alert_facility && html`<span class="badge-alert">Alert Facility</span>`}
       </div>
     </div>
   `;

--- a/hyperscribe/scribe/static/soap-group.js
+++ b/hyperscribe/scribe/static/soap-group.js
@@ -289,9 +289,9 @@ function RemovalRow({ command, commandIndex, onEdit, onDelete, readOnly, patient
       <span class="removal-action-label">${config.actionLabel}</span>
       <span class="removal-item-name">${itemName}</span>
       ${type === 'stop_medication' && readOnly && (data.rationale || data.alert_facility) && html`
-        <div style="font-size: 13px; color: #6b7280; margin-top: 2px;">
+        <div style="display: flex; align-items: center; gap: 6px; font-size: 13px; color: #6b7280; margin-top: 2px;">
           ${data.rationale || ''}
-          ${alertFacilityEnabled && data.alert_facility && html`<span class="badge badge-alert" style="margin-left: 6px;">Alert Facility</span>`}
+          ${alertFacilityEnabled && data.alert_facility && html`<span class="badge-alert">Alert Facility</span>`}
         </div>
       `}
     </div>
@@ -1419,6 +1419,7 @@ export function SoapGroup({ title, groupColor, sections, commandBySectionKey, on
                     noteId=${noteId}
                     staffId=${staffId}
                     staffName=${staffName}
+                    alertFacilityEnabled=${alertFacilityEnabled}
                     onEditingChange=${onEditingChange}
                   />
                 </div>
@@ -1654,6 +1655,7 @@ export function SoapGroup({ title, groupColor, sections, commandBySectionKey, on
                       staffId=${staffId}
                       staffName=${staffName}
                       isRecommendation=${true}
+                      alertFacilityEnabled=${alertFacilityEnabled}
                       onEditingChange=${onEditingChange}
                     />
                   </div>
@@ -1713,6 +1715,7 @@ export function SoapGroup({ title, groupColor, sections, commandBySectionKey, on
                       staffId=${staffId}
                       staffName=${staffName}
                       isRecommendation=${true}
+                      alertFacilityEnabled=${alertFacilityEnabled}
                       onEditingChange=${onEditingChange}
                     />
                   </div>

--- a/hyperscribe/scribe/static/styles.css
+++ b/hyperscribe/scribe/static/styles.css
@@ -771,6 +771,9 @@ h2 { margin-bottom: 4px; }
 .allergy-severity-badge.severity-moderate { background: #fff3e0; color: #e65100; }
 .allergy-severity-badge.severity-severe { background: #fce4ec; color: #c62828; }
 
+/* "Alert Facility" pill, shown on read-view command rows when the flag is set. */
+.badge-alert { align-self: flex-start; font-size: 12px; font-weight: 600; padding: 3px 10px; border-radius: 12px; background: #fef3c7; color: #92400e; white-space: nowrap; flex-shrink: 0; }
+
 /* Task rows */
 .task-row { display: flex; align-items: center; gap: 8px; padding: 4px; border-radius: 8px; cursor: pointer; }
 .task-row.editing { flex-direction: column; align-items: stretch; cursor: default; }

--- a/tests/hyperscribe/scribe/commands/test_adjust_prescription.py
+++ b/tests/hyperscribe/scribe/commands/test_adjust_prescription.py
@@ -70,3 +70,42 @@ def test_to_effects_returns_originate_and_review() -> None:
     assert len(effects) == 2
     command.originate.assert_called_once()
     command.review.assert_called_once()
+
+
+def _make_command() -> MagicMock:
+    cmd = MagicMock()
+    cmd.command_uuid = "00000000-0000-0000-0000-0000000000c1"
+    cmd.note_uuid = "00000000-0000-0000-0000-0000000000cc"
+    return cmd
+
+
+def test_pending_metadata_flag_off_returns_none() -> None:
+    cmd = _make_command()
+    proposal = {"data": {"alert_facility": True}}
+    assert AdjustPrescriptionParser().pending_metadata(cmd, proposal, feature_flags={}) is None
+    assert AdjustPrescriptionParser().pending_metadata(cmd, proposal, feature_flags=None) is None
+    assert AdjustPrescriptionParser().pending_metadata(cmd, proposal, feature_flags={"AlertFacilityEnabled": False}) is None
+
+
+def test_pending_metadata_flag_on_alert_truthy_returns_yes() -> None:
+    cmd = _make_command()
+    proposal = {"data": {"alert_facility": True}}
+    result = AdjustPrescriptionParser().pending_metadata(cmd, proposal, feature_flags={"AlertFacilityEnabled": True})
+    assert result == {
+        "command_uuid": cmd.command_uuid,
+        "command_type": "adjust_prescription",
+        "note_uuid": cmd.note_uuid,
+        "metadata": {"alert_facility": "Yes"},
+    }
+
+
+def test_pending_metadata_flag_on_alert_falsy_defaults_to_no() -> None:
+    cmd = _make_command()
+    for proposal in (
+        {"data": {"alert_facility": False}},
+        {"data": {}},
+        None,
+    ):
+        result = AdjustPrescriptionParser().pending_metadata(cmd, proposal, feature_flags={"AlertFacilityEnabled": True})
+        assert result is not None
+        assert result["metadata"] == {"alert_facility": "No"}

--- a/tests/hyperscribe/scribe/commands/test_prescription.py
+++ b/tests/hyperscribe/scribe/commands/test_prescription.py
@@ -118,3 +118,42 @@ def test_build_invalid_quantity_ignored() -> None:
         parser.build(data, "note-uuid", "cmd-uuid")
 
     assert mock_cmd.call_args.kwargs["quantity_to_dispense"] is None
+
+
+def _make_command() -> MagicMock:
+    cmd = MagicMock()
+    cmd.command_uuid = "00000000-0000-0000-0000-0000000000a1"
+    cmd.note_uuid = "00000000-0000-0000-0000-0000000000aa"
+    return cmd
+
+
+def test_pending_metadata_flag_off_returns_none() -> None:
+    cmd = _make_command()
+    proposal = {"data": {"alert_facility": True}}
+    assert PrescriptionParser().pending_metadata(cmd, proposal, feature_flags={}) is None
+    assert PrescriptionParser().pending_metadata(cmd, proposal, feature_flags=None) is None
+    assert PrescriptionParser().pending_metadata(cmd, proposal, feature_flags={"AlertFacilityEnabled": False}) is None
+
+
+def test_pending_metadata_flag_on_alert_truthy_returns_yes() -> None:
+    cmd = _make_command()
+    proposal = {"data": {"alert_facility": True}}
+    result = PrescriptionParser().pending_metadata(cmd, proposal, feature_flags={"AlertFacilityEnabled": True})
+    assert result == {
+        "command_uuid": cmd.command_uuid,
+        "command_type": "prescribe",
+        "note_uuid": cmd.note_uuid,
+        "metadata": {"alert_facility": "Yes"},
+    }
+
+
+def test_pending_metadata_flag_on_alert_falsy_defaults_to_no() -> None:
+    cmd = _make_command()
+    for proposal in (
+        {"data": {"alert_facility": False}},
+        {"data": {}},
+        None,
+    ):
+        result = PrescriptionParser().pending_metadata(cmd, proposal, feature_flags={"AlertFacilityEnabled": True})
+        assert result is not None
+        assert result["metadata"] == {"alert_facility": "No"}

--- a/tests/hyperscribe/scribe/commands/test_refill.py
+++ b/tests/hyperscribe/scribe/commands/test_refill.py
@@ -1,0 +1,98 @@
+from unittest.mock import MagicMock, patch
+
+from hyperscribe.scribe.commands.refill import RefillParser
+
+
+def test_extract_returns_none() -> None:
+    parser = RefillParser()
+    assert parser.extract("some text") is None
+
+
+def test_extract_all_returns_empty() -> None:
+    parser = RefillParser()
+    assert parser.extract_all("some text") == []
+
+
+def test_command_type() -> None:
+    assert RefillParser().command_type == "refill"
+
+
+def test_data_field_is_none() -> None:
+    assert RefillParser().data_field is None
+
+
+def test_build_with_all_fields() -> None:
+    parser = RefillParser()
+    data = {
+        "fdb_code": "285665",
+        "sig": "Take 1 tablet daily",
+        "days_supply": 30,
+        "quantity_to_dispense": 30,
+        "refills": 2,
+        "substitutions": "allowed",
+    }
+    with patch("hyperscribe.scribe.commands.refill.RefillCommand") as mock_cmd:
+        mock_cmd.return_value = MagicMock()
+        with patch("hyperscribe.scribe.commands.refill.PrescribeCommand") as mock_prescribe:
+            mock_prescribe.Substitutions.ALLOWED = "ALLOWED"
+            mock_prescribe.Substitutions.NOT_ALLOWED = "NOT_ALLOWED"
+            with patch.object(parser, "_resolve_prescriber", return_value="provider-123"):
+                parser.build(data, "note-uuid", "cmd-uuid")
+
+    mock_cmd.assert_called_once()
+    call_kwargs = mock_cmd.call_args.kwargs
+    assert call_kwargs["fdb_code"] == "285665"
+    assert call_kwargs["sig"] == "Take 1 tablet daily"
+    assert call_kwargs["note_uuid"] == "note-uuid"
+
+
+def test_to_effects_returns_originate_and_review() -> None:
+    parser = RefillParser()
+    command = MagicMock()
+    command.originate.return_value = MagicMock()
+    command.review.return_value = MagicMock()
+
+    effects = parser.to_effects(command)
+
+    assert len(effects) == 2
+    command.originate.assert_called_once()
+    command.review.assert_called_once()
+
+
+def _make_command() -> MagicMock:
+    cmd = MagicMock()
+    cmd.command_uuid = "00000000-0000-0000-0000-0000000000d1"
+    cmd.note_uuid = "00000000-0000-0000-0000-0000000000dd"
+    return cmd
+
+
+def test_pending_metadata_flag_off_returns_none() -> None:
+    cmd = _make_command()
+    proposal = {"data": {"alert_facility": True}}
+    assert RefillParser().pending_metadata(cmd, proposal, feature_flags={}) is None
+    assert RefillParser().pending_metadata(cmd, proposal, feature_flags=None) is None
+    assert RefillParser().pending_metadata(cmd, proposal, feature_flags={"AlertFacilityEnabled": False}) is None
+
+
+def test_pending_metadata_flag_on_alert_truthy_returns_yes() -> None:
+    cmd = _make_command()
+    proposal = {"data": {"alert_facility": True}}
+    result = RefillParser().pending_metadata(cmd, proposal, feature_flags={"AlertFacilityEnabled": True})
+    assert result == {
+        "command_uuid": cmd.command_uuid,
+        "command_type": "refill",
+        "note_uuid": cmd.note_uuid,
+        "metadata": {"alert_facility": "Yes"},
+    }
+
+
+def test_pending_metadata_flag_on_alert_falsy_defaults_to_no() -> None:
+    cmd = _make_command()
+    for proposal in (
+        {"data": {"alert_facility": False}},
+        {"data": {}},
+        None,
+    ):
+        result = RefillParser().pending_metadata(cmd, proposal, feature_flags={"AlertFacilityEnabled": True})
+        assert result is not None
+        assert result["metadata"] == {"alert_facility": "No"}


### PR DESCRIPTION
Ticket: https://canvasmedical.atlassian.net/browse/KOALA-5474

Extends the `AlertFacilityEnabled`-gated "Alert Facility" toggle — previously only on `medication_statement` and `stop_medication` — to the `prescribe`, `refill`, and `adjust_prescription` order commands.

## Backend
- Extracted the shared `pending_metadata` logic into `AlertFacilityMetadataMixin` (`commands/base.py`) and mixed it into all five parsers (`medication_statement`, `stop_medication`, `prescribe`, `refill`, `adjust_prescription`). The builder's metadata-emission loop is generic, so no builder changes were needed.

## Frontend
- `order-row.js`: thread `alertFacilityEnabled` through `OrderRow`, add the toggle to the prescribe/refill/adjust edit form, persist `alert_facility` in command data (including the per-tab Rx snapshots), and render the read-view badge.
- `soap-group.js`: pass `alertFacilityEnabled` to all `OrderRow` render sites.
- Defined a `.badge-alert` pill style and removed the previously-undefined `badge` class from all four read-view usages; normalized the stop-medication badge spacing to use flex `gap` instead of an inline margin.

## Behavior
- Feature remains fully gated by the `AlertFacilityEnabled` secret; no UI or metadata when the flag is off.
- Toggle defaults to off; an untouched toggle records `alert_facility: "No"` when the flag is on, consistent with the existing medication behavior.

## Tests
- Added `pending_metadata` tests for the prescribe and adjust parsers, and a new `test_refill.py` (the refill parser previously had no tests). Full scribe suite passes.
