### PR TITLE
scribe: parse dictated height + "Respiratory rate" so BMI shows on the vitals card

### DIFF
--- a/hyperscribe/scribe/commands/vitals.py
+++ b/hyperscribe/scribe/commands/vitals.py
@@ -28,8 +28,8 @@ def _parse_vitals(text: str) -> dict[str, int | float | None]:
         if m:
             result["pulse"] = int(m.group(1))
             continue
-        # Respiration
-        m = re.search(r"(?:RR|Resp(?:iration)?\s*(?:rate)?)[:\s]*(\d+)", line, re.IGNORECASE)
+        # Respiration — "RR", "Respiration", "Respiratory rate", "Resp rate"
+        m = re.search(r"(?:RR|Resp[a-z]*(?:\s*rate)?)[:\s]*(\d+)", line, re.IGNORECASE)
         if m:
             result["respiration_rate"] = int(m.group(1))
             continue
@@ -43,11 +43,26 @@ def _parse_vitals(text: str) -> dict[str, int | float | None]:
         if m:
             result["body_temperature"] = float(m.group(1))
             continue
-        # Height (feet'inches")
-        m = re.search(r"Height[:\s]*(\d+)'(\d+)\"", line, re.IGNORECASE)
-        if m:
-            result["height"] = int(m.group(1)) * 12 + int(m.group(2))
-            continue
+        # Height — stored in inches. The pipeline normalizes spoken height to plain
+        # inches ("70 in"), but also accept the typographic 5'10" form and spoken
+        # feet/inches ("5 ft 10 in", "5 feet 10 inches", "5 foot 10", "6 feet").
+        if re.search(r"\bheight\b", line, re.IGNORECASE):
+            feet_inches = re.search(
+                r"(\d+)\s*(?:'|ft\b|foot\b|feet\b)\s*(\d+)\s*(?:\"|in\b|inch|inches)?",
+                line,
+                re.IGNORECASE,
+            )
+            feet_only = re.search(r"(\d+)\s*(?:'|ft\b|foot\b|feet\b)", line, re.IGNORECASE)
+            inches_only = re.search(r"(\d+)\s*(?:\"|in\b|inch|inches)", line, re.IGNORECASE)
+            if feet_inches:
+                result["height"] = int(feet_inches.group(1)) * 12 + int(feet_inches.group(2))
+                continue
+            if feet_only:
+                result["height"] = int(feet_only.group(1)) * 12
+                continue
+            if inches_only:
+                result["height"] = int(inches_only.group(1))
+                continue
         # Weight
         m = re.search(r"Weight[:\s]*(\d+)\s*(?:lbs?|pounds?)", line, re.IGNORECASE)
         if m:

--- a/tests/hyperscribe/scribe/commands/test_vitals.py
+++ b/tests/hyperscribe/scribe/commands/test_vitals.py
@@ -77,6 +77,49 @@ def test_build() -> None:
     )
 
 
+def test_parse_vitals_respiratory_rate_phrasing() -> None:
+    # Nabla/LLM emits "Respiratory rate", not "Respiration" — the old regex missed it.
+    assert _parse_vitals("Respiratory rate: 14 breaths/min")["respiration_rate"] == 14
+
+
+def test_parse_vitals_height_plain_inches() -> None:
+    # The LLM normalizes spoken height to plain inches ("70 in"), never the 5'10" form.
+    assert _parse_vitals("Height: 70 in")["height"] == 70
+    assert _parse_vitals("Height: 70 inches")["height"] == 70
+
+
+def test_parse_vitals_height_spoken_feet_inches() -> None:
+    assert _parse_vitals("Height: 5 ft 10 in")["height"] == 70
+    assert _parse_vitals("Height: 5 feet 10 inches")["height"] == 70
+    assert _parse_vitals("Height: 5 foot 10")["height"] == 70
+
+
+def test_parse_vitals_height_feet_only() -> None:
+    assert _parse_vitals("Height: 6 feet")["height"] == 72
+
+
+def test_parse_vitals_production_display_string() -> None:
+    # The exact multi-line display the Scribe pipeline produced on scribeqa-sandbox.
+    text = (
+        "- Blood pressure: 124/76 mmHg\n"
+        "- Heart rate: 72 bpm\n"
+        "- Respiratory rate: 14 breaths/min\n"
+        "- Temperature: 98.2 °F\n"
+        "- Oxygen saturation: 99%\n"
+        "- Weight: 195 lb\n"
+        "- Height: 70 in"
+    )
+    result = _parse_vitals(text)
+    assert result["blood_pressure_systole"] == 124
+    assert result["blood_pressure_diastole"] == 76
+    assert result["pulse"] == 72
+    assert result["respiration_rate"] == 14
+    assert result["body_temperature"] == 98.2
+    assert result["oxygen_saturation"] == 99
+    assert result["weight_lbs"] == 195
+    assert result["height"] == 70
+
+
 def test_build_without_new_fields() -> None:
     parser = VitalsParser()
     data = {


### PR DESCRIPTION
## Summary

Fixes the Scribe vitals parser dropping **height** and **respiratory rate** from realistic dictation, which meant **BMI never appeared on the vitals card** even though the card-side rendering (added in #278) works correctly.

## Root cause

`_parse_vitals` in `hyperscribe/scribe/commands/vitals.py` had two regexes that don't match what the Scribe pipeline actually produces:

- **Height** only matched the typographic feet-inches form (`5'10"`). The pipeline normalizes spoken height to plain inches — e.g. dictating "Height 70 inches" yields a `Height: 70 in` display string, which never matched, so `height` was dropped. BMI is computed from height + weight, so with no height the card never showed a BMI.
- **Respiration** matched `Respiration`/`Resp`/`RR` but not `Respiratory rate`, which is the phrasing the pipeline emits, so `respiration_rate` was dropped as well.

## Fix

Height now parses, in priority order: typographic `5'10"`, spoken feet+inches (`5 ft 10 in`, `5 feet 10 inches`, `5 foot 10`), feet-only (`6 feet`), and plain inches (`70 in` / `70 inches`). Respiration now matches `Respiratory rate` in addition to the existing forms. Both store the same units as before (height in inches).

## How it was found

Fake-mic UAT on `scribeqa-sandbox` against `feat/canvas-scribe`: a dictated visit including "Weight 195 pounds. Height 70 inches" generated a vitals command whose `data` had weight but no height and no respiratory rate, and the vitals card showed no BMI. Typing the height into the card's edit form made `BMI 28` appear immediately — confirming the card render is fine and the gap was purely upstream parsing.

## Tests

Added `_parse_vitals` cases for the `Respiratory rate` phrasing, plain-inch and spoken feet/inch height forms, and the exact multi-line display string the pipeline produced. Red before, green after. Full `tests/hyperscribe/scribe/commands/` suite passes (450).

Note: there is a pre-existing, unrelated failure on the base branch (`test_edit_existing_commands_silently_drops_disallowed_section`, from the #259 Rx-validation interaction with edit-commands) — it fails on `feat/canvas-scribe` without this change and is not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)