### PR TITLE
fix: dedupe approved Scribe commands from Additional Commands (KOALA-5634)

### DIFF
--- a/hyperscribe/scribe/commands/_rx_validation.py
+++ b/hyperscribe/scribe/commands/_rx_validation.py
@@ -25,9 +25,11 @@ front-end, and makes the failure debuggable from the audit log.
 This module is intentionally framework-agnostic: pure functions that take a
 ``data`` dict and return a list of human-readable error strings.
 """
+
 from __future__ import annotations
 
 import re
+
 # NOTE: only ``Decimal`` is imported here. The Canvas plugin sandbox allowlists
 # ``Decimal`` from ``decimal`` but rejects ``InvalidOperation`` — importing it
 # raises ``ImportError`` at plugin-load time and de-registers every handler
@@ -58,9 +60,7 @@ def _has_value(value: Any) -> bool:
     return True
 
 
-def _validate_required_string(
-    data: dict[str, Any], field: str, label: str, errors: list[str]
-) -> None:
+def _validate_required_string(data: dict[str, Any], field: str, label: str, errors: list[str]) -> None:
     if not _has_value(data.get(field)):
         errors.append(f"{label} is required")
 
@@ -151,10 +151,7 @@ def _validate_sig(value: Any, errors: list[str]) -> None:
     if len(text) > SIG_MAX_LENGTH:
         errors.append(f"Sig exceeds {SIG_MAX_LENGTH} characters")
     if _RE_INVALID_CHARACTERS.search(text):
-        errors.append(
-            "Sig contains characters not allowed by Surescripts "
-            "(remove newlines, tabs, and non-ASCII)"
-        )
+        errors.append("Sig contains characters not allowed by Surescripts (remove newlines, tabs, and non-ASCII)")
 
 
 def _validate_note_to_pharmacist(value: Any, errors: list[str]) -> None:
@@ -163,13 +160,10 @@ def _validate_note_to_pharmacist(value: Any, errors: list[str]) -> None:
         return
     text = str(value)
     if len(text) > NOTE_TO_PHARMACIST_MAX_LENGTH:
-        errors.append(
-            f"Note to pharmacist exceeds {NOTE_TO_PHARMACIST_MAX_LENGTH} characters"
-        )
+        errors.append(f"Note to pharmacist exceeds {NOTE_TO_PHARMACIST_MAX_LENGTH} characters")
     if _RE_INVALID_CHARACTERS.search(text):
         errors.append(
-            "Note to pharmacist contains characters not allowed by Surescripts "
-            "(remove newlines, tabs, and non-ASCII)"
+            "Note to pharmacist contains characters not allowed by Surescripts (remove newlines, tabs, and non-ASCII)"
         )
 
 
@@ -189,8 +183,7 @@ def _validate_optional_change_medication_to(value: Any, errors: list[str]) -> No
         return
     if value.strip() == "":
         errors.append(
-            "New medication code is empty — leave it unset to keep the existing "
-            "medication, or pick a replacement"
+            "New medication code is empty — leave it unset to keep the existing medication, or pick a replacement"
         )
 
 

--- a/hyperscribe/scribe/commands/adjust_prescription.py
+++ b/hyperscribe/scribe/commands/adjust_prescription.py
@@ -51,9 +51,7 @@ class AdjustPrescriptionParser(CommandParser):
         if not fdb_code:
             return errors
         try:
-            patient_id = (
-                Note.objects.values_list("patient__id", flat=True).get(id=note_uuid)
-            )
+            patient_id = Note.objects.values_list("patient__id", flat=True).get(id=note_uuid)
         except Note.DoesNotExist:
             errors.append("Note not found; cannot verify the source medication")
             return errors

--- a/hyperscribe/scribe/commands/refill.py
+++ b/hyperscribe/scribe/commands/refill.py
@@ -39,9 +39,7 @@ class RefillParser(CommandParser):
         if not fdb_code:
             return errors
         try:
-            patient_id = (
-                Note.objects.values_list("patient__id", flat=True).get(id=note_uuid)
-            )
+            patient_id = Note.objects.values_list("patient__id", flat=True).get(id=note_uuid)
         except Note.DoesNotExist:
             errors.append("Note not found; cannot verify the medication")
             return errors
@@ -55,8 +53,7 @@ class RefillParser(CommandParser):
             .exists()
         ):
             errors.append(
-                "The selected medication is not active on this patient — "
-                "refill requires an existing active medication"
+                "The selected medication is not active on this patient — refill requires an existing active medication"
             )
         return errors
 

--- a/hyperscribe/scribe/static/summary.js
+++ b/hyperscribe/scribe/static/summary.js
@@ -456,6 +456,36 @@ export function Scribe({ noteId, patientId, staffId, staffName, providerName, pr
   const [cachedTemplateName, setCachedTemplateName] = useState(initSummary?.selected_template_name ?? null);
   const cacheLoadedRef = useRef(!!initialData);
   const addNowAttemptedRef = useRef([]);
+  // KOALA_5634_RECOMMENDATIONS_REF: live mirror of `recommendations`. syncNoteCommands
+  // needs to consult both `commands` (via the `setCommands(prev => ...)` updater) AND
+  // `recommendations` when deciding whether a fetched uuid is "Scribe-side" vs
+  // "ad-hoc / brand new." Adding `recommendations` to the useCallback deps would
+  // re-create syncNoteCommands on every recommendation accept / reject and re-fire
+  // every effect that depends on it; a ref keeps the callback stable while still
+  // exposing the latest value at call time. Bug context (KOALA-5634): without this,
+  // accepted recommendations get appended as `from_the_note` duplicates on the next
+  // syncNoteCommands call after approval.
+  const recommendationsRef = useRef(recommendations);
+  // KOALA_5634_RECOMMENDATIONS_REF: commitRecommendations() is the canonical
+  // entry point for ALL approval-flow setRecommendations writes (cache-load
+  // restore, /insert-commands success re-stamp, handleAddNow rec stamp).
+  // Why a helper instead of a one-off inline prime per call site:
+  //   - React's setRecommendations batches into a future commit. The useEffect
+  //     mirror at ~600 only runs post-commit. Approval-flow sites trigger
+  //     syncNoteCommands synchronously (cache-load via its `finally`, approve
+  //     via the post-success CLOSE_MODAL → NOTE_TAB_CHANGE bridge, handleAddNow
+  //     via NOTE_TAB_CHANGE on the just-inserted command). Without an imperative
+  //     prime that closes the gap, recommendationsRef.current reads stale and
+  //     syncNoteCommands appends just-stamped recs as `from_the_note` duplicates.
+  //   - Three sites is enough that an extracted helper beats remembering the
+  //     prime-then-set ordering at each call site.
+  // The ref mirror at ~600 stays as belt-and-braces for non-approval setRecommendations
+  // call sites (handleGenerate, handleMakeChanges, per-rec toggles) — they do not
+  // race against a synchronous syncNoteCommands trigger and don't need this helper.
+  const commitRecommendations = (next) => {
+    recommendationsRef.current = typeof next === 'function' ? next(recommendationsRef.current) : next;
+    setRecommendations(next);
+  };
   // Set to true after the first save-summary 403 (`_authorize_edit` denial:
   // note locked or wrong author). Gates subsequent autosaves so the Scribe
   // tab doesn't fire one POST per state change against a note it can't
@@ -583,6 +613,13 @@ export function Scribe({ noteId, patientId, staffId, staffName, providerName, pr
     setWasFinalized(true);
   }, [isAuthor, isNoteEditable, approved, commands, recommendations]);
 
+  // Keep the recommendations ref in lockstep with state so syncNoteCommands
+  // (a stable callback that intentionally avoids `recommendations` in its deps)
+  // sees the latest uuids when filtering fetched commands. See KOALA_5634_RECOMMENDATIONS_REF.
+  useEffect(() => {
+    recommendationsRef.current = recommendations;
+  }, [recommendations]);
+
   // Pull the note's actual Command rows from the server and merge them into
   // local state. Commands the Scribe already inserted itself stay as-is
   // (richer local data); commands that exist on the note but not locally are
@@ -600,6 +637,17 @@ export function Scribe({ noteId, patientId, staffId, staffName, providerName, pr
       const data = await res.json();
       const fetched = data.commands || [];
       const fetchedByUuid = new Map(fetched.map(c => [c.command_uuid, c]));
+      // KOALA_5634_SYNC_CONSULTS_RECOMMENDATIONS: collect uuids from the live
+      // recommendations list as well — accepted recs that were just inserted
+      // carry a command_uuid (stamped in handleInsert) but live in
+      // `recommendations`, not `commands`. Without this guard the next sync
+      // would treat the rec's uuid as unknown and append the chart row as a
+      // duplicate `from_the_note` card under ADDITIONAL COMMANDS (KOALA-5634).
+      const recommendationUuids = new Set(
+        (recommendationsRef.current || [])
+          .map(r => r && r.command_uuid)
+          .filter(Boolean)
+      );
       setCommands(prev => {
         const merged = [];
         const keptUuids = new Set();
@@ -620,11 +668,15 @@ export function Scribe({ noteId, patientId, staffId, staffName, providerName, pr
           // else: had a UUID but it's gone from the note → drop.
         }
         for (const cmd of fetched) {
-          if (!keptUuids.has(cmd.command_uuid)) {
-            // New ad-hoc command from the note body — append as-is so it
-            // lands in the FROM THE NOTE block.
-            merged.push(cmd);
-          }
+          if (keptUuids.has(cmd.command_uuid)) continue;
+          // KOALA_5634_SYNC_CONSULTS_RECOMMENDATIONS: skip uuids that are
+          // already represented by a stamped recommendation — they render in
+          // the SOAP groups via the `recommendations` array, not as locked
+          // ADDITIONAL COMMANDS cards.
+          if (recommendationUuids.has(cmd.command_uuid)) continue;
+          // New ad-hoc command from the note body — append as-is so it
+          // lands in the FROM THE NOTE block.
+          merged.push(cmd);
         }
         return merged;
       });
@@ -689,7 +741,13 @@ export function Scribe({ noteId, patientId, staffId, staffName, providerName, pr
             // Full cached summary — restore everything.
             setNoteData(cached.note);
             setCommands(cached.commands || []);
-            setRecommendations(cached.recommendations || []);
+            // KOALA_5634_RECOMMENDATIONS_REF: commitRecommendations() primes the
+            // ref synchronously before the syncNoteCommands() call in the `finally`
+            // block fires. Without that prime, a fetched command_uuid that belongs
+            // to a cached, stamped recommendation would be appended as a
+            // from_the_note duplicate (KOALA-5634), and the duplicate would
+            // persist because the next sync sees it in `commands` and preserves it.
+            commitRecommendations(cached.recommendations || []);
             setUnmatchedConditions(cached.unmatched_conditions || []);
             setDiagnosisSuggestions(cached.diagnosis_suggestions || {});
             // Repopulate Add Now attempted entries from cached items for verification merge.
@@ -1731,6 +1789,55 @@ export function Scribe({ noteId, patientId, staffId, staffName, providerName, pr
       }
     }
 
+    // KOALA_5634_DIAGNOSE_TO_ASSESS_UPSTREAM_FLIP: convert in place any diagnose row
+    // whose ICD-10 code matches an existing patient condition into an assess. Done
+    // BEFORE the insertable filter so the local `workingCommands` row already carries
+    // command_type='assess' by the time `/insert-commands` is POSTed and stamped.
+    // Why upstream-flip (Option A) instead of a post-stamp alias (the old approach):
+    // the alias keyed `diagnose:<truncated display>` against `assess:<truncated display>`,
+    // which could collide with an unrelated assess row that happened to share the
+    // 80-char display. Flipping the local row's command_type means the canonical
+    // `${command_type}:${display}` stamping key matches without any alias bookkeeping
+    // — and the local Scribe-side representation now matches what's actually on
+    // the chart. (KOALA-5634)
+    // Recommendations are not flipped here: the recommendations pipeline does not
+    // emit diagnose entries (medication_statement / allergy / refer / task /
+    // prescribe-via-rec only), so the rec stamp pass has no diagnose→assess
+    // mismatch to reconcile.
+    try {
+      const condRes = await fetch(
+        `${API_BASE}/patient-conditions?patient_id=${encodeURIComponent(patientId)}`
+      );
+      const condData = await condRes.json();
+      const codeToMatch = new Map();
+      for (const pc of (condData.conditions || [])) {
+        codeToMatch.set((pc.code || '').replace('.', '').toUpperCase(), pc);
+      }
+      workingCommands = workingCommands.map(c => {
+        if (c.command_type !== 'diagnose') return c;
+        // Only flip rows the provider actually accepted with an ICD - mirrors the
+        // downstream `allInsertable` filter that drops unaccepted/no-ICD diagnose
+        // rows entirely. Flipping a row without an ICD would create an assess
+        // with `condition_id=undefined` which would tank /insert-commands.
+        if (!c.data.icd10_code || !c.data.accepted) return c;
+        const code = (c.data.icd10_code || '').replace('.', '').toUpperCase();
+        const match = codeToMatch.get(code);
+        if (!match) return c;
+        return {
+          ...c,
+          command_type: 'assess',
+          data: {
+            condition_id: match.condition_id,
+            narrative: c.data.today_assessment || '',
+            background: c.data.background || null,
+            status: null,
+          },
+        };
+      });
+    } catch (err) {
+      console.error('Failed to fetch patient conditions for assess check:', err);
+    }
+
     const SECTION_TYPES = new Set(['physical_exam', 'ros', 'chart_review', 'history_review']);
     const insertable = workingCommands.filter(c => {
       // Either flag means "already on the note." command_uuid is the
@@ -1808,44 +1915,17 @@ export function Scribe({ noteId, patientId, staffId, staffName, providerName, pr
       });
       return;
     }
-    let allInsertable = [...insertable, ...acceptedRecs]
-      .map(({ _template_inserted, ...c }) => c); // Strip internal marker.
+    // Strip internal marker. Then drop any unmatched / unaccepted diagnose row that
+    // survived `insertable` (which only gates on `display`): the upstream Option-A
+    // flip (KOALA_5634_DIAGNOSE_TO_ASSESS_UPSTREAM_FLIP, just before the insertable
+    // filter) converts ICD-matched, accepted diagnose rows into assess rows, but
+    // rows that are unaccepted or lack an ICD stay as diagnose and must be dropped
+    // here before /insert-commands sees them (those rows have no condition_id and
+    // would tank the batch).
+    const allInsertable = [...insertable, ...acceptedRecs]
+      .map(({ _template_inserted, ...c }) => c)
+      .filter(c => c.command_type !== 'diagnose' || (c.data.icd10_code && c.data.accepted));
 
-    // Convert diagnose commands: match against patient conditions to decide assess vs diagnose.
-    // Skip diagnose commands with no ICD code (provider didn't select one).
-    try {
-      const condRes = await fetch(
-        `${API_BASE}/patient-conditions?patient_id=${encodeURIComponent(patientId)}`
-      );
-      const condData = await condRes.json();
-      const patientConditions = condData.conditions || [];
-
-      allInsertable = allInsertable
-        .filter(c => c.command_type !== 'diagnose' || (c.data.icd10_code && c.data.accepted))
-        .map(c => {
-          if (c.command_type !== 'diagnose') return c;
-          const code = (c.data.icd10_code || '').replace('.', '').toUpperCase();
-          const match = patientConditions.find(pc => {
-            const pcCode = (pc.code || '').replace('.', '').toUpperCase();
-            return pcCode === code;
-          });
-          if (match) {
-            return {
-              ...c,
-              command_type: 'assess',
-              data: {
-                condition_id: match.condition_id,
-                narrative: c.data.today_assessment || '',
-                background: c.data.background || null,
-                status: null,
-              },
-            };
-          }
-          return c;
-        });
-    } catch (err) {
-      console.error('Failed to fetch patient conditions for assess check:', err);
-    }
     // Prescriptions first so they appear at the top of the note.
     const RX_SET = new Set(['prescribe', 'refill', 'adjust_prescription']);
     allInsertable.sort((a, b) => (RX_SET.has(a.command_type) ? 0 : 1) - (RX_SET.has(b.command_type) ? 0 : 1));
@@ -1893,8 +1973,25 @@ export function Scribe({ noteId, patientId, staffId, staffName, providerName, pr
         // Amend re-stamping happened earlier (right after /edit-existing-commands
         // succeeded); here we only re-stamp the freshly-inserted commands.
         let updatedCommands = workingCommands;
+        // KOALA_5634_STAMP_RECOMMENDATIONS_ON_APPROVE: parallel re-stamp pass for
+        // accepted recommendations. Accepted recs are POSTed to /insert-commands
+        // alongside `workingCommands`, but the original stamping loop only iterated
+        // `workingCommands` — recs landed on the chart with server-side uuids while
+        // local `recommendations` stayed unstamped. The next syncNoteCommands then
+        // saw "new" uuids it couldn't match and appended every accepted rec under
+        // ADDITIONAL COMMANDS (KOALA-5634). Stamping recs the same way drops them
+        // into syncNoteCommands' uuid-match branch (line ~617), which preserves
+        // their section_key and only flips `already_documented=true`.
+        // Defaults to the unmodified closure; only reassigned below when `attempted`
+        // has entries to stamp. Empty-attempted = nothing to stamp = closure is
+        // faithful (no recs landed on the chart, so persisting the pre-stamp
+        // recommendations array is correct).
+        let updatedRecommendations = recommendations;
         if (data.attempted && data.attempted.length > 0) {
-          const uuidMap = new Map((data.attempted || []).map(a => [`${a.command_type}:${a.display}`, a.command_uuid]));
+          const uuidMap = new Map();
+          for (const a of (data.attempted || [])) {
+            uuidMap.set(`${a.command_type}:${a.display}`, a.command_uuid);
+          }
           updatedCommands = workingCommands.map(cmd => {
             const key = `${cmd.command_type}:${(cmd.display || '').slice(0, 80)}`;
             const uuid = uuidMap.get(key);
@@ -1906,6 +2003,22 @@ export function Scribe({ noteId, patientId, staffId, staffName, providerName, pr
             return uuid ? { ...cmd, command_uuid: uuid, already_documented: true } : cmd;
           });
           setCommands(updatedCommands);
+          updatedRecommendations = recommendations.map(rec => {
+            // Only stamp recs that we actually attempted to insert: accepted +
+            // not already on the chart + has a display string. Skip anything
+            // that already has a uuid (defensive — shouldn't happen on a fresh
+            // approval, but matters for re-approve flows).
+            if (rec.command_uuid || !rec.accepted || rec.already_documented || !rec.display) return rec;
+            const key = `${rec.command_type}:${(rec.display || '').slice(0, 80)}`;
+            const uuid = uuidMap.get(key);
+            return uuid ? { ...rec, command_uuid: uuid, already_documented: true } : rec;
+          });
+          // KOALA_5634_RECOMMENDATIONS_REF: commitRecommendations() primes the
+          // ref before the next syncNoteCommands fires (whether triggered by the
+          // post-success CLOSE_MODAL → NOTE_TAB_CHANGE bridge or by any other path)
+          // so it sees the stamped uuids without waiting for the useEffect
+          // ref-mirror to run post-commit.
+          commitRecommendations(updatedRecommendations);
         }
         // CACHE_FLIP_UNCONDITIONAL_ON_APPROVE_SUCCESS - KOALA-5485 cache-flip regression:
         // the approved=true cache write must fire UNCONDITIONALLY on the success branch,
@@ -1922,8 +2035,13 @@ export function Scribe({ noteId, patientId, staffId, staffName, providerName, pr
         //       for command types that don't surface attempted entries), the cache
         //       must reflect approved=true so reload doesn't lose the approval.
         // Pinned by `test_summary_js_cache_flip_to_approved_true_is_unconditional_on_success`.
+        // KOALA_5634_STAMP_RECOMMENDATIONS_ON_APPROVE: persist `updatedRecommendations`
+        // (with command_uuid + already_documented stamped on the accepted recs) — not
+        // the stale closure `recommendations`. Otherwise a page reload restores the
+        // pre-stamp state and the very next syncNoteCommands duplicates every accepted
+        // rec under ADDITIONAL COMMANDS.
         saveSummaryToCache(noteData, updatedCommands, true, {
-          recommendations, unmatched_conditions: unmatchedConditions,
+          recommendations: updatedRecommendations, unmatched_conditions: unmatchedConditions,
           diagnosis_suggestions: diagnosisSuggestions,
           selected_template_name: selectedTemplate?.name || null, mode,
         });
@@ -2066,7 +2184,14 @@ export function Scribe({ noteId, patientId, staffId, staffName, providerName, pr
         addNowAttemptedRef.current.push(attemptedEntry);
       }
       if (isRecommendation) {
-        setRecommendations(prev => prev.map((rec, i) =>
+        // KOALA_5634_RECOMMENDATIONS_REF: commitRecommendations() primes the ref
+        // synchronously so the next syncNoteCommands (typically NOTE_TAB_CHANGE
+        // on the freshly-inserted command) sees the new command_uuid in
+        // recommendationsRef.current and skips the matching fetched row. Without
+        // the prime, the just-added rec would re-appear under ADDITIONAL COMMANDS
+        // as a from_the_note duplicate. Same race class as cache-load and
+        // approve-success; same fix via the shared helper.
+        commitRecommendations(prev => prev.map((rec, i) =>
           i === index ? { ...rec, already_documented: true, accepted: true, _added_now: true, _adding: false, command_uuid: attemptedEntry?.command_uuid || null } : rec
         ));
       } else {

--- a/tests/hyperscribe/scribe/api/test_session_view.py
+++ b/tests/hyperscribe/scribe/api/test_session_view.py
@@ -1220,6 +1220,392 @@ def test_summary_js_cache_flip_to_approved_true_is_unconditional_on_success() ->
     )
 
 
+def test_summary_js_stamps_accepted_recommendations_after_insert_commands() -> None:
+    """KOALA-5634 ADDITIONAL COMMANDS duplicate regression (recommendations leg).
+
+    Bug: accepted recommendations (medication_statement, allergy, refer, task,
+    prescribe-via-rec) get POSTed to ``/insert-commands`` alongside scribe-side
+    commands, land successfully on the chart, but the post-success stamping
+    loop in ``handleInsert`` only iterates ``workingCommands`` - never
+    ``recommendations``. The recs stay with no ``command_uuid`` /
+    ``already_documented`` locally. The next ``syncNoteCommands`` (fires on
+    note-tab change, on mount, and after the cache load) fetches the same
+    uuids back from ``/note-commands``, can't match them against any local
+    state, and appends them under ``ADDITIONAL COMMANDS`` as
+    ``section_key=from_the_note`` cards - duplicating every accepted rec the
+    user just approved.
+
+    Two structural pins, both required:
+      1. Marker comment ``KOALA_5634_STAMP_RECOMMENDATIONS_ON_APPROVE`` is
+         present in ``summary.js`` (intent breadcrumb for future maintainers).
+      2. Inside ``handleInsert``'s success branch, a ``setRecommendations(``
+         call appears AFTER the existing ``setCommands(updatedCommands)`` call
+         and BEFORE the unconditional ``saveSummaryToCache(...true...)`` post-
+         success cache write. This pins the stamping order: stamp first, then
+         persist the stamped state.
+
+    Behavioral caveat: structural pin only - it does NOT execute React code.
+    A regression that deletes the marker but keeps the stamping is caught by
+    (1). A regression that removes ``setRecommendations`` from the success
+    branch is caught by (2). A behavioral pin would require JS test infra
+    (out of scope for this repo).
+    """
+    from pathlib import Path
+
+    summary_js = Path(__file__).resolve().parents[4] / "hyperscribe" / "scribe" / "static" / "summary.js"
+    src = summary_js.read_text()
+
+    # (1) Marker comment - intent / trace breadcrumb.
+    assert "KOALA_5634_STAMP_RECOMMENDATIONS_ON_APPROVE" in src, (
+        "summary.js handleInsert success branch is missing the "
+        "KOALA_5634_STAMP_RECOMMENDATIONS_ON_APPROVE marker. Without re-stamping "
+        "accepted recommendations with command_uuid + already_documented after "
+        "/insert-commands success, the next syncNoteCommands appends every "
+        "accepted rec as a from_the_note duplicate under ADDITIONAL COMMANDS. "
+        "Restore the setRecommendations(...) call alongside the existing "
+        "setCommands(...) stamp pass and tag it with the marker."
+    )
+
+    # (2) Structural: setCommands(updatedCommands) must be followed by a recs
+    # stamp call (commitRecommendations(...) post round-2 extraction, or
+    # setRecommendations(...) pre-extraction — accept either so this pin
+    # survives the helper extraction without losing teeth on the ordering
+    # invariant). That stamp must come BEFORE the unconditional success cache
+    # write so the cached payload reflects the stamped state.
+    set_commands_idx = src.find("setCommands(updatedCommands)")
+    assert set_commands_idx != -1, (
+        "Expected to find the `setCommands(updatedCommands)` stamp call inside "
+        "handleInsert's /insert-commands success branch. If the stamp variable "
+        "has been renamed, update this pin."
+    )
+
+    after_set_commands = src[set_commands_idx:]
+    recs_stamp_pattern = re.compile(r"(commitRecommendations|setRecommendations)\(")
+    recs_stamp_match = recs_stamp_pattern.search(after_set_commands)
+    assert recs_stamp_match is not None, (
+        "Missing recs stamp call (commitRecommendations(...) or "
+        "setRecommendations(...)) after setCommands(updatedCommands) in "
+        "handleInsert's success branch. Accepted recommendations need to be "
+        "stamped with their server-assigned command_uuid alongside the "
+        "workingCommands stamp pass - otherwise syncNoteCommands re-appends "
+        "them as ADDITIONAL COMMANDS duplicates (KOALA-5634)."
+    )
+
+    set_recs_idx = set_commands_idx + recs_stamp_match.start()
+
+    # The unconditional cache write (pinned by the KOALA-5485 test above) is the
+    # post-success persistence point. The recs stamp must run BEFORE it so the
+    # cached recommendations array carries the new uuids; otherwise a reload
+    # restores the un-stamped state and the next sync duplicates the recs.
+    unconditional_cache_pattern = re.compile(r"saveSummaryToCache\s*\(\s*noteData\s*,[^,]+,\s*true\s*,")
+    cache_match = unconditional_cache_pattern.search(src, set_commands_idx)
+    assert cache_match is not None, (
+        "Could not locate the unconditional saveSummaryToCache(..., true, ...) "
+        "post-success cache write after setCommands(updatedCommands). The "
+        "KOALA-5485 pin should also be failing - check that test for context."
+    )
+    assert set_recs_idx < cache_match.start(), (
+        "The recs stamp (commitRecommendations(...) / setRecommendations(...)) "
+        "must run BEFORE the unconditional saveSummaryToCache(..., true, ...) "
+        "call so the cached recommendations array carries the server-assigned "
+        "command_uuids. Currently the stamp happens after the cache write - on "
+        "reload the un-stamped recs come back and the next syncNoteCommands "
+        "duplicates them under ADDITIONAL COMMANDS (KOALA-5634)."
+    )
+
+
+def test_summary_js_sync_note_commands_skips_recommendation_uuids() -> None:
+    """KOALA-5634 ADDITIONAL COMMANDS duplicate regression (sync leg).
+
+    Bug context: stamping recommendations with ``command_uuid`` (the fix above)
+    is necessary but not sufficient. ``syncNoteCommands`` only consults the
+    ``commands`` array when deciding whether a fetched uuid is already
+    represented locally - stamped recommendations live in the ``recommendations``
+    array, so the sync still appends them as ``from_the_note`` cards.
+
+    Two structural pins, both required:
+      1. Marker comment ``KOALA_5634_SYNC_CONSULTS_RECOMMENDATIONS`` is present
+         in ``summary.js`` inside the syncNoteCommands callback.
+      2. The fallback branch that appends unmatched uuids (where the old code
+         pushed a ``from_the_note`` card) now contains a guard that consults a
+         recommendation-uuid set. Pinned by looking for the literal
+         ``recommendationUuids.has(`` test followed by a ``continue`` inside
+         the ``syncNoteCommands`` callback body.
+
+    Why a separate test from the stamping pin: the bug has two distinct fix
+    sites and either alone is insufficient. Splitting the test keeps each
+    site's regression surface tight.
+    """
+    from pathlib import Path
+
+    summary_js = Path(__file__).resolve().parents[4] / "hyperscribe" / "scribe" / "static" / "summary.js"
+    src = summary_js.read_text()
+
+    # (1) Marker comment.
+    assert "KOALA_5634_SYNC_CONSULTS_RECOMMENDATIONS" in src, (
+        "summary.js syncNoteCommands is missing the "
+        "KOALA_5634_SYNC_CONSULTS_RECOMMENDATIONS marker. Without consulting "
+        "the recommendation uuids, fetched uuids that belong to stamped "
+        "recommendations get appended as duplicate ADDITIONAL COMMANDS cards "
+        "(KOALA-5634)."
+    )
+
+    # (2) Structural: locate the syncNoteCommands declaration and ensure the
+    # body contains a `recommendationUuids.has(...)` guard. We slice from the
+    # callback start to a generous bound after it to avoid matching unrelated
+    # text far away in the file.
+    sync_decl = "const syncNoteCommands = useCallback(async () => {"
+    sync_idx = src.find(sync_decl)
+    assert sync_idx != -1, (
+        "Expected to find `const syncNoteCommands = useCallback(async () => {` "
+        "in summary.js. If the callback signature changed, update this pin."
+    )
+
+    # Walk forward counting braces to find the end of the callback body.
+    open_brace_pos = sync_idx + len(sync_decl) - 1  # position of the `{`
+    depth = 0
+    close_pos = -1
+    for i in range(open_brace_pos, len(src)):
+        if src[i] == "{":
+            depth += 1
+        elif src[i] == "}":
+            depth -= 1
+            if depth == 0:
+                close_pos = i
+                break
+    assert close_pos != -1, "Could not find matching close brace for syncNoteCommands callback body."
+
+    body = src[sync_idx:close_pos]
+    assert "recommendationUuids.has(" in body, (
+        "syncNoteCommands body must consult `recommendationUuids.has(...)` when "
+        "deciding whether to append a fetched command as a from_the_note card. "
+        "Without this guard, stamped recommendations get duplicated under "
+        "ADDITIONAL COMMANDS on every sync (KOALA-5634)."
+    )
+
+
+def test_summary_js_diagnose_to_assess_upstream_flip() -> None:
+    """KOALA-5634 ADDITIONAL COMMANDS duplicate regression (assess leg).
+
+    A ``diagnose`` command whose ICD-10 code matches an existing patient
+    condition is transformed into an ``assess`` at insert time. Round 1
+    addressed this with an alias step in the post-stamp ``uuidMap``
+    (``diagnose:<display>`` → server uuid). The alias relied solely on the
+    80-char-truncated display and could collide with an unrelated ``assess``
+    row that happened to share the same truncation. Round 2 (per the Council's
+    strategist) replaces the alias with an upstream flip: the local
+    ``workingCommands`` row is converted to ``assess`` BEFORE the
+    ``insertable`` filter, so the canonical ``${command_type}:${display}``
+    stamping key matches without any aliasing.
+
+    Three structural pins (all required):
+      1. Marker comment ``KOALA_5634_DIAGNOSE_TO_ASSESS_UPSTREAM_FLIP`` is
+         present in ``summary.js``.
+      2. A ``workingCommands = workingCommands.map(`` assignment carrying a
+         diagnose→assess transform appears BEFORE the ``insertable`` filter
+         (``const insertable = workingCommands.filter(``).
+      3. The post-stamp ``uuidMap.set(`diagnose:`` alias step has been
+         removed — its presence indicates a regression to the round-1 alias
+         approach (which carries the collision risk the upstream flip avoids).
+
+    Why pin #3 (negative assertion): if the alias re-appears alongside the
+    upstream flip, the alias takes precedence in the stamping path, which
+    silently re-introduces the collision surface the round-2 fix removed.
+    """
+    from pathlib import Path
+
+    summary_js = Path(__file__).resolve().parents[4] / "hyperscribe" / "scribe" / "static" / "summary.js"
+    src = summary_js.read_text()
+
+    # (1) Marker comment.
+    assert "KOALA_5634_DIAGNOSE_TO_ASSESS_UPSTREAM_FLIP" in src, (
+        "summary.js handleInsert is missing the "
+        "KOALA_5634_DIAGNOSE_TO_ASSESS_UPSTREAM_FLIP marker. Round 2 replaces "
+        "the round-1 post-stamp alias with an upstream flip of the local "
+        "workingCommands row; the marker is the intent breadcrumb for that "
+        "transition (KOALA-5634)."
+    )
+
+    # (2) The upstream flip must happen on workingCommands and must precede
+    # the insertable filter. We locate the marker and a nearby workingCommands
+    # reassignment that maps diagnose → assess, then assert that whole block
+    # sits before `const insertable = workingCommands.filter(`.
+    flip_marker_idx = src.find("KOALA_5634_DIAGNOSE_TO_ASSESS_UPSTREAM_FLIP")
+    insertable_decl = "const insertable = workingCommands.filter("
+    insertable_idx = src.find(insertable_decl)
+    assert insertable_idx != -1, (
+        "Expected to find `const insertable = workingCommands.filter(` in "
+        "summary.js handleInsert. If the variable name changed, update this pin."
+    )
+    assert flip_marker_idx < insertable_idx, (
+        "The KOALA_5634_DIAGNOSE_TO_ASSESS_UPSTREAM_FLIP block must appear "
+        "BEFORE the `const insertable = workingCommands.filter(` declaration. "
+        "Running the flip after `insertable` means the stamping key on "
+        "workingCommands still says `diagnose`, the canonical stamp key "
+        "misses, and the row duplicates on the next syncNoteCommands "
+        "(KOALA-5634)."
+    )
+    flip_window = src[flip_marker_idx:insertable_idx]
+    flip_assignment_pattern = re.compile(
+        r"workingCommands\s*=\s*workingCommands\.map\(",
+    )
+    assert flip_assignment_pattern.search(flip_window) is not None, (
+        "Expected `workingCommands = workingCommands.map(...)` inside the "
+        "KOALA_5634_DIAGNOSE_TO_ASSESS_UPSTREAM_FLIP block. The flip must "
+        "actually mutate workingCommands so the local row's command_type "
+        "becomes `assess` before the stamping loop runs (KOALA-5634)."
+    )
+    assess_flip_pattern = re.compile(
+        r"command_type:\s*['\"]assess['\"]",
+    )
+    assert assess_flip_pattern.search(flip_window) is not None, (
+        "The upstream-flip block must reassign the matched row's "
+        "`command_type` to 'assess'. Without that reassignment the "
+        "workingCommands row stays as `diagnose` and the canonical stamp "
+        "key still misses (KOALA-5634)."
+    )
+
+    # (3) Negative assertion: the round-1 alias step must NOT be present.
+    # `uuidMap.set(`diagnose:` was the load-bearing alias call; its absence
+    # is the regression-shield against re-introducing the collision-prone
+    # alias alongside the upstream flip.
+    assert "uuidMap.set(`diagnose:" not in src, (
+        "Found a `uuidMap.set(`diagnose:` call in summary.js. Round 2 "
+        "removed the post-stamp alias in favor of the upstream "
+        "KOALA_5634_DIAGNOSE_TO_ASSESS_UPSTREAM_FLIP. If the alias has been "
+        "reintroduced, the round-1 collision surface is back: the alias keys "
+        "solely on the 80-char-truncated display + command_type and can "
+        "stamp an unrelated assess row's uuid onto a diagnose row that "
+        "shares the truncated display."
+    )
+
+
+def test_summary_js_commit_recommendations_helper_centralizes_prime() -> None:
+    """KOALA-5634 single-helper invariant for ref-prime ordering.
+
+    Round 1 (and the first cut of round 2) had two-statement
+    ``recommendationsRef.current = X; setRecommendations(X)`` blocks at three
+    approval-flow sites: cache-load, /insert-commands success re-stamp, and
+    handleAddNow's rec stamp. Council consensus was to extract a
+    ``commitRecommendations`` helper so the prime-then-set ordering lives in
+    exactly one place (and a clear comment can explain WHY the prime is
+    necessary). This test pins the extraction.
+
+    Pins:
+      1. Marker comment ``KOALA_5634_RECOMMENDATIONS_REF`` is present.
+      2. The helper definition is co-located with the
+         ``recommendationsRef.current =`` assignment (i.e. the assignment
+         appears within ~400 chars of a marker, capturing the helper body).
+      3. The three approval-flow sites — cache-load (the ``loadOrGenerate``
+         body), ``handleInsert``'s /insert-commands success branch, and
+         ``handleAddNow`` — each call ``commitRecommendations(``.
+      4. Negative: none of those three sites contain an inline
+         ``recommendationsRef.current =`` assignment outside the helper. (The
+         useEffect mirror near line 600 is the only other legitimate
+         assignment and lives outside these handler bodies.)
+
+    Why a separate test from the three existing pins: those pin the
+    recommendation-uuid plumbing (stamping, sync filter, diagnose-flip). This
+    test pins the *coordination discipline* that keeps the prime-then-set
+    ordering uniform — so a future contributor can't quietly drop the prime
+    at a new call site without tripping a pin.
+    """
+    from pathlib import Path
+
+    summary_js = Path(__file__).resolve().parents[4] / "hyperscribe" / "scribe" / "static" / "summary.js"
+    src = summary_js.read_text()
+
+    # (1) Marker comment is present (multiple occurrences are fine — we just
+    # need at least one).
+    assert "KOALA_5634_RECOMMENDATIONS_REF" in src, (
+        "summary.js is missing the KOALA_5634_RECOMMENDATIONS_REF marker. "
+        "This marker tags the helper that centralizes the recommendationsRef "
+        "imperative prime; without it future readers have no breadcrumb for "
+        "the race-coupling between setRecommendations and a synchronous "
+        "syncNoteCommands trigger (KOALA-5634)."
+    )
+
+    # (2) Helper definition co-located with the assignment: a marker followed
+    # within ~400 chars by `recommendationsRef.current =`. This captures the
+    # helper body, where the assignment is the load-bearing statement.
+    helper_pattern = re.compile(
+        r"KOALA_5634_RECOMMENDATIONS_REF[\s\S]{0,400}recommendationsRef\.current\s*=",
+    )
+    assert helper_pattern.search(src) is not None, (
+        "Expected a `recommendationsRef.current = ...` assignment within ~400 "
+        "chars of a KOALA_5634_RECOMMENDATIONS_REF marker. The helper "
+        "definition should be co-located with the marker so the WHY (the "
+        "race that requires the imperative prime) lives next to the code "
+        "that does the priming."
+    )
+
+    # Helper to slice a JS function/callback body from `decl` to its matching
+    # close brace. Mirrors the brace-walk used in the syncNoteCommands pin
+    # below so we only assert against the relevant handler body.
+    def _slice_callback_body(haystack: str, decl: str) -> str:
+        start = haystack.find(decl)
+        assert start != -1, f"Expected to find `{decl}` in summary.js."
+        # Find the first `{` after the declaration anchor.
+        brace_open = haystack.find("{", start)
+        assert brace_open != -1, f"No opening brace found after `{decl}`."
+        depth = 0
+        for i in range(brace_open, len(haystack)):
+            ch = haystack[i]
+            if ch == "{":
+                depth += 1
+            elif ch == "}":
+                depth -= 1
+                if depth == 0:
+                    return haystack[start : i + 1]
+        raise AssertionError(f"Could not find matching close brace for `{decl}`.")
+
+    handle_insert_body = _slice_callback_body(src, "const handleInsert = useCallback(")
+    handle_add_now_body = _slice_callback_body(src, "const handleAddNow = useCallback(")
+    # loadOrGenerate is the cache-load async function inside the main load useEffect.
+    load_or_generate_body = _slice_callback_body(src, "async function loadOrGenerate()")
+
+    # (3) Each of the three sites calls commitRecommendations(.
+    assert "commitRecommendations(" in load_or_generate_body, (
+        "Cache-load (`loadOrGenerate`) must use commitRecommendations(...) to "
+        "restore the cached recommendations array. Without the helper the "
+        "imperative prime is missing and the cached, stamped recommendations' "
+        "uuids will not be in recommendationsRef.current when "
+        "syncNoteCommands fires in the `finally` block (KOALA-5634)."
+    )
+    assert "commitRecommendations(" in handle_insert_body, (
+        "handleInsert's /insert-commands success branch must use "
+        "commitRecommendations(updatedRecommendations) to stamp accepted "
+        "recommendations. Without the helper the ref-prime is missing and "
+        "the post-success syncNoteCommands re-appends the stamped recs as "
+        "ADDITIONAL COMMANDS duplicates (KOALA-5634)."
+    )
+    assert "commitRecommendations(" in handle_add_now_body, (
+        "handleAddNow's success branch (the isRecommendation stamping path) "
+        "must use commitRecommendations(...) so the just-stamped command_uuid "
+        "is in recommendationsRef.current before the next syncNoteCommands "
+        "trigger (typically NOTE_TAB_CHANGE on the freshly-added command). "
+        "Without the helper, the added rec re-appears under ADDITIONAL "
+        "COMMANDS as a from_the_note duplicate (KOALA-5634)."
+    )
+
+    # (4) Negative: no inline `recommendationsRef.current =` in these handler
+    # bodies. The only legitimate assignment lives in the helper itself and
+    # in the useEffect mirror (both outside these slices).
+    inline_assignment = "recommendationsRef.current ="
+    for site_name, body in (
+        ("loadOrGenerate", load_or_generate_body),
+        ("handleInsert", handle_insert_body),
+        ("handleAddNow", handle_add_now_body),
+    ):
+        assert inline_assignment not in body, (
+            f"Found an inline `recommendationsRef.current = ...` assignment "
+            f"inside `{site_name}`. Round 2 centralized the prime in "
+            "commitRecommendations(); replace the inline assignment with a "
+            "commitRecommendations(...) call so the prime-then-set ordering "
+            "and its WHY-comment live in exactly one place (KOALA-5634)."
+        )
+
+
 @patch("hyperscribe.scribe.api.session_view.audit_event")
 @patch("hyperscribe.scribe.api.session_view.build_effects")
 def test_insert_commands_audit_payload_excludes_display_phi(mock_build: MagicMock, mock_audit: MagicMock) -> None:
@@ -1630,12 +2016,25 @@ def test_edit_existing_commands_silently_drops_disallowed_section(mock_build: Ma
     mock_build.return_value = ([], [])
 
     view = _helper_instance()
+    # validate_proposals runs before the section_key filter, so the payload
+    # must pass shape validation for this test to actually exercise the
+    # silent-drop path. Use a fully valid prescribe payload — the section
+    # filter (not the validator) is what we're verifying drops it.
     commands = [
         {
             "command_type": "prescribe",
             "command_uuid": "rx-uuid",
             "section_key": "_recommended",  # not in EDITABLE_AMEND_SECTIONS
-            "data": {"sig": "daily"},
+            "data": {
+                "fdb_code": "285665",
+                "sig": "Take 1 tablet by mouth daily",
+                "quantity_to_dispense": 30,
+                "type_to_dispense": "C48480",
+                "refills": 2,
+                "substitutions": "allowed",
+                "days_supply": 30,
+                "note_to_pharmacist": "",
+            },
             "display": "Lisinopril",
         },
     ]

--- a/tests/hyperscribe/scribe/commands/test_rx_validation.py
+++ b/tests/hyperscribe/scribe/commands/test_rx_validation.py
@@ -212,9 +212,7 @@ def test_note_to_pharmacist_max_length_is_210() -> None:
     which would silently fail at REVIEW because canvas-core caps it at 210."""
     over = "a" * (NOTE_TO_PHARMACIST_MAX_LENGTH + 1)
     errors = validate_rx_payload(_good_payload(note_to_pharmacist=over))
-    assert any(
-        f"exceeds {NOTE_TO_PHARMACIST_MAX_LENGTH}" in e for e in errors
-    )
+    assert any(f"exceeds {NOTE_TO_PHARMACIST_MAX_LENGTH}" in e for e in errors)
     # Exactly at the boundary is fine.
     at_limit = "a" * NOTE_TO_PHARMACIST_MAX_LENGTH
     assert validate_rx_payload(_good_payload(note_to_pharmacist=at_limit)) == []

--- a/uv.lock
+++ b/uv.lock
@@ -2,6 +2,13 @@ version = 1
 revision = 3
 requires-python = ">=3.11, <3.13"
 
+[options]
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer-span = "P7D"
+
+[options.exclude-newer-package]
+canvas = { timestamp = "0001-01-01T00:00:00Z", span = "PT1S" }
+
 [[package]]
 name = "annotated-doc"
 version = "0.0.4"


### PR DESCRIPTION
[KOALA-5634](https://canvasmedical.atlassian.net/browse/KOALA-5634)

On Scribe summary approval, commands that successfully posted to the Commands tab were appearing duplicated under the **Additional Commands** section of the Summary tab — most commonly `medication_statement` recommendations and `diagnose` cards whose ICD matched a patient condition. The duplicates also weren't rendering as already-documented. Brigade-priority defect.

Three root causes, all in `summary.js`. (1) Accepted recommendations never had their server uuid stamped locally on `/insert-commands` success — only `workingCommands` did — so the next `syncNoteCommands` sweep saw "new" uuids and dropped them into the `from_the_note` fallback. (2) The diagnose→assess transformation flipped `command_type` on the POST but not on the local row, so the canonical `${command_type}:${display}` lookup never matched and stamping silently missed. (3) `syncNoteCommands` only consulted `commands`, not `recommendations`, so even a correctly-stamped rec would re-surface.

Fix extracts a `commitRecommendations(next)` helper that synchronously primes a `recommendationsRef` before `setRecommendations` at the three approval-flow sites (cache-load, approve, `handleAddNow`) — closing the React-commit race against `syncNoteCommands`. Diagnose rows that match a patient condition are now flipped to `command_type: 'assess'` upstream of the stamping pass so the canonical lookup key matches without alias bookkeeping (and without the 80-char-truncated `display` collision surface the alias would have introduced). Four structural-pin tests in `test_session_view.py` pin the invariants. Also fixes a pre-existing fixture bug in `test_edit_existing_commands_silently_drops_disallowed_section` whose prescribe payload lacked required `substitutions`/`fdb_code` fields, causing `validate_proposals` to 400 before the section-key filter could exercise the silent-drop contract under test.

Localhost UAT passed: approved a Scribe summary containing both a `medication_statement` recommendation and a `diagnose` with an ICD matching the patient's active condition; post-approval `from_the_note` contained only pre-existing ad-hoc chart commands (no duplicates of the just-approved entries), `already_documented=True` on the stamped rec.

[KOALA-5634]: https://canvasmedical.atlassian.net/browse/KOALA-5634?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ