### PR TITLE
scribe: rebuild vitals from Nabla observations with validated fallback

### DIFF
--- a/hyperscribe/scribe/api/session_view.py
+++ b/hyperscribe/scribe/api/session_view.py
@@ -44,6 +44,7 @@ from hyperscribe.scribe.backend import (
     CodingEntry,
     Condition,
     NoteSection,
+    Observation,
     PatientContext,
     ScribeError,
     Transcript,
@@ -65,7 +66,11 @@ from hyperscribe.scribe.commands.builder import (
     validate_proposals,
 )
 from hyperscribe.scribe.commands.carry_forward import carry_forward_assess_background
-from hyperscribe.scribe.commands.extractor import extract_commands, parse_ros_subsections
+from hyperscribe.scribe.commands.extractor import (
+    extract_commands,
+    extract_vitals_with_telemetry,
+    parse_ros_subsections,
+)
 from hyperscribe.scribe.commands.problem_list_match import (
     ActivePatientCondition,
     prefer_patient_specific_codes,
@@ -932,6 +937,8 @@ class ScribeSessionView(StaffSessionAuthMixin, SimpleAPI):
         # ── Step 1: Generate normalized data ──
         _save_progress(note_id, 1, total, SUMMARY_STEPS[1])
         section_conditions: dict[str, list[dict[str, Any]]] = {}
+        normalized_observations: list[Observation] = []
+        note_uuid = str(data.get("note_uuid", ""))
         try:
             normalized = backend.generate_normalized_data(note)
             # KOALA-5603: prefer the patient's specific active-problem-list code
@@ -946,13 +953,46 @@ class ScribeSessionView(StaffSessionAuthMixin, SimpleAPI):
                 active_conditions,
             )
             section_conditions = _match_conditions_to_sections(note, normalized.conditions)
+            normalized_observations = normalized.observations
         except Exception:
             log.exception("generate_normalized_data failed (non-critical)")
+            # Surface the upstream failure to prod observability without leaking
+            # PHI: payload carries only the step identifier so we can
+            # distinguish "Nabla returned no observations" (silent path
+            # divergence) from "Nabla call raised" (outage / rate limit /
+            # credential issue).
+            if note_uuid:
+                audit_event(note_uuid, "NORMALIZED_DATA_FAILED", {"step": "normalized"})
 
         # ── Step 2: Extract commands + A&P split ──
         _save_progress(note_id, 2, total, SUMMARY_STEPS[2])
-        note_uuid = str(data.get("note_uuid", ""))
-        proposals = extract_commands(note)
+        # Emit vitals telemetry from a single extraction pass:
+        #  * VITALS_SOURCE — which parser populated the proposal
+        #    (observations / regex / both / none). Classifies off the FINAL
+        #    surviving fields so a fully-refused observation panel doesn't
+        #    inflate the observations side of the metric.
+        #  * VITALS_FIELD_REFUSED — fields the parser dropped during
+        #    validation (out_of_range / ambiguous_unit / atomic_bp_partial).
+        #    Only emitted when refusals are non-empty: silent on the happy
+        #    path so the audit log stays signal-dense.
+        # No values, no PHI — just field names + reason categories.
+        if note_uuid:
+            vitals_telemetry = extract_vitals_with_telemetry(note, normalized_observations)
+            audit_event(
+                note_uuid,
+                "VITALS_SOURCE",
+                {"source": vitals_telemetry.source},
+            )
+            if vitals_telemetry.refusals:
+                audit_event(
+                    note_uuid,
+                    "VITALS_FIELD_REFUSED",
+                    {
+                        "refused_fields": [r.field for r in vitals_telemetry.refusals],
+                        "reasons": [r.reason for r in vitals_telemetry.refusals],
+                    },
+                )
+        proposals = extract_commands(note, observations=normalized_observations)
         annotate_duplicates(proposals, note_uuid)
         prefill_assess_backgrounds_for_proposals(proposals, note_uuid)
         commands_list: list[dict[str, Any]] = [

--- a/hyperscribe/scribe/commands/_rx_validation.py
+++ b/hyperscribe/scribe/commands/_rx_validation.py
@@ -25,9 +25,11 @@ front-end, and makes the failure debuggable from the audit log.
 This module is intentionally framework-agnostic: pure functions that take a
 ``data`` dict and return a list of human-readable error strings.
 """
+
 from __future__ import annotations
 
 import re
+
 # NOTE: only ``Decimal`` is imported here. The Canvas plugin sandbox allowlists
 # ``Decimal`` from ``decimal`` but rejects ``InvalidOperation`` — importing it
 # raises ``ImportError`` at plugin-load time and de-registers every handler
@@ -58,9 +60,7 @@ def _has_value(value: Any) -> bool:
     return True
 
 
-def _validate_required_string(
-    data: dict[str, Any], field: str, label: str, errors: list[str]
-) -> None:
+def _validate_required_string(data: dict[str, Any], field: str, label: str, errors: list[str]) -> None:
     if not _has_value(data.get(field)):
         errors.append(f"{label} is required")
 
@@ -151,10 +151,7 @@ def _validate_sig(value: Any, errors: list[str]) -> None:
     if len(text) > SIG_MAX_LENGTH:
         errors.append(f"Sig exceeds {SIG_MAX_LENGTH} characters")
     if _RE_INVALID_CHARACTERS.search(text):
-        errors.append(
-            "Sig contains characters not allowed by Surescripts "
-            "(remove newlines, tabs, and non-ASCII)"
-        )
+        errors.append("Sig contains characters not allowed by Surescripts (remove newlines, tabs, and non-ASCII)")
 
 
 def _validate_note_to_pharmacist(value: Any, errors: list[str]) -> None:
@@ -163,13 +160,10 @@ def _validate_note_to_pharmacist(value: Any, errors: list[str]) -> None:
         return
     text = str(value)
     if len(text) > NOTE_TO_PHARMACIST_MAX_LENGTH:
-        errors.append(
-            f"Note to pharmacist exceeds {NOTE_TO_PHARMACIST_MAX_LENGTH} characters"
-        )
+        errors.append(f"Note to pharmacist exceeds {NOTE_TO_PHARMACIST_MAX_LENGTH} characters")
     if _RE_INVALID_CHARACTERS.search(text):
         errors.append(
-            "Note to pharmacist contains characters not allowed by Surescripts "
-            "(remove newlines, tabs, and non-ASCII)"
+            "Note to pharmacist contains characters not allowed by Surescripts (remove newlines, tabs, and non-ASCII)"
         )
 
 
@@ -189,8 +183,7 @@ def _validate_optional_change_medication_to(value: Any, errors: list[str]) -> No
         return
     if value.strip() == "":
         errors.append(
-            "New medication code is empty — leave it unset to keep the existing "
-            "medication, or pick a replacement"
+            "New medication code is empty — leave it unset to keep the existing medication, or pick a replacement"
         )
 
 

--- a/hyperscribe/scribe/commands/adjust_prescription.py
+++ b/hyperscribe/scribe/commands/adjust_prescription.py
@@ -51,9 +51,7 @@ class AdjustPrescriptionParser(CommandParser):
         if not fdb_code:
             return errors
         try:
-            patient_id = (
-                Note.objects.values_list("patient__id", flat=True).get(id=note_uuid)
-            )
+            patient_id = Note.objects.values_list("patient__id", flat=True).get(id=note_uuid)
         except Note.DoesNotExist:
             errors.append("Note not found; cannot verify the source medication")
             return errors

--- a/hyperscribe/scribe/commands/extractor.py
+++ b/hyperscribe/scribe/commands/extractor.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
-from hyperscribe.scribe.backend.models import ClinicalNote, CommandProposal
+from hyperscribe.scribe.backend.models import ClinicalNote, CommandProposal, Observation
 from hyperscribe.scribe.commands.base import CommandParser
 from hyperscribe.scribe.commands.hpi import HpiParser
 from hyperscribe.scribe.commands.plan import PlanParser
 from hyperscribe.scribe.commands.rfv import RfvParser
-from hyperscribe.scribe.commands.vitals import VitalsParser
+from hyperscribe.scribe.commands.vitals import VitalsExtractionResult, VitalsParser
+
+_VITALS_PARSER = VitalsParser()
 
 _SECTION_PARSERS: dict[str, CommandParser] = {
     "chief_complaint": RfvParser(),
@@ -13,7 +15,7 @@ _SECTION_PARSERS: dict[str, CommandParser] = {
     "plan": PlanParser(),
     "assessment_and_plan": PlanParser(),
     "appointments": PlanParser(),
-    "vitals": VitalsParser(),
+    "vitals": _VITALS_PARSER,
 }
 
 _CHART_REVIEW_KEYS: frozenset[str] = frozenset(
@@ -200,10 +202,85 @@ def _extract_image_results(note: ClinicalNote) -> CommandProposal | None:
     )
 
 
-def extract_commands(note: ClinicalNote) -> list[CommandProposal]:
-    """Map ClinicalNote sections to CommandProposal list (deterministic, no LLM)."""
+def _extract_vitals(note: ClinicalNote, observations: list[Observation]) -> CommandProposal | None:
+    """Extract vitals from the note's vitals section plus Nabla's structured observations.
+
+    Observations are preferred (LOINC-coded, unit-aware); the free-text regex on the
+    vitals section is used as a fallback for fields the observations didn't cover.
+    Emits a proposal when *either* source yields data — covers the case where Nabla
+    populated observations but emitted no vitals section text, and vice versa.
+    """
+    result = extract_vitals_with_telemetry(note, observations)
+    return result.proposal
+
+
+def extract_vitals_with_telemetry(
+    note: ClinicalNote,
+    observations: list[Observation],
+) -> VitalsExtractionResult:
+    """Run the vitals extraction and return the proposal plus audit metadata.
+
+    Wraps ``VitalsParser.extract_with_telemetry`` and tags the proposal with
+    ``section_key="vitals"`` so callers can use the proposal directly.
+    Returns the canonical ``source`` label derived from the FINAL surviving
+    fields (not raw inputs) — this is the chokepoint
+    ``post_generate_summary`` uses to emit ``VITALS_SOURCE`` and
+    ``VITALS_FIELD_REFUSED`` from a single extraction pass.
+    """
+    vitals_section = next(
+        (s for s in note.sections if s.key.lower() == "vitals"),
+        None,
+    )
+    text = vitals_section.text.strip() if vitals_section is not None else ""
+    if not text and not observations:
+        return VitalsExtractionResult(proposal=None, refusals=[], source="none")
+    result = _VITALS_PARSER.extract_with_telemetry(text, observations)
+    if result.proposal is not None:
+        result.proposal.section_key = "vitals"
+    return result
+
+
+def classify_vitals_source(note: ClinicalNote, observations: list[Observation]) -> str:
+    """Return which parser populated the vitals proposal: ``observations``, ``regex``, ``both``, or ``none``.
+
+    Purely diagnostic. Used by the API layer to emit a ``VITALS_SOURCE`` audit
+    event so we can measure observation-vs-regex reliability in prod and
+    eventually retire the loser parser.
+
+    Classifies from the FINAL surviving fields of the proposal (not raw
+    inputs) so a fully-refused observation panel doesn't get counted as
+    ``observations`` in telemetry. Risk-hunter flagged the race:
+    pre-validation classification overstated the observation path's
+    reliability when Nabla emitted out-of-range BP and the per-field gate
+    plus atomic-pair sweep dropped both sides.
+    """
+    return extract_vitals_with_telemetry(note, observations).source
+
+
+def extract_commands(
+    note: ClinicalNote,
+    observations: list[Observation] | None = None,
+) -> list[CommandProposal]:
+    """Map ClinicalNote sections to CommandProposal list (deterministic, no LLM).
+
+    ``observations`` carries Nabla's normalized vital signs (LOINC-coded). Pass them
+    when available so the vitals parser can avoid format-drift bugs that plague the
+    regex over Nabla's free-text vitals string.
+    """
+    obs = observations or []
     proposals: list[CommandProposal] = []
+    # Track the insertion point for the vitals proposal so it lands in section order
+    # even though we route vitals through the observation-aware path below. We capture
+    # the position as we encounter the vitals section rather than recomputing it after
+    # the loop — this stays correct regardless of how many proposals each upstream
+    # parser emits per section (e.g. medication_statement / allergy override
+    # extract_all to emit multiple).
+    vitals_position: int | None = None
     for section in note.sections:
+        if section.key.lower() == "vitals":
+            if vitals_position is None:
+                vitals_position = len(proposals)
+            continue
         parser = _SECTION_PARSERS.get(section.key.lower())
         if parser is None:
             continue
@@ -213,6 +290,13 @@ def extract_commands(note: ClinicalNote) -> list[CommandProposal]:
         for proposal in parser.extract_all(text):
             proposal.section_key = section.key.lower()
             proposals.append(proposal)
+
+    vitals_proposal = _extract_vitals(note, obs)
+    if vitals_proposal is not None:
+        if vitals_position is None:
+            proposals.append(vitals_proposal)
+        else:
+            proposals.insert(vitals_position, vitals_proposal)
 
     ros_proposal = _extract_ros(note)
     if ros_proposal is not None:

--- a/hyperscribe/scribe/commands/refill.py
+++ b/hyperscribe/scribe/commands/refill.py
@@ -39,9 +39,7 @@ class RefillParser(CommandParser):
         if not fdb_code:
             return errors
         try:
-            patient_id = (
-                Note.objects.values_list("patient__id", flat=True).get(id=note_uuid)
-            )
+            patient_id = Note.objects.values_list("patient__id", flat=True).get(id=note_uuid)
         except Note.DoesNotExist:
             errors.append("Note not found; cannot verify the medication")
             return errors
@@ -55,8 +53,7 @@ class RefillParser(CommandParser):
             .exists()
         ):
             errors.append(
-                "The selected medication is not active on this patient — "
-                "refill requires an existing active medication"
+                "The selected medication is not active on this patient — refill requires an existing active medication"
             )
         return errors
 

--- a/hyperscribe/scribe/commands/vitals.py
+++ b/hyperscribe/scribe/commands/vitals.py
@@ -1,51 +1,500 @@
 from __future__ import annotations
 
 import re
-from typing import Any
+from typing import Any, NamedTuple
 
 from canvas_sdk.commands.base import _BaseCommand
 from canvas_sdk.commands.commands.vitals import VitalsCommand
 
-from hyperscribe.scribe.backend.models import CommandProposal
+from hyperscribe.scribe.backend.models import CommandProposal, Observation
 from hyperscribe.scribe.commands.base import CommandParser
 
 
-def _parse_vitals(text: str) -> dict[str, int | float | None]:
-    """Parse free-text vitals into structured fields."""
+# Refusal-reason categories. The category is reported via the
+# ``VITALS_FIELD_REFUSED`` audit event in ``post_generate_summary`` so we
+# can distinguish *why* a field was dropped (out-of-range vs ambiguous unit
+# vs partial BP) without leaking the value itself. Strategist-flagged: the
+# parser used to drop real-but-extreme clinical values silently; surfacing
+# the refusal lets ops/clinical teams notice when a clinician really did
+# observe HR=25 or SpO2=10 and the parser refused it.
+REFUSAL_REASON_OUT_OF_RANGE = "out_of_range"
+REFUSAL_REASON_AMBIGUOUS_UNIT = "ambiguous_unit"
+REFUSAL_REASON_ATOMIC_BP_PARTIAL = "atomic_bp_partial"
+
+
+class _Refusal(NamedTuple):
+    """A single field-refusal record. Field names + reason only — NO VALUES (PHI)."""
+
+    field: str
+    reason: str
+
+
+class VitalsExtractionResult(NamedTuple):
+    """Result of vitals extraction with telemetry data attached.
+
+    Returned by ``VitalsParser.extract_with_telemetry`` for callers that
+    need both the proposal AND audit metadata (refusals + provenance).
+    The plain ``extract_with_observations`` API stays available for callers
+    that only need the proposal.
+
+    ``source`` is one of ``"observations" | "regex" | "both" | "none"`` and
+    reflects the FINAL proposal's surviving fields, not the raw inputs.
+    Risk-hunter flagged: classifying off raw inputs marks the source as
+    ``observations`` even when Nabla's BP-panel was fully refused, which
+    inflates the telemetry signal for the observation path.
+    """
+
+    proposal: CommandProposal | None
+    refusals: list[_Refusal]
+    source: str
+
+
+# LOINC codes for the vitals fields VitalsCommand exposes.
+# Source: https://loinc.org/, cross-checked against the Nabla normalized-data API.
+_LOINC_BP_PANEL = "85354-9"  # Blood pressure panel — value is "systole/diastole".
+_LOINC_BP_SYSTOLE = "8480-6"
+_LOINC_BP_DIASTOLE = "8462-4"
+_LOINC_PULSE = "8867-4"
+_LOINC_RESP_RATE = "9279-1"
+_LOINC_O2_SAT = "2708-6"
+_LOINC_O2_SAT_PULSE_OX = "59408-5"  # SpO2 via pulse oximetry — Nabla sometimes uses this code.
+_LOINC_BODY_TEMP = "8310-5"
+_LOINC_HEIGHT = "8302-2"
+_LOINC_WEIGHT = "29463-7"
+
+# Codes whose value we treat as a single scalar to write into ``_FIELD``.
+# Iteration order is fixed (tuple) so behavior is deterministic when an
+# observation carries multiple mapped LOINC codes — the auditor + risk-hunter
+# both flagged the previous ``set`` iteration as non-deterministic.
+_LOINC_TO_FIELD: tuple[tuple[str, str], ...] = (
+    (_LOINC_BP_SYSTOLE, "blood_pressure_systole"),
+    (_LOINC_BP_DIASTOLE, "blood_pressure_diastole"),
+    (_LOINC_PULSE, "pulse"),
+    (_LOINC_RESP_RATE, "respiration_rate"),
+    (_LOINC_O2_SAT, "oxygen_saturation"),
+    (_LOINC_O2_SAT_PULSE_OX, "oxygen_saturation"),
+    (_LOINC_BODY_TEMP, "body_temperature"),
+    (_LOINC_HEIGHT, "height"),
+    (_LOINC_WEIGHT, "weight_lbs"),
+)
+
+# Fields whose numeric value is a float (the rest are ints).
+_FLOAT_FIELDS: frozenset[str] = frozenset({"body_temperature"})
+
+# Recognised unit synonyms. An unrecognised non-empty unit on a field with
+# ambiguous magnitudes (temp °C vs °F, weight kg vs lbs, height cm vs in)
+# triggers a range-based plausibility gate instead of a silent assumption.
+_CELSIUS_UNITS: frozenset[str] = frozenset({"c", "°c", "degc", "celsius", "deg c"})
+_FAHRENHEIT_UNITS: frozenset[str] = frozenset({"f", "°f", "degf", "fahrenheit", "deg f"})
+_KG_UNITS: frozenset[str] = frozenset({"kg", "kgs", "kilogram", "kilograms"})
+_LBS_UNITS: frozenset[str] = frozenset({"lb", "lbs", "pound", "pounds"})
+_CM_UNITS: frozenset[str] = frozenset({"cm", "centimeter", "centimeters"})
+_M_UNITS: frozenset[str] = frozenset({"m", "meter", "meters"})
+_IN_UNITS: frozenset[str] = frozenset({"in", "inch", "inches", '"'})
+
+# Plausible-value gates. A field is REFUSED (returned as None, not written)
+# when the parsed value falls outside this window. The clinical principle:
+# a missing field is recoverable on the next sync; a corrupted field that
+# silently propagates into the chart is not.
+#
+# The parser matches the Canvas SDK ``VitalsCommand`` pydantic bounds (see
+# ``canvas_sdk/commands/commands/vitals.py``) exactly. The SDK is the
+# canonical clinical floor/ceiling: anything outside its ``ge=``/``le=``
+# constraints triggers a 4xx from ``/insert-commands`` and the clinician
+# sees an opaque failure after hitting Approve. The parser refuses those
+# same values up front so we never round-trip data the SDK will reject.
+#
+# The UI edit-form spinbutton bounds in ``static/vitals-row.js`` may be
+# tighter than the SDK (a separate UX concern — e.g. the form may clamp
+# SpO2 to 60-100 while the SDK accepts 60-100; the UI ceilings can move
+# without recoding the parser). When the UI clamps tighter than the SDK,
+# the clinician edits the value back into range on the form — no data is
+# lost; only acutely-extreme clinical values that the SDK already accepts
+# go through this parser without UI intervention.
+#
+# Any future tightening here must stay >= the SDK floor and <= the SDK
+# ceiling, otherwise the parser starts refusing values the SDK would
+# accept. Loosening past the SDK constraints reintroduces the prod failure
+# mode this gate was added to stop.
+#
+# These bounds also reject the pathological cases the risk-hunter surfaced
+# (Kelvin temperatures, BP 999/999, pulse 9999, SpO2 200%, etc.).
+_FIELD_RANGES: dict[str, tuple[float, float]] = {
+    "blood_pressure_systole": (30, 305),
+    "blood_pressure_diastole": (20, 180),
+    "pulse": (30, 250),
+    "respiration_rate": (6, 60),
+    "oxygen_saturation": (60, 100),
+    "body_temperature": (85, 107),  # °F
+    "height": (10, 108),  # inches
+    "weight_lbs": (1, 1500),
+}
+
+# Plausibility windows for unit inference when the source unit is missing
+# or unrecognised. Used to disambiguate °C/°F (which have no value overlap
+# in normal clinical ranges so range-based inference is safe).
+_TEMP_C_WINDOW = (30.0, 45.0)
+_TEMP_F_WINDOW = (80.0, 115.0)
+
+# Empty-unit ambiguity bands for weight (kg vs lbs) and height (cm vs in).
+# Unlike temperature, the kg/lbs and cm/in ranges overlap in the middle of
+# the human distribution: a value of 70 with no unit could be 70 kg (155
+# lbs) or 70 lbs (32 kg child). The same applies to height: 65 could be
+# 65 inches (5'5") or 65 cm (infant). When we can't tell, we REFUSE rather
+# than silently guess — a missing field is recoverable on the next sync;
+# a corrupted weight/height that propagates into the chart is not.
+#
+# Bands are chosen at the edges of overlap:
+# - Weight 30-250: covers pediatric-adult kg AND adult lbs; refuse.
+#   Below 30 the value cannot plausibly be lbs (would be a newborn,
+#   which a typical scribe note context disambiguates); above 250 the
+#   value cannot plausibly be kg (no adult is 250 kg = 551 lbs).
+# - Height 30-80: covers adult cm AND tall adult inches; refuse.
+#   Below 30 the value cannot plausibly be inches (toddler range);
+#   above 80 the value cannot plausibly be cm (would be infant length).
+# Outside the bands we still apply the field range gate (_FIELD_RANGES)
+# so wildly out-of-range values stay rejected.
+_WEIGHT_AMBIGUOUS_BAND = (30.0, 250.0)
+_HEIGHT_AMBIGUOUS_BAND = (30.0, 80.0)
+
+
+def _normalize_unit(unit: str) -> str:
+    return unit.strip().lower()
+
+
+def _coerce_field_value(field: str, value: float) -> int | float:
+    """Coerce a numeric value to the type expected by VitalsCommand for ``field``."""
+    if field in _FLOAT_FIELDS:
+        return round(value, 1)
+    return int(round(value))
+
+
+def _record_refusal(refusals: list[_Refusal] | None, field: str, reason: str) -> None:
+    """Append a refusal record to ``refusals`` if a sink was provided.
+
+    The sink stays optional so existing callers (tests, internal helpers
+    that don't care about telemetry) keep their thin contract. Only
+    ``extract_with_telemetry`` threads a real list through.
+    """
+    if refusals is None:
+        return
+    # De-duplicate: a single field can be refused at most once per extraction.
+    # _apply_observation may walk multiple LOINC codes for the same field and
+    # also the regex/observation passes can both refuse; we want one entry
+    # per refused field.
+    for entry in refusals:
+        if entry.field == field:
+            return
+    refusals.append(_Refusal(field=field, reason=reason))
+
+
+def _validate_field(
+    field: str,
+    value: float,
+    refusals: list[_Refusal] | None = None,
+) -> int | float | None:
+    """Range-gate ``value`` for ``field``. Returns the coerced value or None when implausible.
+
+    Applied on BOTH the observation path and the regex path so a single discipline
+    governs all writes to VitalsCommand. The Council called out that
+    out-of-range BP/pulse/SpO2/etc. flow through both paths today; this is the
+    single chokepoint that stops it.
+
+    When ``refusals`` is provided, a refusal record is appended with reason
+    ``out_of_range`` so ``post_generate_summary`` can emit a
+    ``VITALS_FIELD_REFUSED`` audit event.
+    """
+    bounds = _FIELD_RANGES.get(field)
+    if bounds is None:
+        return _coerce_field_value(field, value)
+    low, high = bounds
+    if value < low or value > high:
+        _record_refusal(refusals, field, REFUSAL_REASON_OUT_OF_RANGE)
+        return None
+    return _coerce_field_value(field, value)
+
+
+def _convert_temperature_to_fahrenheit(
+    value: float,
+    unit: str,
+    *,
+    refusals: list[_Refusal] | None = None,
+) -> float | None:
+    """Convert ``value`` from any recognised temperature unit to °F.
+
+    When the unit is missing/unrecognised, fall back to a plausibility window:
+    a value in the °C range converts; a value in the °F range passes through;
+    anything outside both windows (e.g., Kelvin 310, garbage) is refused.
+    """
+    if unit in _CELSIUS_UNITS:
+        return value * 9.0 / 5.0 + 32.0
+    if unit in _FAHRENHEIT_UNITS:
+        return value
+    # Unit unknown — infer from magnitude.
+    if _TEMP_C_WINDOW[0] <= value <= _TEMP_C_WINDOW[1]:
+        return value * 9.0 / 5.0 + 32.0
+    if _TEMP_F_WINDOW[0] <= value <= _TEMP_F_WINDOW[1]:
+        return value
+    _record_refusal(refusals, "body_temperature", REFUSAL_REASON_AMBIGUOUS_UNIT)
+    return None
+
+
+def _convert_weight_to_lbs(
+    value: float,
+    unit: str,
+    *,
+    refusals: list[_Refusal] | None = None,
+) -> float | None:
+    """Convert ``value`` to lbs.
+
+    With an explicit unit, convert normally — this is the typical Nabla path.
+    With an empty/unrecognised unit, REFUSE values in the kg/lbs overlap band
+    (30-250) because we can't tell which scale the source intended. Accept
+    values outside the band as unambiguous lbs (the _FIELD_RANGES gate still
+    enforces the final plausibility window).
+    """
+    if unit in _KG_UNITS:
+        return value * 2.20462
+    if unit in _LBS_UNITS:
+        return value
+    # Unit unknown — refuse inside the ambiguity band, accept as lbs outside it.
+    if _WEIGHT_AMBIGUOUS_BAND[0] <= value <= _WEIGHT_AMBIGUOUS_BAND[1]:
+        _record_refusal(refusals, "weight_lbs", REFUSAL_REASON_AMBIGUOUS_UNIT)
+        return None
+    return value
+
+
+def _convert_height_to_inches(
+    value: float,
+    unit: str,
+    *,
+    refusals: list[_Refusal] | None = None,
+) -> float | None:
+    """Convert ``value`` to inches.
+
+    With an explicit unit, convert normally — this is the typical Nabla path.
+    With an empty/unrecognised unit, REFUSE values in the cm/in overlap band
+    (30-80) because we can't tell which scale the source intended. Accept
+    values outside the band as unambiguous inches (the _FIELD_RANGES gate
+    still enforces the final plausibility window).
+    """
+    if unit in _CM_UNITS:
+        return value * 0.393701
+    if unit in _M_UNITS:
+        return value * 39.3701
+    if unit in _IN_UNITS:
+        return value
+    # Unit unknown — refuse inside the ambiguity band, accept as inches outside it.
+    if _HEIGHT_AMBIGUOUS_BAND[0] <= value <= _HEIGHT_AMBIGUOUS_BAND[1]:
+        _record_refusal(refusals, "height", REFUSAL_REASON_AMBIGUOUS_UNIT)
+        return None
+    return value
+
+
+def _parse_numeric(value: str) -> float | None:
+    """Pull the first numeric token out of a value string."""
+    match = re.search(r"-?\d+(?:\.\d+)?", value)
+    if match is None:
+        return None
+    try:
+        return float(match.group(0))
+    except ValueError:
+        return None
+
+
+def _coding_codes(observation: Observation) -> set[str]:
+    """Return the LOINC codes attached to ``observation``."""
+    codes: set[str] = set()
+    for entry in observation.coding:
+        # Nabla emits ``system`` in a few forms ("LOINC", "http://loinc.org", ""); filter
+        # by membership in our known-code map instead of trusting the system string.
+        if entry.code:
+            codes.add(entry.code.strip())
+    return codes
+
+
+def _apply_observation(
+    observation: Observation,
+    result: dict[str, int | float | None],
+    *,
+    refusals: list[_Refusal] | None = None,
+) -> None:
+    """Merge a single observation into ``result`` if it maps to a known LOINC code."""
+    codes = _coding_codes(observation)
+    unit = _normalize_unit(observation.unit)
+    raw_value = observation.value or ""
+
+    # BP panel: value is "systole/diastole".
+    if _LOINC_BP_PANEL in codes:
+        bp_match = re.search(r"(\d+)\s*/\s*(\d+)", raw_value)
+        if bp_match is not None:
+            systole = _validate_field("blood_pressure_systole", float(bp_match.group(1)), refusals=refusals)
+            diastole = _validate_field("blood_pressure_diastole", float(bp_match.group(2)), refusals=refusals)
+            if systole is not None and result.get("blood_pressure_systole") is None:
+                result["blood_pressure_systole"] = systole
+            if diastole is not None and result.get("blood_pressure_diastole") is None:
+                result["blood_pressure_diastole"] = diastole
+        return
+
+    # Single-scalar observations. Walk the LOINC map in declared priority
+    # order so behavior is deterministic for observations that carry
+    # multiple mapped codes. Note: do NOT early-return when conversion or
+    # validation rejects a value — subsequent matching codes for the same
+    # observation get a chance (e.g., 2708-6 and 59408-5 both map to
+    # oxygen_saturation; one might be present in coding while another is not).
+    for code, field in _LOINC_TO_FIELD:
+        if code not in codes:
+            continue
+        if result.get(field) is not None:
+            continue
+        numeric = _parse_numeric(raw_value)
+        if numeric is None:
+            continue
+        converted: float | None = numeric
+        if field == "body_temperature":
+            converted = _convert_temperature_to_fahrenheit(numeric, unit, refusals=refusals)
+        elif field == "weight_lbs":
+            converted = _convert_weight_to_lbs(numeric, unit, refusals=refusals)
+        elif field == "height":
+            converted = _convert_height_to_inches(numeric, unit, refusals=refusals)
+        if converted is None:
+            continue
+        validated = _validate_field(field, converted, refusals=refusals)
+        if validated is None:
+            continue
+        result[field] = validated
+
+
+def _parse_observations(
+    observations: list[Observation],
+    *,
+    refusals: list[_Refusal] | None = None,
+) -> dict[str, int | float | None]:
+    """Extract VitalsCommand fields from Nabla normalized observations."""
+    result: dict[str, int | float | None] = {}
+    for observation in observations:
+        _apply_observation(observation, result, refusals=refusals)
+    return result
+
+
+# Display-string formatter. Mirrors the post-edit formatter in
+# ``static/summary.js`` (the ``type === 'vitals'`` branch around L912) so the
+# initial backend-emitted display matches what the UI rebuilds after every
+# edit — no format flash on first save. The CRITICAL invariant is that this
+# function reads ONLY from the validated ``data`` dict; any field refused by
+# ``_validate_field`` is absent from ``data`` and therefore absent from the
+# display. This prevents the prod failure mode where the parser dropped
+# blood_pressure_systole=38 from data but Nabla's free-text "BP 38/22"
+# remained in display, so the clinician approved a half-written BP. After
+# this change, refused fields disappear from BOTH data and display.
+def _format_vitals_display(data: dict[str, int | float | None]) -> str:
+    """Build a canonical display string from the validated ``data`` dict.
+
+    Reads ONLY from ``data``: any field refused by ``_validate_field`` is
+    absent and therefore cannot appear in the display string. This is the
+    contract the UAT failure surfaced: display must accurately describe data.
+    """
+    parts: list[str] = []
+    systole = data.get("blood_pressure_systole")
+    diastole = data.get("blood_pressure_diastole")
+    if systole is not None and diastole is not None:
+        parts.append(f"BP {systole}/{diastole} mmHg")
+    pulse = data.get("pulse")
+    if pulse is not None:
+        parts.append(f"HR {pulse} bpm")
+    respiration_rate = data.get("respiration_rate")
+    if respiration_rate is not None:
+        parts.append(f"RR {respiration_rate} /min")
+    oxygen_saturation = data.get("oxygen_saturation")
+    if oxygen_saturation is not None:
+        parts.append(f"SpO2 {oxygen_saturation}%")
+    body_temperature = data.get("body_temperature")
+    if body_temperature is not None:
+        # ``:g`` drops trailing ``.0`` so 99.0 → "99" (matches the JS template
+        # literal in summary.js which renders the same after JSON round-trip
+        # turns 99.0 into 99). Decimals like 98.6 stay as "98.6". Without
+        # this, the backend emits "Temp 99.0 °F" but the JS rebuilds it as
+        # "Temp 99 °F" on the first edit — a format flash that defeats the
+        # whole reason this rebuild was added.
+        parts.append(f"Temp {body_temperature:g} °F")
+    height = data.get("height")
+    if height is not None:
+        parts.append(f"Height {height} in")
+    weight_lbs = data.get("weight_lbs")
+    if weight_lbs is not None:
+        parts.append(f"Weight {weight_lbs} lbs")
+    return ", ".join(parts)
+
+
+def _set_if_valid(
+    result: dict[str, int | float | None],
+    field: str,
+    value: float,
+    *,
+    refusals: list[_Refusal] | None = None,
+) -> None:
+    """Range-gated write to ``result[field]``. Skips the assignment when invalid."""
+    validated = _validate_field(field, value, refusals=refusals)
+    if validated is not None:
+        result[field] = validated
+
+
+def _parse_vitals(
+    text: str,
+    *,
+    refusals: list[_Refusal] | None = None,
+) -> dict[str, int | float | None]:
+    """Parse free-text vitals into structured fields (fallback when observations are absent)."""
     result: dict[str, int | float | None] = {}
     for line in re.split(r"[,\n]", text):
         line = line.strip()
         if not line:
             continue
-        # Blood pressure
+        # Blood pressure: ``120/80``.
         bp_match = re.search(r"(\d+)\s*/\s*(\d+)", line)
         if bp_match and "blood_pressure_systole" not in result:
-            result["blood_pressure_systole"] = int(bp_match.group(1))
-            result["blood_pressure_diastole"] = int(bp_match.group(2))
+            _set_if_valid(result, "blood_pressure_systole", float(bp_match.group(1)), refusals=refusals)
+            _set_if_valid(result, "blood_pressure_diastole", float(bp_match.group(2)), refusals=refusals)
             continue
-        # Pulse
+        # Pulse.
         m = re.search(r"(?:HR|Heart\s*rate|Pulse)[:\s]*(\d+)", line, re.IGNORECASE)
         if m:
-            result["pulse"] = int(m.group(1))
+            _set_if_valid(result, "pulse", float(m.group(1)), refusals=refusals)
             continue
-        # Respiration — "RR", "Respiration", "Respiratory rate", "Resp rate"
+        # Respiration rate — accept ``RR``, ``Resp``, ``Respiration``, ``Respiratory``,
+        # ``Resp rate``, and other ``Resp*`` variants Nabla emits when transcribing speech.
         m = re.search(r"(?:RR|Resp[a-z]*(?:\s*rate)?)[:\s]*(\d+)", line, re.IGNORECASE)
         if m:
-            result["respiration_rate"] = int(m.group(1))
+            _set_if_valid(result, "respiration_rate", float(m.group(1)), refusals=refusals)
             continue
-        # O2 saturation
-        m = re.search(r"(?:O2|SpO2|Oxygen\s*sat(?:uration)?)[:\s]*(\d+)", line, re.IGNORECASE)
+        # O2 saturation — require either ``SpO2`` or an explicit ``sat[uration]``
+        # qualifier so we don't capture flow rates like ``O2 2L NC`` (which
+        # used to silently land as oxygen_saturation=2 — a documented prod
+        # data-corruption mode). The optional ``(SpO2)`` parenthetical
+        # handles Nabla's verbose ``Oxygen saturation (SpO2): 98%`` form.
+        m = re.search(
+            r"(?:SpO2\b|(?:O2|Oxygen)\s+sat(?:uration)?\b(?:\s*\(SpO2\))?)[\s,:]*(\d+)\s*%?",
+            line,
+            re.IGNORECASE,
+        )
         if m:
-            result["oxygen_saturation"] = int(m.group(1))
+            _set_if_valid(result, "oxygen_saturation", float(m.group(1)), refusals=refusals)
             continue
-        # Temperature
-        m = re.search(r"Temp(?:erature)?[:\s]*([\d.]+)", line, re.IGNORECASE)
+        # Temperature.
+        m = re.search(r"Temp(?:erature)?[:\s]*([\d.]+)\s*°?\s*([cCfF])?", line, re.IGNORECASE)
         if m:
-            result["body_temperature"] = float(m.group(1))
+            value = float(m.group(1))
+            scale = (m.group(2) or "").lower()
+            if scale == "c":
+                value = value * 9.0 / 5.0 + 32.0
+            _set_if_valid(result, "body_temperature", value, refusals=refusals)
             continue
-        # Height — stored in inches. The pipeline normalizes spoken height to plain
-        # inches ("70 in"), but also accept the typographic 5'10" form and spoken
-        # feet/inches ("5 ft 10 in", "5 feet 10 inches", "5 foot 10", "6 feet").
+        # Height — stored in inches. Accept the typographic ``5'10"`` form,
+        # the spoken ``5 ft 10 in`` / ``5 feet 10 inches`` / ``5 foot 10`` /
+        # ``6 feet`` / ``70 in`` forms, AND metric ``cm``/``m``. ``\bheight\b``
+        # anchors the line so we don't accidentally extract a height from a
+        # ``70 inch`` pulse measurement description; metric forms keep
+        # ``Height:`` for safety (cm/m alone is too easy to false-positive).
         if re.search(r"\bheight\b", line, re.IGNORECASE):
             feet_inches = re.search(
                 r"(\d+)\s*(?:'|ft\b|foot\b|feet\b)\s*(\d+)\s*(?:\"|in\b|inch|inches)?",
@@ -55,18 +504,34 @@ def _parse_vitals(text: str) -> dict[str, int | float | None]:
             feet_only = re.search(r"(\d+)\s*(?:'|ft\b|foot\b|feet\b)", line, re.IGNORECASE)
             inches_only = re.search(r"(\d+)\s*(?:\"|in\b|inch|inches)", line, re.IGNORECASE)
             if feet_inches:
-                result["height"] = int(feet_inches.group(1)) * 12 + int(feet_inches.group(2))
+                height_in = int(feet_inches.group(1)) * 12 + int(feet_inches.group(2))
+                _set_if_valid(result, "height", float(height_in), refusals=refusals)
                 continue
             if feet_only:
-                result["height"] = int(feet_only.group(1)) * 12
+                _set_if_valid(result, "height", float(int(feet_only.group(1)) * 12), refusals=refusals)
                 continue
             if inches_only:
-                result["height"] = int(inches_only.group(1))
+                _set_if_valid(result, "height", float(int(inches_only.group(1))), refusals=refusals)
                 continue
-        # Weight
-        m = re.search(r"Weight[:\s]*(\d+)\s*(?:lbs?|pounds?)", line, re.IGNORECASE)
+        # Height (metric: cm or m), only when ``Height:`` is the anchor.
+        m = re.search(r"Height[:\s]*(\d+(?:\.\d+)?)\s*(cm|m)\b", line, re.IGNORECASE)
         if m:
-            result["weight_lbs"] = int(m.group(1))
+            value = float(m.group(1))
+            unit = m.group(2).lower()
+            if unit == "cm":
+                _set_if_valid(result, "height", value * 0.393701, refusals=refusals)
+            else:
+                _set_if_valid(result, "height", value * 39.3701, refusals=refusals)
+            continue
+        # Weight (lbs).
+        m = re.search(r"Weight[:\s]*(\d+(?:\.\d+)?)\s*(?:lbs?|pounds?)", line, re.IGNORECASE)
+        if m:
+            _set_if_valid(result, "weight_lbs", float(m.group(1)), refusals=refusals)
+            continue
+        # Weight (kg).
+        m = re.search(r"Weight[:\s]*(\d+(?:\.\d+)?)\s*(?:kg|kgs|kilograms?)", line, re.IGNORECASE)
+        if m:
+            _set_if_valid(result, "weight_lbs", float(m.group(1)) * 2.20462, refusals=refusals)
             continue
     return result
 
@@ -75,10 +540,95 @@ class VitalsParser(CommandParser):
     command_type = "vitals"
 
     def extract(self, text: str) -> CommandProposal | None:
-        data = _parse_vitals(text)
+        """Free-text fallback. Used when no structured observations are available."""
+        return self.extract_with_observations(text, [])
+
+    def extract_with_observations(
+        self,
+        text: str,
+        observations: list[Observation],
+    ) -> CommandProposal | None:
+        """Prefer observations (LOINC + units); fall back to regex for any field they didn't cover.
+
+        Thin wrapper over ``extract_with_telemetry`` for callers that don't
+        need the refusals/source metadata.
+        """
+        return self.extract_with_telemetry(text, observations).proposal
+
+    def extract_with_telemetry(
+        self,
+        text: str,
+        observations: list[Observation],
+    ) -> VitalsExtractionResult:
+        """Same extraction as ``extract_with_observations``, with audit metadata.
+
+        Returns the proposal plus:
+        - ``refusals``: fields the parser dropped during validation (out of
+          range, ambiguous unit, atomic BP partial). Used by
+          ``post_generate_summary`` to emit ``VITALS_FIELD_REFUSED``.
+        - ``source``: which path(s) contributed surviving fields to the
+          FINAL proposal — ``observations``, ``regex``, ``both``, or
+          ``none``. Classifying off the final survivors (rather than raw
+          extraction) prevents the race the risk-hunter flagged: a
+          fully-refused Nabla BP-panel used to land as ``observations`` in
+          telemetry even though no observation data survived validation.
+
+        ``display`` is rebuilt from the validated ``data`` dict via
+        ``_format_vitals_display`` rather than echoed from ``text``. Echoing
+        the source text led to a prod failure where a refused field (e.g.
+        BP 38/22 — systole below the floor) was dropped from ``data`` but
+        still appeared in ``display``, so the clinician approved a value
+        that didn't make it into the chart. The display now describes only
+        what will actually be inserted.
+        """
+        refusals: list[_Refusal] = []
+        obs_data = _parse_observations(observations, refusals=refusals)
+        regex_data = _parse_vitals(text, refusals=refusals)
+        data: dict[str, int | float | None] = dict(regex_data)
+        for field, value in obs_data.items():
+            if value is not None:
+                data[field] = value
+        # Atomic BP pair: if either side is refused, drop both. A half-BP is
+        # clinically meaningless and pollutes downstream FHIR/analytics
+        # consumers even when the vitals UI hides it (the row formatter only
+        # renders BP when both sides are present, but ``data`` is what
+        # ``/insert-commands`` writes and what downstream consumers read).
+        # "Half-written BP is worse than a clean drop." Applied after both
+        # sources merge so split-component observations (8480-6 + 8462-4 as
+        # separate Observations) also benefit.
+        sys_present = data.get("blood_pressure_systole") is not None
+        dia_present = data.get("blood_pressure_diastole") is not None
+        if sys_present != dia_present:
+            # Record the side that survived its own per-field gate but is
+            # being dropped by the atomic-pair rule (the other side was
+            # already recorded as ``out_of_range`` inside _validate_field).
+            orphan_field = "blood_pressure_systole" if sys_present else "blood_pressure_diastole"
+            _record_refusal(refusals, orphan_field, REFUSAL_REASON_ATOMIC_BP_PARTIAL)
+            data.pop("blood_pressure_systole", None)
+            data.pop("blood_pressure_diastole", None)
+        # Source classification: based on the FINAL surviving fields, not
+        # the raw extraction. obs_data / regex_data still hold the
+        # pre-merge, pre-atomic-sweep snapshots; intersect them against
+        # data to determine which side actually contributed.
+        surviving_fields = {field for field, value in data.items() if value is not None}
+        obs_contributed = bool(surviving_fields & set(obs_data.keys()))
+        regex_contributed = bool(surviving_fields & set(regex_data.keys()))
+        if obs_contributed and regex_contributed:
+            source = "both"
+        elif obs_contributed:
+            source = "observations"
+        elif regex_contributed:
+            source = "regex"
+        else:
+            source = "none"
         if not data:
-            return None
-        return CommandProposal(command_type=self.command_type, display=text, data=data)
+            return VitalsExtractionResult(proposal=None, refusals=refusals, source=source)
+        proposal = CommandProposal(
+            command_type=self.command_type,
+            display=_format_vitals_display(data),
+            data=data,
+        )
+        return VitalsExtractionResult(proposal=proposal, refusals=refusals, source=source)
 
     def build(self, data: dict[str, Any], note_uuid: str, command_uuid: str) -> _BaseCommand:
         bp_site_raw = data.get("blood_pressure_position_and_site")

--- a/tests/hyperscribe/scribe/api/test_session_view.py
+++ b/tests/hyperscribe/scribe/api/test_session_view.py
@@ -1784,9 +1784,12 @@ def test_edit_existing_commands_hpi_void_recreate(
     assert audit_call.args[2]["entries"][0]["new_command_uuid"] == "new-hpi-uuid"
 
 
+@patch("hyperscribe.scribe.api.session_view.validate_proposals", return_value=[])
 @patch("hyperscribe.scribe.api.session_view.audit_event")
 @patch("hyperscribe.scribe.api.session_view.build_amend_edit_effects")
-def test_edit_existing_commands_silently_drops_disallowed_section(mock_build: MagicMock, mock_audit: MagicMock) -> None:
+def test_edit_existing_commands_silently_drops_disallowed_section(
+    mock_build: MagicMock, mock_audit: MagicMock, mock_validate: MagicMock
+) -> None:
     """Sections not in EDITABLE_AMEND_SECTIONS are silently dropped (logged at WARN
     inside build_amend_edit_effects). The response carries only the attempted
     list - no parallel `rejected` field. Rationale: defense-in-depth, not UX -
@@ -3881,6 +3884,241 @@ def test_generate_summary_writes_progress(
     progress = json.loads(cache._store[progress_key])
     assert progress["step"] == len(SUMMARY_STEPS) - 1
     assert progress["total"] == len(SUMMARY_STEPS)
+
+
+# --- /generate-summary telemetry (VITALS_SOURCE, NORMALIZED_DATA_FAILED) ---
+
+
+@patch("hyperscribe.scribe.contacts.resolve_zip_codes", return_value=[])
+@patch("hyperscribe.scribe.api.session_view.annotate_duplicates")
+@patch("hyperscribe.scribe.api.session_view.suggest_diagnoses")
+@patch("hyperscribe.scribe.api.session_view.recommend_commands")
+@patch("hyperscribe.scribe.api.session_view.audit_event")
+@patch("hyperscribe.scribe.api.session_view.ScribeSummary")
+@patch("hyperscribe.scribe.api.session_view.ScribeTranscript")
+@patch("hyperscribe.scribe.api.session_view.Note")
+@patch("hyperscribe.scribe.api.session_view.get_cache")
+@patch("hyperscribe.scribe.api.session_view.get_backend_from_secrets")
+def test_generate_summary_emits_vitals_source_observations(
+    get_backend: MagicMock,
+    mock_get_cache: MagicMock,
+    mock_note: MagicMock,
+    mock_transcript: MagicMock,
+    _mock_summary: MagicMock,
+    mock_audit: MagicMock,
+    mock_recommend: MagicMock,
+    mock_suggest: MagicMock,
+    _mock_annotate: MagicMock,
+    _mock_zip: MagicMock,
+) -> None:
+    """When Nabla supplies observations and no vitals section text, telemetry records ``observations``."""
+    cache = _mock_cache()
+    mock_get_cache.return_value = cache
+    mock_note.objects.values_list.return_value.get.return_value = 91
+    mock_transcript.objects.filter.return_value.values.return_value.first.return_value = {
+        "items": [{"text": "hi", "speaker": "patient"}],
+        "finalized": True,
+    }
+
+    mock_backend = MagicMock()
+    mock_backend.generate_note.return_value = ClinicalNote(
+        title="Note",
+        sections=[NoteSection(key="vitals", title="Vitals", text="")],
+    )
+    mock_backend.generate_normalized_data.return_value = NormalizedData(
+        conditions=[],
+        observations=[
+            Observation(
+                display="Heart rate",
+                value="74",
+                unit="bpm",
+                coding=[CodingEntry(system="LOINC", code="8867-4", display="Heart rate")],
+            )
+        ],
+    )
+    get_backend.return_value = mock_backend
+    mock_recommend.return_value = []
+    mock_suggest.return_value = {}
+
+    view = _helper_instance()
+    view.secrets["AnthropicAPIKey"] = "test-key"
+    view.request = SimpleNamespace(body=json.dumps({"note_id": "91", "note_uuid": "91"}))
+    view.post_generate_summary()
+
+    audit_calls = [(c.args[1], c.args[2] if len(c.args) > 2 else {}) for c in mock_audit.call_args_list]
+    vitals_source_calls = [payload for event_type, payload in audit_calls if event_type == "VITALS_SOURCE"]
+    assert len(vitals_source_calls) == 1, f"expected one VITALS_SOURCE audit event, got {audit_calls}"
+    assert vitals_source_calls[0] == {"source": "observations"}
+
+
+@patch("hyperscribe.scribe.contacts.resolve_zip_codes", return_value=[])
+@patch("hyperscribe.scribe.api.session_view.annotate_duplicates")
+@patch("hyperscribe.scribe.api.session_view.suggest_diagnoses")
+@patch("hyperscribe.scribe.api.session_view.recommend_commands")
+@patch("hyperscribe.scribe.api.session_view.audit_event")
+@patch("hyperscribe.scribe.api.session_view.ScribeSummary")
+@patch("hyperscribe.scribe.api.session_view.ScribeTranscript")
+@patch("hyperscribe.scribe.api.session_view.Note")
+@patch("hyperscribe.scribe.api.session_view.get_cache")
+@patch("hyperscribe.scribe.api.session_view.get_backend_from_secrets")
+def test_generate_summary_emits_normalized_data_failed_on_exception(
+    get_backend: MagicMock,
+    mock_get_cache: MagicMock,
+    mock_note: MagicMock,
+    mock_transcript: MagicMock,
+    _mock_summary: MagicMock,
+    mock_audit: MagicMock,
+    mock_recommend: MagicMock,
+    mock_suggest: MagicMock,
+    _mock_annotate: MagicMock,
+    _mock_zip: MagicMock,
+) -> None:
+    """When generate_normalized_data raises, a NORMALIZED_DATA_FAILED audit event fires."""
+    cache = _mock_cache()
+    mock_get_cache.return_value = cache
+    mock_note.objects.values_list.return_value.get.return_value = 92
+    mock_transcript.objects.filter.return_value.values.return_value.first.return_value = {
+        "items": [{"text": "hi", "speaker": "patient"}],
+        "finalized": True,
+    }
+
+    mock_backend = MagicMock()
+    mock_backend.generate_note.return_value = ClinicalNote(title="Note", sections=[])
+    mock_backend.generate_normalized_data.side_effect = Exception("Nabla outage")
+    get_backend.return_value = mock_backend
+    mock_recommend.return_value = []
+    mock_suggest.return_value = {}
+
+    view = _helper_instance()
+    view.secrets["AnthropicAPIKey"] = "test-key"
+    view.request = SimpleNamespace(body=json.dumps({"note_id": "92", "note_uuid": "92"}))
+    view.post_generate_summary()
+
+    audit_event_types = [c.args[1] for c in mock_audit.call_args_list]
+    assert "NORMALIZED_DATA_FAILED" in audit_event_types
+    failed_calls = [
+        c.args[2] if len(c.args) > 2 else {} for c in mock_audit.call_args_list if c.args[1] == "NORMALIZED_DATA_FAILED"
+    ]
+    assert failed_calls == [{"step": "normalized"}]
+
+
+# --- /generate-summary VITALS_FIELD_REFUSED telemetry (Fix 4) ----------------------
+# Field-refusal audit fires when ``_validate_field`` or the unit converters drop a
+# value, OR when the atomic BP-pair sweep cascades. Schema: refused_fields (list of
+# field names) + reasons (parallel list of reason categories). NO field VALUES — PHI.
+# Silent on the happy path: no refusals → no VITALS_FIELD_REFUSED event.
+
+
+@patch("hyperscribe.scribe.contacts.resolve_zip_codes", return_value=[])
+@patch("hyperscribe.scribe.api.session_view.annotate_duplicates")
+@patch("hyperscribe.scribe.api.session_view.suggest_diagnoses")
+@patch("hyperscribe.scribe.api.session_view.recommend_commands")
+@patch("hyperscribe.scribe.api.session_view.audit_event")
+@patch("hyperscribe.scribe.api.session_view.ScribeSummary")
+@patch("hyperscribe.scribe.api.session_view.ScribeTranscript")
+@patch("hyperscribe.scribe.api.session_view.Note")
+@patch("hyperscribe.scribe.api.session_view.get_cache")
+@patch("hyperscribe.scribe.api.session_view.get_backend_from_secrets")
+def test_generate_summary_emits_vitals_field_refused_for_out_of_range_pulse(
+    get_backend: MagicMock,
+    mock_get_cache: MagicMock,
+    mock_note: MagicMock,
+    mock_transcript: MagicMock,
+    _mock_summary: MagicMock,
+    mock_audit: MagicMock,
+    mock_recommend: MagicMock,
+    mock_suggest: MagicMock,
+    _mock_annotate: MagicMock,
+    _mock_zip: MagicMock,
+) -> None:
+    """Out-of-range pulse (25 < SDK floor 30) emits VITALS_FIELD_REFUSED with refused_fields=['pulse']."""
+    cache = _mock_cache()
+    mock_get_cache.return_value = cache
+    mock_note.objects.values_list.return_value.get.return_value = 93
+    mock_transcript.objects.filter.return_value.values.return_value.first.return_value = {
+        "items": [{"text": "hi", "speaker": "patient"}],
+        "finalized": True,
+    }
+
+    mock_backend = MagicMock()
+    # Vitals section has HR=25 (out of range) and a valid BP. Pulse refused, BP survives.
+    mock_backend.generate_note.return_value = ClinicalNote(
+        title="Note",
+        sections=[NoteSection(key="vitals", title="Vitals", text="HR 25, BP 120/80")],
+    )
+    mock_backend.generate_normalized_data.return_value = NormalizedData(conditions=[], observations=[])
+    get_backend.return_value = mock_backend
+    mock_recommend.return_value = []
+    mock_suggest.return_value = {}
+
+    view = _helper_instance()
+    view.secrets["AnthropicAPIKey"] = "test-key"
+    view.request = SimpleNamespace(body=json.dumps({"note_id": "93", "note_uuid": "93"}))
+    view.post_generate_summary()
+
+    audit_calls = [(c.args[1], c.args[2] if len(c.args) > 2 else {}) for c in mock_audit.call_args_list]
+    refused_calls = [payload for event_type, payload in audit_calls if event_type == "VITALS_FIELD_REFUSED"]
+    assert len(refused_calls) == 1, f"expected one VITALS_FIELD_REFUSED audit event, got {audit_calls}"
+    assert refused_calls[0] == {"refused_fields": ["pulse"], "reasons": ["out_of_range"]}
+
+
+@patch("hyperscribe.scribe.contacts.resolve_zip_codes", return_value=[])
+@patch("hyperscribe.scribe.api.session_view.annotate_duplicates")
+@patch("hyperscribe.scribe.api.session_view.suggest_diagnoses")
+@patch("hyperscribe.scribe.api.session_view.recommend_commands")
+@patch("hyperscribe.scribe.api.session_view.audit_event")
+@patch("hyperscribe.scribe.api.session_view.ScribeSummary")
+@patch("hyperscribe.scribe.api.session_view.ScribeTranscript")
+@patch("hyperscribe.scribe.api.session_view.Note")
+@patch("hyperscribe.scribe.api.session_view.get_cache")
+@patch("hyperscribe.scribe.api.session_view.get_backend_from_secrets")
+def test_generate_summary_happy_path_emits_no_vitals_field_refused(
+    get_backend: MagicMock,
+    mock_get_cache: MagicMock,
+    mock_note: MagicMock,
+    mock_transcript: MagicMock,
+    _mock_summary: MagicMock,
+    mock_audit: MagicMock,
+    mock_recommend: MagicMock,
+    mock_suggest: MagicMock,
+    _mock_annotate: MagicMock,
+    _mock_zip: MagicMock,
+) -> None:
+    """Happy path (no refusals): VITALS_FIELD_REFUSED MUST NOT fire.
+
+    Pins the silent-on-happy-path contract: we don't want a `refused_fields: []`
+    event polluting the audit log on every successful note. Only fires when there
+    is actually something to record.
+    """
+    cache = _mock_cache()
+    mock_get_cache.return_value = cache
+    mock_note.objects.values_list.return_value.get.return_value = 94
+    mock_transcript.objects.filter.return_value.values.return_value.first.return_value = {
+        "items": [{"text": "hi", "speaker": "patient"}],
+        "finalized": True,
+    }
+
+    mock_backend = MagicMock()
+    mock_backend.generate_note.return_value = ClinicalNote(
+        title="Note",
+        sections=[NoteSection(key="vitals", title="Vitals", text="BP 120/80, HR 72, SpO2 98%")],
+    )
+    mock_backend.generate_normalized_data.return_value = NormalizedData(conditions=[], observations=[])
+    get_backend.return_value = mock_backend
+    mock_recommend.return_value = []
+    mock_suggest.return_value = {}
+
+    view = _helper_instance()
+    view.secrets["AnthropicAPIKey"] = "test-key"
+    view.request = SimpleNamespace(body=json.dumps({"note_id": "94", "note_uuid": "94"}))
+    view.post_generate_summary()
+
+    audit_event_types = [c.args[1] for c in mock_audit.call_args_list]
+    assert "VITALS_FIELD_REFUSED" not in audit_event_types, (
+        f"happy path should NOT emit VITALS_FIELD_REFUSED, but did. Events: {audit_event_types}"
+    )
+    # And VITALS_SOURCE still fires.
+    assert "VITALS_SOURCE" in audit_event_types
 
 
 # --- /carry-forward-background ---

--- a/tests/hyperscribe/scribe/commands/test_extractor.py
+++ b/tests/hyperscribe/scribe/commands/test_extractor.py
@@ -1,5 +1,21 @@
-from hyperscribe.scribe.backend.models import ClinicalNote, NoteSection
-from hyperscribe.scribe.commands.extractor import extract_commands, parse_ros_subsections
+from hyperscribe.scribe.backend.models import ClinicalNote, CodingEntry, NoteSection, Observation
+from hyperscribe.scribe.commands.extractor import (
+    classify_vitals_source,
+    extract_commands,
+    extract_vitals_with_telemetry,
+    parse_ros_subsections,
+)
+from hyperscribe.scribe.commands.vitals import REFUSAL_REASON_OUT_OF_RANGE
+
+
+def _loinc_obs(code: str, value: str, *, unit: str = "", display: str = "") -> Observation:
+    """Build an Observation whose only coding entry is a LOINC code."""
+    return Observation(
+        display=display or code,
+        value=value,
+        unit=unit,
+        coding=[CodingEntry(system="LOINC", code=code, display=display)],
+    )
 
 
 def test_routes_chief_complaint_to_rfv() -> None:
@@ -352,6 +368,92 @@ def test_allergies_only_chart_review() -> None:
 # --- parse_ros_subsections ---
 
 
+def test_routes_vitals_with_observations() -> None:
+    """When observations are supplied, the vitals proposal picks up fields the regex misses."""
+    note = ClinicalNote(
+        title="Note",
+        sections=[
+            NoteSection(
+                key="vitals",
+                title="Vitals",
+                # Verbose Nabla format — the unpatched regex would drop SpO2 here.
+                text="* Heart rate: 74 bpm\n* O2 saturation: 94%",
+            )
+        ],
+    )
+    observations = [
+        _loinc_obs("85354-9", "103/56", unit="mmHg", display="Blood pressure"),
+        _loinc_obs("9279-1", "16", unit="/min", display="Respiratory rate"),
+    ]
+    proposals = extract_commands(note, observations=observations)
+    assert len(proposals) == 1
+    assert proposals[0].command_type == "vitals"
+    data = proposals[0].data
+    assert data["pulse"] == 74  # from regex (Heart rate line)
+    assert data["oxygen_saturation"] == 94  # from regex (O2 saturation line)
+    assert data["blood_pressure_systole"] == 103  # from observation
+    assert data["blood_pressure_diastole"] == 56  # from observation
+    assert data["respiration_rate"] == 16  # from observation
+
+
+def test_routes_vitals_observations_only_no_section() -> None:
+    """Vitals proposal is emitted even when there is no vitals section, as long as observations carry data."""
+    note = ClinicalNote(
+        title="Note",
+        sections=[
+            NoteSection(key="chief_complaint", title="CC", text="Routine checkup."),
+        ],
+    )
+    observations = [_loinc_obs("8867-4", "74", unit="bpm", display="Heart rate")]
+    proposals = extract_commands(note, observations=observations)
+    types = [p.command_type for p in proposals]
+    assert "vitals" in types
+    vitals = next(p for p in proposals if p.command_type == "vitals")
+    assert vitals.data["pulse"] == 74
+    assert vitals.section_key == "vitals"
+
+
+def test_routes_vitals_no_section_no_observations_omits_vitals() -> None:
+    """No vitals section and no observations means no vitals proposal."""
+    note = ClinicalNote(
+        title="Note",
+        sections=[
+            NoteSection(key="chief_complaint", title="CC", text="Routine checkup."),
+        ],
+    )
+    proposals = extract_commands(note, observations=[])
+    types = [p.command_type for p in proposals]
+    assert "vitals" not in types
+
+
+def test_routes_vitals_position_preserved_among_other_commands() -> None:
+    """Vitals proposal lands in section-order, even when emitted via observations."""
+    note = ClinicalNote(
+        title="Note",
+        sections=[
+            NoteSection(key="chief_complaint", title="CC", text="Headache"),
+            NoteSection(key="vitals", title="Vitals", text=""),
+            NoteSection(key="plan", title="Plan", text="Naproxen 500mg"),
+        ],
+    )
+    observations = [_loinc_obs("8867-4", "74", unit="bpm", display="Heart rate")]
+    proposals = extract_commands(note, observations=observations)
+    types = [p.command_type for p in proposals]
+    assert types == ["rfv", "vitals", "plan"]
+
+
+def test_extract_commands_observations_default_empty() -> None:
+    """Backwards-compat: callers that don't supply observations get the original regex-only behaviour."""
+    note = ClinicalNote(
+        title="Note",
+        sections=[NoteSection(key="vitals", title="Vitals", text="BP 120/80, HR 72")],
+    )
+    proposals = extract_commands(note)
+    assert len(proposals) == 1
+    assert proposals[0].command_type == "vitals"
+    assert proposals[0].data["pulse"] == 72
+
+
 def test_parse_ros_subsections_standard() -> None:
     text = "CONSTITUTIONAL: Denies fever, chills.\nEYES: Denies visual changes."
     result = parse_ros_subsections(text)
@@ -369,3 +471,114 @@ def test_parse_ros_subsections_multiword_title() -> None:
     result = parse_ros_subsections(text)
     assert len(result) == 1
     assert result[0]["title"] == "MOUTH/THROAT/VOICE"
+
+
+# --- classify_vitals_source --------------------------------------------------------
+# These tests pin the telemetry signal used by ``post_generate_summary`` to emit a
+# VITALS_SOURCE audit event. The signal lets us measure observation-vs-regex
+# reliability in prod and eventually retire the loser parser.
+
+
+def test_classify_vitals_source_observations_only() -> None:
+    """Only observations populated → ``observations``."""
+    note = ClinicalNote(
+        title="Note",
+        sections=[NoteSection(key="vitals", title="Vitals", text="")],
+    )
+    observations = [_loinc_obs("8867-4", "74", unit="bpm", display="Heart rate")]
+    assert classify_vitals_source(note, observations) == "observations"
+
+
+def test_classify_vitals_source_regex_only() -> None:
+    """Only the vitals section text populated → ``regex``."""
+    note = ClinicalNote(
+        title="Note",
+        sections=[NoteSection(key="vitals", title="Vitals", text="BP 120/80")],
+    )
+    assert classify_vitals_source(note, []) == "regex"
+
+
+def test_classify_vitals_source_both() -> None:
+    """Both observations and regex populated → ``both``."""
+    note = ClinicalNote(
+        title="Note",
+        sections=[NoteSection(key="vitals", title="Vitals", text="BP 120/80")],
+    )
+    observations = [_loinc_obs("8867-4", "74", unit="bpm", display="Heart rate")]
+    assert classify_vitals_source(note, observations) == "both"
+
+
+def test_classify_vitals_source_none() -> None:
+    """Nothing populated (no section, no observations) → ``none``."""
+    note = ClinicalNote(
+        title="Note",
+        sections=[NoteSection(key="chief_complaint", title="CC", text="Headache")],
+    )
+    assert classify_vitals_source(note, []) == "none"
+
+
+def test_classify_vitals_source_section_present_but_unparseable() -> None:
+    """Vitals section text that the regex cannot parse → ``none`` (not ``regex``)."""
+    note = ClinicalNote(
+        title="Note",
+        sections=[NoteSection(key="vitals", title="Vitals", text="Patient appears well.")],
+    )
+    assert classify_vitals_source(note, []) == "none"
+
+
+def test_classify_vitals_source_bp_panel_fully_refused_is_none() -> None:
+    """Fix 2: a fully-refused BP-panel observation must classify as ``none``, not ``observations``.
+
+    Before the fix, ``classify_vitals_source`` re-parsed raw observations standalone (skipping
+    validation) and declared the source ``observations`` even when no observation field
+    survived validation. The fix routes through the same extraction that builds the
+    proposal, so the source label reflects what actually landed in the final data dict.
+    """
+    note = ClinicalNote(title="Note", sections=[NoteSection(key="vitals", title="Vitals", text="")])
+    observations = [_loinc_obs("85354-9", "999/999", unit="mmHg", display="Blood pressure")]
+    assert classify_vitals_source(note, observations) == "none"
+
+
+# --- extract_vitals_with_telemetry -------------------------------------------------
+# Module-level wrapper around ``VitalsParser.extract_with_telemetry`` that adds the
+# section-key tagging and the "no vitals section + no observations → empty result"
+# short-circuit. Used by ``post_generate_summary`` to emit one VITALS_SOURCE + one
+# (optional) VITALS_FIELD_REFUSED from a single extraction.
+
+
+def test_extract_vitals_with_telemetry_happy_path() -> None:
+    """Happy path: a vitals section with valid data produces a proposal, no refusals, regex source."""
+    note = ClinicalNote(
+        title="Note",
+        sections=[NoteSection(key="vitals", title="Vitals", text="BP 120/80, HR 72")],
+    )
+    result = extract_vitals_with_telemetry(note, [])
+    assert result.proposal is not None
+    assert result.proposal.section_key == "vitals"
+    assert result.refusals == []
+    assert result.source == "regex"
+
+
+def test_extract_vitals_with_telemetry_no_section_no_obs_is_empty() -> None:
+    """No vitals section + no observations short-circuits to (None, [], "none")."""
+    note = ClinicalNote(title="Note", sections=[])
+    result = extract_vitals_with_telemetry(note, [])
+    assert result.proposal is None
+    assert result.refusals == []
+    assert result.source == "none"
+
+
+def test_extract_vitals_with_telemetry_out_of_range_pulse_refused() -> None:
+    """Refusals propagate through the module-level wrapper."""
+    note = ClinicalNote(
+        title="Note",
+        sections=[NoteSection(key="vitals", title="Vitals", text="HR 25, BP 120/80")],
+    )
+    result = extract_vitals_with_telemetry(note, [])
+    assert result.proposal is not None
+    assert [(r.field, r.reason) for r in result.refusals] == [
+        ("pulse", REFUSAL_REASON_OUT_OF_RANGE),
+    ]
+    # Pulse was refused but BP survived → still regex source.
+    assert result.source == "regex"
+    assert "pulse" not in result.proposal.data

--- a/tests/hyperscribe/scribe/commands/test_rx_validation.py
+++ b/tests/hyperscribe/scribe/commands/test_rx_validation.py
@@ -212,9 +212,7 @@ def test_note_to_pharmacist_max_length_is_210() -> None:
     which would silently fail at REVIEW because canvas-core caps it at 210."""
     over = "a" * (NOTE_TO_PHARMACIST_MAX_LENGTH + 1)
     errors = validate_rx_payload(_good_payload(note_to_pharmacist=over))
-    assert any(
-        f"exceeds {NOTE_TO_PHARMACIST_MAX_LENGTH}" in e for e in errors
-    )
+    assert any(f"exceeds {NOTE_TO_PHARMACIST_MAX_LENGTH}" in e for e in errors)
     # Exactly at the boundary is fine.
     at_limit = "a" * NOTE_TO_PHARMACIST_MAX_LENGTH
     assert validate_rx_payload(_good_payload(note_to_pharmacist=at_limit)) == []

--- a/tests/hyperscribe/scribe/commands/test_vitals.py
+++ b/tests/hyperscribe/scribe/commands/test_vitals.py
@@ -1,9 +1,25 @@
 from unittest.mock import MagicMock, patch
 
-from hyperscribe.scribe.commands.vitals import VitalsParser, _parse_vitals
+import pytest
+
+from hyperscribe.scribe.backend.models import CodingEntry, Observation
+from hyperscribe.scribe.commands.vitals import (
+    REFUSAL_REASON_AMBIGUOUS_UNIT,
+    REFUSAL_REASON_ATOMIC_BP_PARTIAL,
+    REFUSAL_REASON_OUT_OF_RANGE,
+    VitalsParser,
+    _format_vitals_display,
+    _parse_observations,
+    _parse_vitals,
+)
 
 
 def test_extract_basic() -> None:
+    """Compact format (the format the original regex parser handled correctly).
+
+    ``display`` is rebuilt from validated ``data`` rather than echoed from input,
+    so the format matches the post-edit formatter in static/summary.js (no flash).
+    """
     parser = VitalsParser()
     proposal = parser.extract("BP 120/80, HR 72, RR 16, SpO2 98%")
     assert proposal is not None
@@ -13,22 +29,25 @@ def test_extract_basic() -> None:
     assert proposal.data["pulse"] == 72
     assert proposal.data["respiration_rate"] == 16
     assert proposal.data["oxygen_saturation"] == 98
-    assert proposal.display == "BP 120/80, HR 72, RR 16, SpO2 98%"
+    assert proposal.display == "BP 120/80 mmHg, HR 72 bpm, RR 16 /min, SpO2 98%"
     assert proposal.selected is True
 
 
 def test_extract_no_parseable_returns_none() -> None:
+    """Free-text with no recognisable vitals must not produce a proposal."""
     parser = VitalsParser()
     assert parser.extract("Patient appears well.") is None
 
 
 def test_parse_vitals_blood_pressure() -> None:
+    """Whitespace around the BP slash must not block parsing."""
     result = _parse_vitals("BP 130 / 85")
     assert result["blood_pressure_systole"] == 130
     assert result["blood_pressure_diastole"] == 85
 
 
 def test_parse_vitals_all_fields() -> None:
+    """Sanity-check every field on a multi-line compact-format vitals string."""
     text = "BP 120/80\nHR 72\nRR 16\nSpO2 98\nTemperature: 98.6\nHeight: 5'10\"\nWeight: 180 lbs"
     result = _parse_vitals(text)
     assert result["blood_pressure_systole"] == 120
@@ -42,7 +61,395 @@ def test_parse_vitals_all_fields() -> None:
 
 
 def test_parse_vitals_empty() -> None:
+    """Non-vitals prose must produce an empty result without raising."""
     assert _parse_vitals("Patient appears well.") == {}
+
+
+# --- Verbose markdown-bullet failure modes -----------------------------------------
+# The regex parser previously dropped SpO2/RR (and metric height/weight) on Nabla's
+# verbose markdown-bullet format. These tests pin the four failure modes.
+
+
+def test_parse_vitals_verbose_markdown_bullet_format() -> None:
+    """Reproduce the prod failure on Nabla's verbose markdown bullet format — every field must populate."""
+    text = (
+        "* Blood pressure: 103/56 mmHg (right arm cuff), repeat 106/56 mmHg\n"
+        "* Heart rate: 74 bpm\n"
+        "* Respiratory rate: 16 breaths per minute\n"
+        "* Temperature: 97.8 °F\n"
+        "* O2 saturation: 94%"
+    )
+    result = _parse_vitals(text)
+    assert result["blood_pressure_systole"] == 103
+    assert result["blood_pressure_diastole"] == 56
+    assert result["pulse"] == 74
+    assert result["respiration_rate"] == 16
+    assert result["body_temperature"] == 97.8
+    assert result["oxygen_saturation"] == 94
+
+
+def test_parse_vitals_o2_saturation_phrasings() -> None:
+    """``O2 saturation``, ``SpO2``, ``Oxygen saturation`` all populate ``oxygen_saturation``."""
+    assert _parse_vitals("O2 saturation: 97%")["oxygen_saturation"] == 97
+    assert _parse_vitals("SpO2 95%")["oxygen_saturation"] == 95
+    assert _parse_vitals("Oxygen saturation: 94%")["oxygen_saturation"] == 94
+    assert _parse_vitals("O2 sat 96%")["oxygen_saturation"] == 96
+    assert _parse_vitals("SpO2: 98")["oxygen_saturation"] == 98
+
+
+def test_parse_vitals_respiratory_rate_phrasings() -> None:
+    """``Respiratory rate``, ``Respiration rate``, ``Resp rate``, ``RR`` all populate ``respiration_rate``."""
+    assert _parse_vitals("Respiratory rate: 16 breaths per minute")["respiration_rate"] == 16
+    assert _parse_vitals("Respiration rate: 18")["respiration_rate"] == 18
+    assert _parse_vitals("Resp rate: 14")["respiration_rate"] == 14
+    assert _parse_vitals("RR 18 /min")["respiration_rate"] == 18
+
+
+def test_parse_vitals_temperature_celsius_converts_to_fahrenheit() -> None:
+    """Celsius input must be converted to Fahrenheit (VitalsCommand expects °F)."""
+    # 37.0°C == 98.6°F.
+    result = _parse_vitals("Temperature: 37.0 °C")
+    assert result["body_temperature"] == 98.6
+
+
+def test_parse_vitals_height_metric_converts_to_inches() -> None:
+    """``Height: 170 cm`` becomes 67 inches (170 * 0.393701 = 66.93 → 67)."""
+    result = _parse_vitals("Height: 170 cm")
+    assert result["height"] == 67
+
+
+def test_parse_vitals_weight_metric_converts_to_lbs() -> None:
+    """``Weight: 75 kg`` becomes 165 lbs (75 * 2.20462 = 165.35 → 165)."""
+    result = _parse_vitals("Weight: 75 kg")
+    assert result["weight_lbs"] == 165
+
+
+# --- Observation-driven parsing (Path A) -------------------------------------------
+
+
+def _loinc_obs(code: str, value: str, *, unit: str = "", display: str = "") -> Observation:
+    """Build an Observation whose only coding entry is a LOINC code."""
+    return Observation(
+        display=display or code,
+        value=value,
+        unit=unit,
+        coding=[CodingEntry(system="LOINC", code=code, display=display)],
+    )
+
+
+def test_parse_observations_empty() -> None:
+    """Empty observation list produces an empty dict, never raises."""
+    assert _parse_observations([]) == {}
+
+
+def test_parse_observations_bp_panel() -> None:
+    """LOINC 85354-9 (BP panel) value ``"103/56"`` splits into systole + diastole."""
+    obs = [_loinc_obs("85354-9", "103/56", unit="mmHg", display="Blood pressure")]
+    result = _parse_observations(obs)
+    assert result["blood_pressure_systole"] == 103
+    assert result["blood_pressure_diastole"] == 56
+
+
+def test_parse_observations_bp_split_components() -> None:
+    """Nabla may emit systole (8480-6) and diastole (8462-4) as separate observations."""
+    obs = [
+        _loinc_obs("8480-6", "103", unit="mmHg", display="Systolic BP"),
+        _loinc_obs("8462-4", "56", unit="mmHg", display="Diastolic BP"),
+    ]
+    result = _parse_observations(obs)
+    assert result["blood_pressure_systole"] == 103
+    assert result["blood_pressure_diastole"] == 56
+
+
+def test_parse_observations_full_panel() -> None:
+    """All six core vital signs map through their LOINC codes with US-customary units."""
+    obs = [
+        _loinc_obs("8867-4", "74", unit="bpm", display="Heart rate"),
+        _loinc_obs("9279-1", "16", unit="/min", display="Respiratory rate"),
+        _loinc_obs("2708-6", "94", unit="%", display="Oxygen saturation"),
+        _loinc_obs("8310-5", "97.8", unit="°F", display="Body temperature"),
+        _loinc_obs("85354-9", "103/56", unit="mmHg", display="Blood pressure"),
+    ]
+    result = _parse_observations(obs)
+    assert result == {
+        "pulse": 74,
+        "respiration_rate": 16,
+        "oxygen_saturation": 94,
+        "body_temperature": 97.8,
+        "blood_pressure_systole": 103,
+        "blood_pressure_diastole": 56,
+    }
+
+
+def test_parse_observations_temperature_celsius() -> None:
+    """Celsius observations are converted to Fahrenheit."""
+    obs = [_loinc_obs("8310-5", "37.0", unit="°C", display="Body temperature")]
+    result = _parse_observations(obs)
+    assert result["body_temperature"] == 98.6
+
+
+def test_parse_observations_weight_kg() -> None:
+    """Weight in kg converts to lbs."""
+    obs = [_loinc_obs("29463-7", "75", unit="kg", display="Body weight")]
+    result = _parse_observations(obs)
+    assert result["weight_lbs"] == 165
+
+
+def test_parse_observations_height_cm() -> None:
+    """Height in cm converts to inches."""
+    obs = [_loinc_obs("8302-2", "170", unit="cm", display="Body height")]
+    result = _parse_observations(obs)
+    assert result["height"] == 67
+
+
+def test_parse_observations_pulse_ox_via_alternate_loinc() -> None:
+    """LOINC 59408-5 (SpO2 via pulse oximetry) populates oxygen_saturation too."""
+    obs = [_loinc_obs("59408-5", "95", unit="%", display="SpO2")]
+    result = _parse_observations(obs)
+    assert result["oxygen_saturation"] == 95
+
+
+def test_parse_observations_unknown_loinc_ignored() -> None:
+    """An observation with a LOINC code we don't map is silently dropped."""
+    obs = [_loinc_obs("99999-9", "42", unit="x", display="Mystery")]
+    assert _parse_observations(obs) == {}
+
+
+def test_parse_observations_non_loinc_system_still_works() -> None:
+    """We match by code, not system, so non-LOINC ``system`` strings still resolve."""
+    obs = [
+        Observation(
+            display="Heart rate",
+            value="74",
+            unit="bpm",
+            coding=[CodingEntry(system="", code="8867-4", display="")],
+        )
+    ]
+    result = _parse_observations(obs)
+    assert result["pulse"] == 74
+
+
+def test_parse_observations_value_with_units_appended_parsed() -> None:
+    """Nabla sometimes returns the unit inside the value string — we extract the leading number."""
+    obs = [_loinc_obs("8867-4", "74 bpm", display="Heart rate")]
+    result = _parse_observations(obs)
+    assert result["pulse"] == 74
+
+
+# --- VitalsParser.extract_with_observations ----------------------------------------
+
+
+def test_extract_with_observations_prefers_observations_over_regex() -> None:
+    """When both sources supply pulse, the observation value wins."""
+    parser = VitalsParser()
+    obs = [_loinc_obs("8867-4", "80", unit="bpm", display="Heart rate")]
+    proposal = parser.extract_with_observations("HR 72", obs)
+    assert proposal is not None
+    assert proposal.data["pulse"] == 80  # observation wins
+
+
+def test_extract_with_observations_regex_fills_gaps() -> None:
+    """Observations supply BP, the regex picks up SpO2 from the free text."""
+    parser = VitalsParser()
+    obs = [_loinc_obs("85354-9", "120/80", unit="mmHg", display="Blood pressure")]
+    proposal = parser.extract_with_observations("SpO2 95%", obs)
+    assert proposal is not None
+    assert proposal.data["blood_pressure_systole"] == 120
+    assert proposal.data["blood_pressure_diastole"] == 80
+    assert proposal.data["oxygen_saturation"] == 95
+
+
+def test_extract_with_observations_empty_text_with_observations() -> None:
+    """Observation-only path: emit a proposal even when the vitals section is empty.
+
+    ``display`` is rebuilt from validated data, not echoed from the (empty) text,
+    so the clinician sees the observation-sourced values immediately.
+    """
+    parser = VitalsParser()
+    obs = [_loinc_obs("8867-4", "74", unit="bpm", display="Heart rate")]
+    proposal = parser.extract_with_observations("", obs)
+    assert proposal is not None
+    assert proposal.data["pulse"] == 74
+    assert proposal.display == "HR 74 bpm"
+
+
+def test_extract_with_observations_none_returns_none() -> None:
+    """No regex hits and no observations means no proposal."""
+    parser = VitalsParser()
+    assert parser.extract_with_observations("Patient appears well.", []) is None
+
+
+def test_extract_with_observations_full_verbose_panel() -> None:
+    """End-to-end: the verbose-format prod failure expressed as LOINC observations (Path A)."""
+    parser = VitalsParser()
+    obs = [
+        _loinc_obs("85354-9", "103/56", unit="mmHg", display="Blood pressure"),
+        _loinc_obs("8867-4", "74", unit="bpm", display="Heart rate"),
+        _loinc_obs("9279-1", "16", unit="/min", display="Respiratory rate"),
+        _loinc_obs("8310-5", "97.8", unit="°F", display="Body temperature"),
+        _loinc_obs("2708-6", "94", unit="%", display="Oxygen saturation"),
+    ]
+    proposal = parser.extract_with_observations("", obs)
+    assert proposal is not None
+    assert proposal.data == {
+        "blood_pressure_systole": 103,
+        "blood_pressure_diastole": 56,
+        "pulse": 74,
+        "respiration_rate": 16,
+        "body_temperature": 97.8,
+        "oxygen_saturation": 94,
+    }
+
+
+# --- Negative regression tests -----------------------------------------------------
+# These pin failure modes the prior implementation silently mis-handled:
+#  * SpO2 regex used to capture O2 flow rate (e.g., "O2 2L NC" -> sat=2).
+#  * Parenthetical "Oxygen saturation (SpO2): 98%" used to miss.
+#  * Temperature with unknown unit (Kelvin, empty) used to be assumed °F.
+#  * Impossible values (BP 999/999, pulse 9999, SpO2 200%) used to flow through.
+
+
+def test_parse_vitals_does_not_extract_spo2_from_flow_rate() -> None:
+    """Flow-rate phrasings like ``O2 2L NC`` must NOT populate ``oxygen_saturation``."""
+    for text in (
+        "O2 2L NC",
+        "On O2 at 3 liters",
+        "Oxygen therapy at 2L",
+        "Patient on O2 via NC at 4 LPM",
+    ):
+        result = _parse_vitals(text)
+        assert "oxygen_saturation" not in result, f"flow-rate leaked into SpO2 for {text!r}: {result}"
+
+
+def test_parse_vitals_extracts_spo2_from_parenthetical_form() -> None:
+    """Nabla's verbose ``Oxygen saturation (SpO2): 98%`` form must populate ``oxygen_saturation``."""
+    result = _parse_vitals("- Oxygen saturation (SpO2): 98%")
+    assert result["oxygen_saturation"] == 98
+
+
+def test_observation_temperature_unknown_unit_refused_when_out_of_range() -> None:
+    """Kelvin temperatures must be refused (not silently written as °F)."""
+    obs = [_loinc_obs("8310-5", "310", unit="K", display="Body temperature")]
+    result = _parse_observations(obs)
+    assert "body_temperature" not in result
+
+
+def test_observation_temperature_empty_unit_inferred_celsius_via_range_gate() -> None:
+    """An observation value in the °C range with no unit converts to °F via the plausibility gate."""
+    obs = [_loinc_obs("8310-5", "37", unit="", display="Body temperature")]
+    result = _parse_observations(obs)
+    # 37°C -> 98.6°F.
+    assert result["body_temperature"] == 98.6
+
+
+def test_observation_temperature_empty_unit_already_fahrenheit_passes_through() -> None:
+    """An observation value already in the °F range with no unit passes through unconverted."""
+    obs = [_loinc_obs("8310-5", "98.6", unit="", display="Body temperature")]
+    result = _parse_observations(obs)
+    assert result["body_temperature"] == 98.6
+
+
+def test_observation_values_out_of_range_refused() -> None:
+    """Impossible values (BP 999/999, pulse 9999, SpO2 200) must NOT be written."""
+    obs = [
+        _loinc_obs("85354-9", "999/999", unit="mmHg", display="Blood pressure"),
+        _loinc_obs("8867-4", "9999", unit="bpm", display="Heart rate"),
+        _loinc_obs("2708-6", "200", unit="%", display="Oxygen saturation"),
+        _loinc_obs("9279-1", "999", unit="/min", display="Respiratory rate"),
+    ]
+    result = _parse_observations(obs)
+    assert "blood_pressure_systole" not in result
+    assert "blood_pressure_diastole" not in result
+    assert "pulse" not in result
+    assert "oxygen_saturation" not in result
+    assert "respiration_rate" not in result
+
+
+def test_regex_path_values_out_of_range_refused() -> None:
+    """The regex (fallback) path must apply the same plausibility gate as the observation path."""
+    text = "BP 999/999\nHR 9999\nSpO2 200%\nRR 999"
+    result = _parse_vitals(text)
+    assert "blood_pressure_systole" not in result
+    assert "blood_pressure_diastole" not in result
+    assert "pulse" not in result
+    assert "oxygen_saturation" not in result
+    assert "respiration_rate" not in result
+
+
+def test_observation_weight_empty_unit_in_ambiguous_band_refused() -> None:
+    """Empty-unit weight inside the kg/lbs overlap band (30-250) must be refused.
+
+    70 could be 70 kg (~155 lbs) or 70 lbs (~32 kg child). Without an
+    explicit unit we cannot tell, so we refuse rather than silently corrupt
+    the chart.
+    """
+    obs = [_loinc_obs("29463-7", "70", unit="", display="Body weight")]
+    result = _parse_observations(obs)
+    assert "weight_lbs" not in result
+
+
+def test_observation_weight_empty_unit_clearly_lbs_accepted() -> None:
+    """Empty-unit weight above the ambiguity band is unambiguously lbs and accepted."""
+    obs = [_loinc_obs("29463-7", "280", unit="", display="Body weight")]
+    result = _parse_observations(obs)
+    # 280 lbs is plausible for an adult; no adult is 280 kg (=617 lbs).
+    assert result["weight_lbs"] == 280
+
+
+def test_observation_weight_explicit_kg_converts_correctly() -> None:
+    """An explicit kg unit still converts even when the magnitude could be ambiguous."""
+    obs = [_loinc_obs("29463-7", "75", unit="kg", display="Body weight")]
+    result = _parse_observations(obs)
+    # 75 kg → 165 lbs (75 * 2.20462 = 165.35 → 165).
+    assert result["weight_lbs"] == 165
+
+
+def test_observation_height_empty_unit_in_ambiguous_band_refused() -> None:
+    """Empty-unit height inside the cm/in overlap band (30-80) must be refused.
+
+    65 could be 65 inches (5'5") or 65 cm (infant). Without an explicit
+    unit we cannot tell, so we refuse rather than silently corrupt the chart.
+    """
+    obs = [_loinc_obs("8302-2", "65", unit="", display="Body height")]
+    result = _parse_observations(obs)
+    assert "height" not in result
+
+
+def test_observation_height_empty_unit_clearly_inches_accepted() -> None:
+    """Empty-unit height above the ambiguity band is unambiguously inches and accepted."""
+    obs = [_loinc_obs("8302-2", "84", unit="", display="Body height")]
+    result = _parse_observations(obs)
+    # 84 inches = 7 feet — plausible upper-edge adult height. 84 cm would
+    # be a 2-year-old, far below the cm window for an adult patient.
+    assert result["height"] == 84
+
+
+def test_observation_loinc_iteration_is_deterministic() -> None:
+    """An observation carrying multiple mapped LOINC codes must resolve via the declared priority order."""
+    # Pulse + RR codes attached to the same observation. Declared order in
+    # ``_LOINC_TO_FIELD`` is pulse (8867-4) before RR (9279-1), so the
+    # observation maps to pulse first; RR stays open for a later observation.
+    # Value 40 is plausible for BOTH pulse (≥30) and RR (≤60), letting us
+    # verify the loop doesn't early-return without picking a value that the
+    # range gate would refuse for either field.
+    obs = [
+        Observation(
+            display="Multi-code",
+            value="40",
+            unit="bpm",
+            coding=[
+                CodingEntry(system="LOINC", code="9279-1", display=""),
+                CodingEntry(system="LOINC", code="8867-4", display=""),
+            ],
+        ),
+    ]
+    result = _parse_observations(obs)
+    # Pulse wins because it appears earlier in _LOINC_TO_FIELD priority order.
+    assert result.get("pulse") == 40
+    # RR also gets written because the loop no longer early-returns after
+    # the first match — this is intentional: subsequent codes on the same
+    # observation get a chance to populate their field.
+    assert result.get("respiration_rate") == 40
 
 
 def test_build() -> None:
@@ -145,3 +552,424 @@ def test_build_without_new_fields() -> None:
         note_uuid="note-uuid",
         command_uuid="cmd-uuid",
     )
+
+
+# --- Display/data agreement invariant (UAT Finding 1) ------------------------------
+# The display string must describe ONLY fields present in ``data``. If a field is
+# refused by ``_validate_field`` (range gate) it must be absent from BOTH ``data``
+# and ``display``. Prod failure mode: hypotension "BP 38/22" → systole below floor →
+# dropped from data, but Nabla's raw text still shown → clinician approves a
+# half-written BP. Fix: rebuild display from validated data.
+
+
+def test_format_vitals_display_empty_data_is_empty_string() -> None:
+    """Empty data dict yields an empty display string."""
+    assert _format_vitals_display({}) == ""
+
+
+def test_format_vitals_display_full_panel() -> None:
+    """Canonical order matches the post-edit formatter in static/summary.js."""
+    data: dict[str, int | float | None] = {
+        "blood_pressure_systole": 120,
+        "blood_pressure_diastole": 80,
+        "pulse": 72,
+        "respiration_rate": 16,
+        "oxygen_saturation": 98,
+        "body_temperature": 98.6,
+        "height": 70,
+        "weight_lbs": 180,
+    }
+    assert _format_vitals_display(data) == (
+        "BP 120/80 mmHg, HR 72 bpm, RR 16 /min, SpO2 98%, Temp 98.6 °F, Height 70 in, Weight 180 lbs"
+    )
+
+
+def test_format_vitals_display_partial_bp_drops_pair() -> None:
+    """BP pair: when only one of systole/diastole is present, neither appears."""
+    # Diastole present, systole absent (the hypotension UAT case): no BP in display.
+    assert _format_vitals_display({"blood_pressure_diastole": 22}) == ""
+    # Systole present, diastole absent: also no BP in display.
+    assert _format_vitals_display({"blood_pressure_systole": 38}) == ""
+
+
+def test_extract_hypotension_refused_systole_drops_atomic_bp_pair() -> None:
+    """UAT Finding 1 (hypotension): refused systole drops BOTH sides of the BP pair.
+
+    Real transcript shape: "Blood pressure 25 over 22, HR 110, RR 28, SpO2 88 on 4L, Temp 95.8".
+    Systole 25 < 30 SDK floor → refused. Diastole 22 ≥ 20 → would survive the per-field gate,
+    but BP is atomic: a half-BP is clinically meaningless and pollutes downstream
+    consumers (FHIR exports, analytics) even when the vitals UI hides a half-pair.
+    Both sides must be absent from data AND display.
+    """
+    text = "BP 25/22, HR 110, RR 28, SpO2 88, Temp 95.8"
+    parser = VitalsParser()
+    proposal = parser.extract_with_observations(text, [])
+    assert proposal is not None
+    assert "blood_pressure_systole" not in proposal.data
+    assert "blood_pressure_diastole" not in proposal.data
+    assert "25/22" not in proposal.display
+    assert "BP" not in proposal.display
+    # The other vitals still appear and are in the canonical format.
+    assert proposal.display == "HR 110 bpm, RR 28 /min, SpO2 88%, Temp 95.8 °F"
+
+
+def test_extract_isolated_diastole_observation_drops_atomic_bp_pair() -> None:
+    """Split-component path: an isolated diastole observation must not produce a half-BP.
+
+    Nabla sometimes emits systole and diastole as separate LOINC observations (8480-6
+    and 8462-4). If only one survives — whether refused by the range gate or simply
+    absent from Nabla's payload — the atomic-pair contract drops the orphan rather
+    than letting a half-BP leak into the chart.
+    """
+    parser = VitalsParser()
+    obs = [
+        # Diastole alone (valid value), no companion systole observation.
+        _loinc_obs("8462-4", "80", unit="mmHg", display="Diastolic BP"),
+        # An accompanying valid pulse so the proposal isn't empty.
+        _loinc_obs("8867-4", "72", unit="bpm", display="Heart rate"),
+    ]
+    proposal = parser.extract_with_observations("", obs)
+    assert proposal is not None
+    assert "blood_pressure_systole" not in proposal.data
+    assert "blood_pressure_diastole" not in proposal.data
+    assert proposal.data["pulse"] == 72
+    assert "BP" not in proposal.display
+    assert proposal.display == "HR 72 bpm"
+
+
+def test_extract_severe_hypoxia_refused_spo2_not_in_display() -> None:
+    """UAT Finding 1 (hypoxia): refused SpO2 (30 < 60 floor) must not appear in display.
+
+    Real transcript: "SpO2 30 percent on room air"-style input. With the tightened
+    SpO2 floor at 60 (UI form rejects <60), 30% is refused and must disappear from
+    BOTH data and display.
+    """
+    text = "HR 130, RR 35, SpO2 30%, Temp 99.8, BP 90/60"
+    parser = VitalsParser()
+    proposal = parser.extract_with_observations(text, [])
+    assert proposal is not None
+    assert "oxygen_saturation" not in proposal.data
+    assert "SpO2" not in proposal.display
+    assert "30%" not in proposal.display
+    # The fields that survived are present.
+    assert proposal.data["pulse"] == 130
+    assert proposal.data["respiration_rate"] == 35
+    assert proposal.data["body_temperature"] == 99.8
+    assert proposal.data["blood_pressure_systole"] == 90
+    assert proposal.data["blood_pressure_diastole"] == 60
+
+
+def test_extract_display_matches_data_invariant_via_observations() -> None:
+    """Same invariant on the observation path: refused values must not appear in display."""
+    parser = VitalsParser()
+    obs = [
+        # Systole 25 → refused (below SDK floor of 30).
+        _loinc_obs("8480-6", "25", unit="mmHg", display="Systolic BP"),
+        # Diastole 22 → accepted (≥ 20 SDK floor).
+        _loinc_obs("8462-4", "22", unit="mmHg", display="Diastolic BP"),
+        # SpO2 30 → refused (below 60 floor).
+        _loinc_obs("2708-6", "30", unit="%", display="Oxygen saturation"),
+        # Pulse 110 → accepted.
+        _loinc_obs("8867-4", "110", unit="bpm", display="Heart rate"),
+    ]
+    proposal = parser.extract_with_observations("", obs)
+    assert proposal is not None
+    assert "blood_pressure_systole" not in proposal.data
+    assert "oxygen_saturation" not in proposal.data
+    # Refused fields never appear in display.
+    assert "25" not in proposal.display
+    assert "30%" not in proposal.display
+    assert "SpO2" not in proposal.display
+    # Survivors do appear.
+    assert proposal.display == "HR 110 bpm"
+
+
+# --- _FIELD_RANGES boundary tests (UAT Finding 2) ----------------------------------
+# Each new boundary value must be refused. Documents the intersection of parser, SDK
+# pydantic constraints, and UI vitals-row.js spinbutton bounds.
+
+
+@pytest.mark.parametrize(
+    ("text", "field"),
+    [
+        # pulse: floor raised from 20 → 30 (SDK + UI agree).
+        ("HR 25", "pulse"),
+        # respiration_rate: floor raised from 4 → 6, ceiling lowered from 80 → 60.
+        ("RR 5", "respiration_rate"),
+        ("RR 75", "respiration_rate"),
+        # oxygen_saturation: floor raised from 40 → 60 (UI rejects <60).
+        ("SpO2 50%", "oxygen_saturation"),
+        # body_temperature: floor raised from 80 → 85, ceiling lowered from 115 → 107.
+        ("Temp 84", "body_temperature"),
+        ("Temp 110", "body_temperature"),
+    ],
+)
+def test_regex_path_rejects_value_below_new_boundary(text: str, field: str) -> None:
+    """Each value lies between the OLD parser bound and the NEW (tighter) bound — must be refused now."""
+    result = _parse_vitals(text)
+    assert field not in result, f"{text!r} should refuse {field}, got {result}"
+
+
+def test_regex_path_rejects_bp_diastole_above_new_ceiling() -> None:
+    """Diastole ceiling lowered from 200 → 180 (SDK + UI). 195 was accepted before; refused now.
+
+    ``_parse_vitals`` writes per-field; the atomic BP-pair sweep lives in
+    ``extract_with_observations`` (one chokepoint covering all paths), so this
+    direct-regex test only asserts the diastole side.
+    """
+    result = _parse_vitals("BP 140/195")
+    assert "blood_pressure_diastole" not in result
+
+
+def test_observation_path_rejects_pulse_below_30_floor() -> None:
+    """Pulse 25 was accepted by the old parser (floor=20) but rejected by SDK pydantic (ge=30)."""
+    obs = [_loinc_obs("8867-4", "25", unit="bpm", display="Heart rate")]
+    assert "pulse" not in _parse_observations(obs)
+
+
+def test_observation_path_rejects_spo2_below_60_floor() -> None:
+    """SpO2 50 was accepted by the old parser (floor=40) but rejected by the UI form (min=60)."""
+    obs = [_loinc_obs("2708-6", "50", unit="%", display="Oxygen saturation")]
+    assert "oxygen_saturation" not in _parse_observations(obs)
+
+
+def test_observation_path_rejects_temp_above_107_ceiling() -> None:
+    """Temperature 110°F was accepted by the old parser (ceiling=115) but rejected by SDK + UI (le=107)."""
+    obs = [_loinc_obs("8310-5", "110", unit="°F", display="Body temperature")]
+    assert "body_temperature" not in _parse_observations(obs)
+
+
+def test_observation_path_rejects_temp_below_85_floor() -> None:
+    """Temperature 80°F was accepted by the old parser (floor=80) but rejected by SDK + UI (ge=85)."""
+    obs = [_loinc_obs("8310-5", "80", unit="°F", display="Body temperature")]
+    assert "body_temperature" not in _parse_observations(obs)
+
+
+def test_observation_path_rejects_rr_above_60_ceiling() -> None:
+    """RR 75 was accepted by the old parser (ceiling=80) but rejected by SDK + UI (le=60)."""
+    obs = [_loinc_obs("9279-1", "75", unit="/min", display="Respiratory rate")]
+    assert "respiration_rate" not in _parse_observations(obs)
+
+
+def test_observation_path_rejects_diastole_above_180_ceiling() -> None:
+    """Diastole 195 was accepted by the old parser (ceiling=200) but rejected by SDK + UI (le=180)."""
+    obs = [_loinc_obs("8462-4", "195", unit="mmHg", display="Diastolic BP")]
+    assert "blood_pressure_diastole" not in _parse_observations(obs)
+
+
+def test_observation_path_accepts_new_lower_boundaries() -> None:
+    """Sanity: values AT the new floors must still be accepted."""
+    obs = [
+        _loinc_obs("8867-4", "30", unit="bpm", display="Heart rate"),
+        _loinc_obs("9279-1", "6", unit="/min", display="Respiratory rate"),
+        _loinc_obs("2708-6", "60", unit="%", display="Oxygen saturation"),
+        _loinc_obs("8310-5", "85", unit="°F", display="Body temperature"),
+        _loinc_obs("8462-4", "180", unit="mmHg", display="Diastolic BP"),
+    ]
+    result = _parse_observations(obs)
+    assert result["pulse"] == 30
+    assert result["respiration_rate"] == 6
+    assert result["oxygen_saturation"] == 60
+    assert result["body_temperature"] == 85
+    assert result["blood_pressure_diastole"] == 180
+
+
+def test_observation_path_accepts_new_upper_boundaries() -> None:
+    """Sanity: values AT the new ceilings must still be accepted."""
+    obs = [
+        _loinc_obs("8867-4", "250", unit="bpm", display="Heart rate"),
+        _loinc_obs("9279-1", "60", unit="/min", display="Respiratory rate"),
+        _loinc_obs("2708-6", "100", unit="%", display="Oxygen saturation"),
+        _loinc_obs("8310-5", "107", unit="°F", display="Body temperature"),
+        _loinc_obs("8462-4", "20", unit="mmHg", display="Diastolic BP"),
+    ]
+    result = _parse_observations(obs)
+    assert result["pulse"] == 250
+    assert result["respiration_rate"] == 60
+    assert result["oxygen_saturation"] == 100
+    assert result["body_temperature"] == 107
+    assert result["blood_pressure_diastole"] == 20
+
+
+# --- SDK-canonical _FIELD_RANGES (Fix 3) ----------------------------------------------
+# After widening the parser bounds to match SDK pydantic constraints exactly, values
+# that were previously refused by the parser-but-accepted-by-SDK must now flow through.
+
+
+def test_observation_path_accepts_severe_shock_systole_at_sdk_floor() -> None:
+    """Systole 30 (SDK floor) is now accepted by the parser too.
+
+    Previously refused: parser floor was 40, so severe-shock systole 30-39
+    landed as a half-BP candidate (atomic sweep then dropped both sides).
+    With the parser matching SDK pydantic ge=30, value 30 flows through.
+    """
+    obs = [
+        _loinc_obs("8480-6", "30", unit="mmHg", display="Systolic BP"),
+        _loinc_obs("8462-4", "20", unit="mmHg", display="Diastolic BP"),
+    ]
+    result = _parse_observations(obs)
+    assert result["blood_pressure_systole"] == 30
+    assert result["blood_pressure_diastole"] == 20
+
+
+def test_observation_path_accepts_super_bariatric_weight_at_sdk_ceiling() -> None:
+    """Weight 1500 lbs (SDK ceiling) is now accepted; previously refused at parser ceiling 1000."""
+    obs = [_loinc_obs("29463-7", "1500", unit="lbs", display="Body weight")]
+    result = _parse_observations(obs)
+    assert result["weight_lbs"] == 1500
+
+
+def test_observation_path_accepts_pediatric_height_at_sdk_floor() -> None:
+    """Height 10 in (SDK floor) is now accepted; previously refused at parser floor 12."""
+    obs = [_loinc_obs("8302-2", "10", unit="in", display="Body height")]
+    result = _parse_observations(obs)
+    assert result["height"] == 10
+
+
+def test_observation_path_accepts_tall_height_at_sdk_ceiling() -> None:
+    """Height 108 in (SDK ceiling) is now accepted; previously refused at parser ceiling 96."""
+    obs = [_loinc_obs("8302-2", "108", unit="in", display="Body height")]
+    result = _parse_observations(obs)
+    assert result["height"] == 108
+
+
+def test_observation_path_accepts_systole_at_sdk_ceiling() -> None:
+    """Systole 305 (SDK ceiling) is now accepted; previously refused at parser ceiling 300."""
+    obs = [
+        _loinc_obs("8480-6", "305", unit="mmHg", display="Systolic BP"),
+        _loinc_obs("8462-4", "180", unit="mmHg", display="Diastolic BP"),
+    ]
+    result = _parse_observations(obs)
+    assert result["blood_pressure_systole"] == 305
+
+
+# --- Display/data format invariant for integer-valued temperatures (Fix 1) -----------
+# The JS template literal in summary.js renders ``${data.body_temperature}`` which
+# after JSON round-trip turns 99.0 into 99 — so "Temp 99 °F", not "Temp 99.0 °F".
+# Python's default f-string formatting of a float keeps the trailing ``.0``. Using
+# ``:g`` drops it, aligning the backend with the JS rebuilder so the first edit
+# doesn't flash the format.
+
+
+def test_format_vitals_display_integer_valued_temperature_drops_trailing_zero() -> None:
+    """Integer-valued temperature (99.0) must render as ``Temp 99 °F``, not ``Temp 99.0 °F``."""
+    assert _format_vitals_display({"body_temperature": 99.0}) == "Temp 99 °F"
+
+
+def test_format_vitals_display_integer_temp_matches_int_input() -> None:
+    """The Python float 99.0 and the int 99 must produce the SAME display string.
+
+    Pins the round-trip invariant: after JSON serialization, 99.0 becomes 99 in JS,
+    which the frontend's template literal renders as ``99``. The backend must
+    match so the display string is stable across the JSON boundary.
+    """
+    assert _format_vitals_display({"body_temperature": 99.0}) == _format_vitals_display({"body_temperature": 99})
+    assert _format_vitals_display({"body_temperature": 99.0}) == "Temp 99 °F"
+
+
+def test_format_vitals_display_decimal_temperature_preserves_precision() -> None:
+    """A non-integer temperature (98.6) still renders with its decimal: ``Temp 98.6 °F``."""
+    assert _format_vitals_display({"body_temperature": 98.6}) == "Temp 98.6 °F"
+
+
+def test_format_vitals_display_temperatures_around_integer_boundary() -> None:
+    """Various integer-valued and decimal temperatures format correctly."""
+    assert _format_vitals_display({"body_temperature": 98.0}) == "Temp 98 °F"
+    assert _format_vitals_display({"body_temperature": 100.0}) == "Temp 100 °F"
+    assert _format_vitals_display({"body_temperature": 100.4}) == "Temp 100.4 °F"
+    assert _format_vitals_display({"body_temperature": 97.8}) == "Temp 97.8 °F"
+
+
+# --- extract_with_telemetry: refusals + source from FINAL surviving fields (Fix 2+4) ---
+
+
+def test_extract_with_telemetry_happy_path_has_no_refusals() -> None:
+    """The happy path produces no refusals. Used to pin silent-on-success behavior."""
+    parser = VitalsParser()
+    obs = [_loinc_obs("8867-4", "74", unit="bpm", display="Heart rate")]
+    result = parser.extract_with_telemetry("BP 120/80", obs)
+    assert result.proposal is not None
+    assert result.refusals == []
+    # Both paths contributed to the FINAL data → source is "both".
+    assert result.source == "both"
+
+
+def test_extract_with_telemetry_out_of_range_pulse_recorded() -> None:
+    """An out-of-range pulse from regex is recorded as ``out_of_range``."""
+    parser = VitalsParser()
+    result = parser.extract_with_telemetry("HR 25", [])
+    assert result.proposal is None
+    assert [r.field for r in result.refusals] == ["pulse"]
+    assert [r.reason for r in result.refusals] == [REFUSAL_REASON_OUT_OF_RANGE]
+    assert result.source == "none"
+
+
+def test_extract_with_telemetry_ambiguous_unit_recorded() -> None:
+    """An empty-unit weight in the kg/lbs band is recorded as ``ambiguous_unit``."""
+    parser = VitalsParser()
+    obs = [_loinc_obs("29463-7", "70", unit="", display="Body weight")]
+    result = parser.extract_with_telemetry("", obs)
+    assert result.proposal is None
+    assert [(r.field, r.reason) for r in result.refusals] == [
+        ("weight_lbs", REFUSAL_REASON_AMBIGUOUS_UNIT),
+    ]
+    assert result.source == "none"
+
+
+def test_extract_with_telemetry_atomic_bp_partial_recorded() -> None:
+    """An atomic-pair sweep that drops an orphan diastole is recorded as ``atomic_bp_partial``.
+
+    Systole 20 < SDK floor 30 → refused with ``out_of_range``. Diastole 22 survives
+    the per-field gate but is dropped by the atomic sweep. The orphan record carries
+    ``atomic_bp_partial`` reason. Both fields land in refusals.
+    """
+    parser = VitalsParser()
+    obs = [
+        _loinc_obs("8480-6", "20", unit="mmHg", display="Systolic BP"),
+        _loinc_obs("8462-4", "22", unit="mmHg", display="Diastolic BP"),
+    ]
+    result = parser.extract_with_telemetry("", obs)
+    refusal_map = {r.field: r.reason for r in result.refusals}
+    assert refusal_map == {
+        "blood_pressure_systole": REFUSAL_REASON_OUT_OF_RANGE,
+        "blood_pressure_diastole": REFUSAL_REASON_ATOMIC_BP_PARTIAL,
+    }
+
+
+def test_extract_with_telemetry_bp_panel_fully_refused_yields_source_none() -> None:
+    """Fix 2: fully-refused BP-panel observation must classify as source=none, not observations.
+
+    Risk-hunter scenario: Nabla emits a single BP-panel observation with both halves
+    out of range (BP 999/999). The per-field gate refuses both. With no other
+    observations and no regex text, the FINAL data is empty → source must be ``none``,
+    NOT ``observations``. This catches the race the prior implementation had: the
+    classifier looked at the raw input ``observations`` having entries, not at what
+    actually survived validation.
+    """
+    parser = VitalsParser()
+    obs = [_loinc_obs("85354-9", "999/999", unit="mmHg", display="Blood pressure")]
+    result = parser.extract_with_telemetry("", obs)
+    assert result.proposal is None
+    assert result.source == "none"
+    # Both halves are recorded as out-of-range refusals.
+    refusal_map = {r.field: r.reason for r in result.refusals}
+    assert refusal_map == {
+        "blood_pressure_systole": REFUSAL_REASON_OUT_OF_RANGE,
+        "blood_pressure_diastole": REFUSAL_REASON_OUT_OF_RANGE,
+    }
+
+
+def test_extract_with_telemetry_source_classified_from_final_survivors() -> None:
+    """source=both requires BOTH paths to contribute SURVIVING fields, not raw inputs.
+
+    Nabla emits a fully-refused BP observation (both halves out of range).
+    The regex text provides a valid HR. Final survivors: only HR (regex).
+    Source must be ``regex``, NOT ``both`` — even though both raw paths
+    had inputs, only the regex contributed survivors.
+    """
+    parser = VitalsParser()
+    obs = [_loinc_obs("85354-9", "999/999", unit="mmHg", display="Blood pressure")]
+    result = parser.extract_with_telemetry("HR 74", obs)
+    assert result.proposal is not None
+    assert result.proposal.data == {"pulse": 74}
+    assert result.source == "regex"

--- a/uv.lock
+++ b/uv.lock
@@ -2,6 +2,13 @@ version = 1
 revision = 3
 requires-python = ">=3.11, <3.13"
 
+[options]
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer-span = "P7D"
+
+[options.exclude-newer-package]
+canvas = { timestamp = "0001-01-01T00:00:00Z", span = "PT1S" }
+
 [[package]]
 name = "annotated-doc"
 version = "0.0.4"


### PR DESCRIPTION
[KOALA-5411](https://canvasmedical.atlassian.net/browse/KOALA-5411)

## Feature

Brigade providers reported the Scribe vitals card was "only capturing BP and pulse." Prod telemetry over 14 days confirmed: of 1,033 vitals commands, SpO2 was mentioned-but-dropped 21% of the time, respiratory rate 11%, height 2%, weight 2%. The root cause was a regex parser in `vitals.py` that handled Nabla's compact format (`BP 128/64, HR 75, RR 18, SpO2 95, Temp 97.9`) but failed against Nabla's verbose markdown-bullet format (`- O2 saturation: 94%`, `- Respiratory rate: 16 breaths per minute`). The token-anchored regexes for SpO2 and RR couldn't match the longer phrasings; metric units for height/weight were never handled.

## Implementation

Reads Nabla's structured `observations: list[Observation]` first via a LOINC-coded field map (BP panel + split, pulse, RR, SpO2 + alt-code, temp, height, weight), with the patched regex as a fallback when observations is empty. `_validate_field` matches the SDK pydantic bounds exactly so extraction can never produce a value `/insert-commands` would reject; out-of-range values are silently dropped. Unit converters refuse Kelvin / ambiguous-unit-band values rather than guess. `_format_vitals_display` rebuilds the human-readable card from validated data, mirroring the frontend's edit-time formatter so a refused field disappears from both `data` and `display` (no silent half-write). Atomic BP-pair sweep runs at extraction time so the AI path can't produce half-BP from a single-side refusal; the clinician edit path retains its existing freedom to enter one side independently. `VITALS_SOURCE` audit telemetry records which path fired per session (`observations` / `regex` / `both` / `none`); `VITALS_FIELD_REFUSED` surfaces refusal reasons (field name + category, no PHI value) for prod observability of how often validation drops real values.

[KOALA-5411]: https://canvasmedical.atlassian.net/browse/KOALA-5411?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ