### PR TITLE
feat: surface background carry-forward on recommended diagnoses (KOALA-5635)

### DIFF
--- a/hyperscribe/scribe/api/session_view.py
+++ b/hyperscribe/scribe/api/session_view.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import re
+import uuid
 from datetime import datetime, timezone
 from http import HTTPStatus
 from typing import Any, Union
@@ -64,6 +65,7 @@ from hyperscribe.scribe.commands.builder import (
     build_metadata_effects,
     prefill_assess_backgrounds,
     prefill_assess_backgrounds_for_proposals,
+    prefill_diagnose_backgrounds,
     validate_proposals,
 )
 from hyperscribe.scribe.commands.carry_forward import carry_forward_assess_background
@@ -1049,7 +1051,45 @@ class ScribeSessionView(StaffSessionAuthMixin, SimpleAPI):
             for p in proposals
         ]
         # A&P split: replace plan command with per-condition diagnose commands.
-        commands_list, unmatched_conditions = split_plan_into_diagnoses(commands_list, section_conditions)
+        # KOALA_5635_PREFILL_DIAGNOSE — pass ``note`` so split_plan stamps
+        # ``condition_id`` on diagnose proposals whose icd10_code matches an
+        # active condition on the patient; then run the dict-shaped diagnose
+        # carry-forward on the resulting commands_list. The upstream
+        # ``prefill_assess_backgrounds_for_proposals`` call above handles only
+        # assess proposals (which don't exist after the split — but the
+        # symmetric call here covers the new diagnose proposals the split
+        # produced). Wired only at this single site because diagnose proposals
+        # do not appear at /extract-commands or /recommend-commands — they're
+        # produced solely by split_plan_into_diagnoses in this flow.
+        # Pre-validate the UUID shape before the ORM lookup. Django's UUIDField
+        # raises ``django.core.exceptions.ValidationError`` (NOT ``ValueError``
+        # and NOT ``Note.DoesNotExist``) for malformed UUIDs; the plugin sandbox
+        # does NOT expose ``django.core.exceptions``, so we absorb that path
+        # upfront with ``uuid.UUID`` (allow-listed in the sandbox). The lookup
+        # catch then narrows to ``Note.DoesNotExist`` without swallowing real
+        # programming errors (AttributeError, TypeError, etc).
+        #
+        # NOTE: ``prefill_assess_backgrounds`` (~line 119 in builder.py) and
+        # ``prefill_assess_backgrounds_for_proposals`` (~line 211 in builder.py)
+        # both have the same latent ValidationError gap (``except
+        # (Note.DoesNotExist, ValueError)``). Deferred to a follow-up ticket
+        # per round-2 scope discipline; not exercised by any current fixture
+        # so the risk is dormant. Find by grep for the narrow tuple.
+        note_for_split: Note | None = None
+        if note_uuid:
+            try:
+                uuid.UUID(str(note_uuid))
+            except (ValueError, TypeError, AttributeError):
+                note_for_split = None
+            else:
+                try:
+                    note_for_split = Note.objects.select_related("patient").get(id=note_uuid)
+                except Note.DoesNotExist:
+                    note_for_split = None
+        commands_list, unmatched_conditions = split_plan_into_diagnoses(
+            commands_list, section_conditions, note=note_for_split
+        )
+        prefill_diagnose_backgrounds(commands_list, note_uuid)
 
         # ── Step 2.5: Reconcile template ROS/PE with Nabla-generated ones ──
         template_ros: list[dict[str, str]] | None = data.get("template_ros_sections")

--- a/hyperscribe/scribe/commands/ap_split.py
+++ b/hyperscribe/scribe/commands/ap_split.py
@@ -1,7 +1,13 @@
 from __future__ import annotations
 
 import re
-from typing import Any
+from typing import Any, TYPE_CHECKING
+
+from canvas_sdk.v1.data.condition import Condition as ConditionModel
+from logger import log
+
+if TYPE_CHECKING:
+    from canvas_sdk.v1.data.note import Note
 
 
 _STOP_WORDS = frozenset(
@@ -155,14 +161,107 @@ def _serialize_proposal(
     }
 
 
+def _normalize_icd10(code: str | None) -> str:
+    """Normalize an ICD-10 code for equality compare.
+
+    Mirrors the frontend ``handleInsert`` diagnose→assess flip in summary.js:
+    strip dots and uppercase. Centralizes the convention so backend and
+    frontend can't drift on what "same code" means.
+    """
+    if not code:
+        return ""
+    return code.replace(".", "").upper()
+
+
+def _build_active_condition_icd10_index(note: Note) -> dict[str, str]:
+    """Map normalized ICD-10 code → SDK condition_id for the note's patient.
+
+    Returns ``{}`` when the note has no patient, the lookup raises, or no
+    active conditions are found. The carry-forward / stamping is best-effort:
+    a missing match just means the diagnose proposal stays an unattached
+    ``diagnose`` (the frontend ``handleInsert`` patient-condition match step
+    is the existing safety net at insert time).
+
+    Uses ``ConditionModel.objects.active().for_patient(patient_id)`` to
+    mirror ``/patient-conditions``. The SDK ``condition.id`` corresponds to
+    home-app ``externally_exposable_id`` — the same shape the
+    ``carry_forward_assess_background`` helper expects in
+    ``proposal_data["condition_id"]`` (it filters ``condition__id=...``).
+    """
+    patient = getattr(note, "patient", None)
+    if patient is None:
+        return {}
+    patient_id = getattr(patient, "id", None)
+    if not patient_id:
+        return {}
+    index: dict[str, str] = {}
+    try:
+        # Per CLAUDE.md ("never fetch full objects from the database if you
+        # only need a couple properties"): pull just (condition_id,
+        # coding_code, coding_system) via ``.values_list()`` instead of
+        # ``.prefetch_related("codings")`` over full ORM objects. The
+        # ``codings`` reverse-FK join is expressed as a double-underscore
+        # field path; Django emits a LEFT JOIN to the coding table and
+        # yields one row per (condition, coding) pair. Conditions without
+        # any codings still surface (with NULL code/system) but get
+        # skipped by the ``not coding_code`` guard below.
+        rows = (
+            ConditionModel.objects.active()
+            .for_patient(str(patient_id))
+            .values_list("id", "codings__code", "codings__system")
+        )
+        for condition_id_raw, coding_code, coding_system in rows:
+            if not coding_code:
+                continue
+            if "icd" not in (coding_system or "").lower():
+                continue
+            normalized = _normalize_icd10(coding_code)
+            if not normalized or normalized in index:
+                continue
+            # Coerce condition_id to str: UUIDField on Postgres yields
+            # ``uuid.UUID`` from .values_list(), but downstream callers
+            # (carry_forward filter on ``condition__id=...``) compare
+            # against string form per SDK ID-mapping convention.
+            index[normalized] = str(condition_id_raw)
+    except Exception:
+        # The carry-forward/stamping is best-effort — a transient ORM error
+        # MUST NOT kill /generate-summary. Broad ``Exception`` is retained
+        # here (vs the narrow ``Note.DoesNotExist`` used at the two
+        # ``note_uuid`` lookup sites) because the failure mode is different:
+        # this catches transient DB/ORM errors during a custom-manager
+        # queryset chain, not malformed user input. ``note.id`` is
+        # internal-only and PHI-safe; do NOT log condition payloads,
+        # patient identifiers, or any clinical content.
+        log.exception(
+            "active condition icd10 index lookup failed for note %s",
+            getattr(note, "id", None),
+        )
+        return {}
+    return index
+
+
 def split_plan_into_diagnoses(
     commands: list[dict[str, Any]],
     section_conditions: dict[str, list[dict[str, Any]]],
+    note: Note | None = None,
 ) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
     """Replace the plan/assessment_and_plan command with per-condition diagnose commands.
 
     Returns ``(updated_commands, unmatched_conditions)`` where *unmatched_conditions*
     are conditions from normalized data that did not match any A&P block header.
+
+    KOALA_5635_STAMP_CONDITION_ID — when ``note`` is supplied, each produced
+    diagnose proposal whose ``icd10_code`` matches an active condition on the
+    note's patient gets ``data["condition_id"]`` stamped with the SDK
+    ``condition.id``. That makes the proposal eligible for the per-(patient,
+    condition) background carry-forward (the frontend later flips
+    ``command_type`` from ``diagnose`` → ``assess`` at insert time when the
+    same ICD-match holds; see ``handleInsert`` in summary.js).
+
+    Why ``note`` is optional: ``split_plan_into_diagnoses`` was pure (no DB
+    access) prior to KOALA-5635 and existing callers in tests still rely on
+    that contract. Callers that have a ``note`` opt-in to the stamping by
+    passing it; callers that don't get the original behavior.
     """
     ap_idx = -1
     for i, c in enumerate(commands):
@@ -181,6 +280,10 @@ def split_plan_into_diagnoses(
 
     diagnose_commands: list[dict[str, Any]] = []
     matched_set: set[int] = set()
+    # KOALA_5635_STAMP_CONDITION_ID — build the active-condition ICD-10 index
+    # once per call (not per block) so we don't N+1 patient_conditions per
+    # diagnose proposal. ``{}`` when ``note`` is None or the lookup fails.
+    active_icd10_index = _build_active_condition_icd10_index(note) if note is not None else {}
 
     for block in blocks:
         # Prefer exact match via Nabla's corresponding_note_problem field.
@@ -207,17 +310,29 @@ def split_plan_into_diagnoses(
             display = block.header
             icd10_code = None
             icd10_display = ""
+        # KOALA_5635_STAMP_CONDITION_ID — when this proposal's icd10_code
+        # matches an active condition on the note's patient, stamp the SDK
+        # condition_id so the dict-shaped carry-forward prefill at the call
+        # site can scope the background lookup to (patient, condition).
+        # Additive only: we do NOT flip command_type to "assess" here — the
+        # frontend handleInsert flip (KOALA-5634 territory) still owns the
+        # diagnose→assess decision at insert time.
+        data: dict[str, Any] = {
+            "icd10_code": icd10_code,
+            "icd10_display": icd10_display,
+            "condition_header": block.header,
+            "today_assessment": "\n".join(block.body),
+            "accepted": False,
+        }
+        if icd10_code and active_icd10_index:
+            stamped_id = active_icd10_index.get(_normalize_icd10(icd10_code))
+            if stamped_id:
+                data["condition_id"] = stamped_id
         diagnose_commands.append(
             _serialize_proposal(
                 command_type="diagnose",
                 display=display,
-                data={
-                    "icd10_code": icd10_code,
-                    "icd10_display": icd10_display,
-                    "condition_header": block.header,
-                    "today_assessment": "\n".join(block.body),
-                    "accepted": False,
-                },
+                data=data,
                 section_key=ap_cmd.get("section_key", "assessment_and_plan"),
             )
         )

--- a/hyperscribe/scribe/commands/builder.py
+++ b/hyperscribe/scribe/commands/builder.py
@@ -125,6 +125,66 @@ def prefill_assess_backgrounds(proposals: list[dict[str, Any]], note_uuid: str) 
         carry_forward_assess_background(data, note)
 
 
+def prefill_diagnose_backgrounds(proposals: list[dict[str, Any]], note_uuid: str) -> None:
+    """KOALA_5635 — dict-shaped diagnose carry-forward.
+
+    Pre-fill ``background`` on diagnose proposals (post-A&P-split) from the
+    most recent prior signed Assessment for the same (patient, condition).
+    Symmetric with :func:`prefill_assess_backgrounds`, but filtered to
+    ``command_type == "diagnose"`` because diagnose proposals only emerge
+    AFTER ``split_plan_into_diagnoses`` runs in ``post_generate_summary``,
+    while the assess-shaped prefill runs earlier (before the split) on the
+    upstream ``CommandProposal``-shaped list.
+
+    Mutates ``proposals[i]["data"]["background"]`` in place. Skips silently
+    when the note can't be loaded, when no diagnose proposals carry a
+    ``condition_id`` (the stamping in ``split_plan_into_diagnoses`` is the
+    upstream gate), or when the lookup fails — the carry-forward is a
+    convenience, not a correctness gate.
+
+    Why a parallel function rather than broadening
+    ``prefill_assess_backgrounds`` to ``("assess", "diagnose")``: at the
+    only site that runs after ``split_plan_into_diagnoses`` (line ~915 of
+    session_view.py), the assess proposals have already been processed by
+    the upstream call. Broadening the filter would re-iterate over them
+    redundantly and conflate two timing layers. The two functions share a
+    delegate (``carry_forward_assess_background``); the symmetry sits at
+    the helper boundary, not the public-function boundary.
+    """
+    if not note_uuid:
+        return
+    diagnose_proposals = [p for p in proposals if p.get("command_type") == "diagnose"]
+    if not diagnose_proposals:
+        return
+    # Pre-validate the UUID shape BEFORE handing it to ``Note.objects.get``.
+    # Django's UUIDField raises ``django.core.exceptions.ValidationError``
+    # (NOT ``ValueError`` and NOT ``Note.DoesNotExist``) for malformed UUIDs
+    # at filter-prep time. The plugin sandbox does NOT expose
+    # ``django.core.exceptions`` (see ``ALLOWED_MODULES`` in
+    # plugin_runner/sandbox.py), so we can't catch it directly here. The
+    # workaround is to validate the UUID shape upfront with ``uuid.UUID``
+    # (which IS in the sandbox allowlist) — that absorbs the malformed-UUID
+    # path so the lookup catch can be the narrow ``Note.DoesNotExist``
+    # without swallowing real programming errors (AttributeError, TypeError).
+    try:
+        uuid.UUID(str(note_uuid))
+    except (ValueError, TypeError, AttributeError):
+        return
+    try:
+        # Carry-forward is best-effort. ``note.id`` is internal-only and
+        # PHI-safe; do NOT log condition payloads, patient identifiers,
+        # or any clinical content.
+        note = Note.objects.select_related("patient").get(id=note_uuid)
+    except Note.DoesNotExist:
+        log.info("prefill_diagnose_backgrounds note lookup miss for %s", note_uuid)
+        return
+    for proposal in diagnose_proposals:
+        data = proposal.get("data")
+        if not isinstance(data, dict):
+            continue
+        carry_forward_assess_background(data, note)
+
+
 def prefill_assess_backgrounds_for_proposals(proposals: list[CommandProposal], note_uuid: str) -> None:
     """``CommandProposal``-shaped variant of :func:`prefill_assess_backgrounds`.
 

--- a/hyperscribe/scribe/static/diagnose-row.js
+++ b/hyperscribe/scribe/static/diagnose-row.js
@@ -27,17 +27,25 @@ function formatIcdCode(raw) {
 export function DiagnoseRow({ command, commandIndex, onEdit, onDelete, readOnly, suggestions, onAccept, onEditingChange }) {
   const data = command.data || {};
   const hasCode = !!data.icd10_code;
-  // KOALA_5635_BACKGROUND_GATE — gate the editable Background section on
-  // ``data.condition_id``. The id is stamped server-side by
-  // ``split_plan_into_diagnoses`` when this proposal's icd10_code matches an
-  // an active condition on the patient. That's also the predicate
-  // ``handleInsert`` uses to flip this row from diagnose → assess at insert
-  // time; rendering Background only when the flip is on the table keeps the
-  // UI honest about which proposals carry a per-(patient, condition)
-  // background. Without a condition_id there is no scope for carry-forward
-  // and the field would be free-text that the home-app assess command
-  // wouldn't persist anyway.
-  const hasConditionId = !!data.condition_id;
+  // KOALA_5635_BACKGROUND_ALWAYS_RENDER — Background renders on EVERY
+  // diagnose-row card, regardless of whether the proposal matched an active
+  // patient condition. Round-2 gated this on ``data.condition_id``; Kevin's
+  // UAT explicitly rejected that gate: the field must be available for ALL
+  // condition cards in ALL situations — new diagnosis, matched assess, AI
+  // rec, user-initiated, prior-background-empty-or-not, and after an ICD
+  // change.
+  //
+  // No silent-drop risk on unmatched ICDs: ``DiagnoseCommand`` in the
+  // canvas-plugins SDK (canvas_sdk/commands/commands/diagnose.py) carries a
+  // ``background: str | None = None`` field, so background round-trips
+  // through both the diagnose and assess persistence paths.
+  //
+  // The KOALA_5635_CLEAR_ON_ICD_CHANGE behavior (handleSelect /
+  // handleClearCode) is STILL in force — the section stays rendered after an
+  // ICD change, but the text content is explicitly cleared. That's the
+  // Council-blessed clinical-data-integrity safeguard against cross-
+  // attaching one condition's background text onto a different condition's
+  // Assessment row in the chart.
 
   const [editingCode, setEditingCode] = useState(!hasCode);
   const [editingText, setEditingText] = useState(false);
@@ -57,9 +65,7 @@ export function DiagnoseRow({ command, commandIndex, onEdit, onDelete, readOnly,
   // KOALA_5635_BACKGROUND_TEXTAREA — local state mirrors AssessNarrative's
   // pattern (soap-group.js): seed from ``data.background``, sync on
   // external prop change ONLY when not editing so a late carry-forward
-  // fetch can't clobber in-progress typing. The state is intentionally NOT
-  // gated on ``hasConditionId`` so the hook order stays stable across
-  // renders (React rule of hooks).
+  // fetch can't clobber in-progress typing.
   const [background, setBackground] = useState(data.background || '');
   const inputRef = useRef(null);
   const containerRef = useRef(null);
@@ -192,14 +198,19 @@ export function DiagnoseRow({ command, commandIndex, onEdit, onDelete, readOnly,
   };
 
   const handleSaveAssessment = () => {
-    // KOALA_5635_BACKGROUND_TEXTAREA — when condition_id is present we also
-    // persist ``background`` through the spread; for non-condition rows we
-    // still spread ``data`` so any pre-existing ``background`` field on the
-    // proposal (set by an upstream carry-forward) round-trips untouched.
-    const newData = { ...data, today_assessment: assessment, accepted: true, rejected: false };
-    if (hasConditionId) {
-      newData.background = background;
-    }
+    // KOALA_5635_BACKGROUND_ALWAYS_RENDER — persist ``background`` on EVERY
+    // save, not only when ``condition_id`` is stamped. The render gate was
+    // removed per Kevin's UAT; the save gate must follow. DiagnoseCommand
+    // accepts background, so unmatched-ICD rows persist it cleanly through
+    // the diagnose path. A round-tripped save that silently drops what the
+    // user typed would be exactly the UX trap the UAT was pushing back on.
+    const newData = {
+      ...data,
+      today_assessment: assessment,
+      background: background,
+      accepted: true,
+      rejected: false,
+    };
     onEdit(commandIndex, newData, 'diagnose');
     setEditingText(false);
   };
@@ -276,26 +287,31 @@ export function DiagnoseRow({ command, commandIndex, onEdit, onDelete, readOnly,
           class="diagnose-row-body${readOnly ? '' : ' editable'}"
           onClick=${() => !readOnly && setEditingText(true)}
         >
-          ${/* KOALA_5635_BACKGROUND_TEXTAREA — read-only Background block,
-              shown only when condition_id is stamped. Mirrors AssessNarrative
+          ${/* KOALA_5635_BACKGROUND_ALWAYS_RENDER — read-only Background
+              block. Renders on every editable card so the affordance is
+              visible regardless of condition_id (Kevin UAT). On truly
+              read-only cards (post-approval) we still suppress when there's
+              nothing to show — an empty BACKGROUND label on a locked card
+              is noise; the user can't act on it. Mirrors AssessNarrative
               (soap-group.js) so a future merge can reconcile shape if rec-
               diagnose is consolidated into the assess UI. */ ''}
-          ${hasConditionId && (data.background || '').length > 0 && html`
+          ${(!readOnly || (data.background || '').length > 0) && html`
             <div class="diagnose-body-label">Background</div>
-            ${(data.background || '').split('\n').map((line, i) => html`
-              <div key=${'b' + i} class="diagnose-body-line">${line}</div>
-            `)}
-            ${(data.background || '').length > 2048 && html`
-              <div class="char-counter over-limit">${data.background.length} / 2048 — text must be shortened before approving</div>
-            `}
+            <div class="rec-hint">Optional. You write this. Carries forward to every note.</div>
+            ${(data.background || '').length > 0
+              ? (data.background || '').split('\n').map((line, i) => html`
+                  <div key=${'b' + i} class="diagnose-body-line">${line}</div>
+                `)
+              : html`<div class="diagnose-body-empty">No background text</div>`}
+            <div class="char-counter${(data.background || '').length > 1900 ? (data.background || '').length > 2048 ? ' over-limit' : ' near-limit' : ''}">${(data.background || '').length} / 2048${(data.background || '').length > 2048 ? ' — text must be shortened before approving' : ''}</div>
           `}
-          ${hasConditionId && (data.background || '').length > 0 && html`
+          ${(!readOnly || (data.background || '').length > 0) && html`
             <div class="diagnose-body-label">Today's assessment</div>
           `}
           ${(data.today_assessment || '').split('\n').map((line, i) => html`
             <div key=${i} class="diagnose-body-line">${line}</div>
           `)}
-          ${!data.today_assessment && !(hasConditionId && (data.background || '').length > 0) && html`
+          ${!data.today_assessment && !(!readOnly || (data.background || '').length > 0) && html`
             <div class="diagnose-body-empty">No assessment text</div>
           `}
           ${(data.today_assessment || '').length > 2048 && html`
@@ -306,25 +322,27 @@ export function DiagnoseRow({ command, commandIndex, onEdit, onDelete, readOnly,
 
       ${editingText && !readOnly && html`
         <div class="diagnose-edit-area">
-          ${/* KOALA_5635_BACKGROUND_TEXTAREA — editable Background textarea,
-              shown only when condition_id is stamped. Above the today's
-              assessment textarea to match AssessNarrative ordering. */ ''}
-          ${hasConditionId && html`
-            <div class="diagnose-body-label">Background</div>
-            <textarea
-              ref=${backgroundRef}
-              class="command-row-textarea"
-              maxLength=${2048}
-              value=${background}
-              onInput=${(e) => setBackground(e.target.value)}
-              onKeyDown=${handleTextKeyDown}
-            />
-            <div class="char-counter${background.length > 1900 ? background.length > 2048 ? ' over-limit' : ' near-limit' : ''}">${background.length} / 2048</div>
-            <div class="diagnose-body-label">Today's assessment</div>
-          `}
+          ${/* KOALA_5635_BACKGROUND_ALWAYS_RENDER — editable Background
+              textarea. Renders unconditionally (Kevin UAT). 2-row textarea
+              (shorter than the 5-row Today's assessment below) with a
+              visible character counter at all character counts. */ ''}
+          <div class="diagnose-body-label">Background</div>
+          <div class="rec-hint">Optional. You write this. Carries forward to every note.</div>
+          <textarea
+            ref=${backgroundRef}
+            class="command-row-textarea"
+            rows=${2}
+            maxLength=${2048}
+            value=${background}
+            onInput=${(e) => setBackground(e.target.value)}
+            onKeyDown=${handleTextKeyDown}
+          />
+          <div class="char-counter${background.length > 1900 ? background.length > 2048 ? ' over-limit' : ' near-limit' : ''}">${background.length} / 2048</div>
+          <div class="diagnose-body-label">Today's assessment</div>
           <textarea
             ref=${textareaRef}
             class="command-row-textarea"
+            rows=${5}
             maxLength=${2048}
             value=${assessment}
             onInput=${(e) => setAssessment(e.target.value)}
@@ -333,7 +351,7 @@ export function DiagnoseRow({ command, commandIndex, onEdit, onDelete, readOnly,
           <div class="char-counter${assessment.length > 1900 ? assessment.length > 2048 ? ' over-limit' : ' near-limit' : ''}">${assessment.length} / 2048</div>
           <div class="command-row-actions">
             <button type="button" class="form-btn form-btn-cancel" onClick=${handleCancelAssessment}>Cancel</button>
-            <button type="button" class="form-btn form-btn-save" disabled=${assessment.length > 2048 || (hasConditionId && background.length > 2048)} onClick=${handleSaveAssessment}>Save</button>
+            <button type="button" class="form-btn form-btn-save" disabled=${assessment.length > 2048 || background.length > 2048} onClick=${handleSaveAssessment}>Save</button>
           </div>
         </div>
       `}

--- a/hyperscribe/scribe/static/diagnose-row.js
+++ b/hyperscribe/scribe/static/diagnose-row.js
@@ -27,6 +27,17 @@ function formatIcdCode(raw) {
 export function DiagnoseRow({ command, commandIndex, onEdit, onDelete, readOnly, suggestions, onAccept, onEditingChange }) {
   const data = command.data || {};
   const hasCode = !!data.icd10_code;
+  // KOALA_5635_BACKGROUND_GATE — gate the editable Background section on
+  // ``data.condition_id``. The id is stamped server-side by
+  // ``split_plan_into_diagnoses`` when this proposal's icd10_code matches an
+  // an active condition on the patient. That's also the predicate
+  // ``handleInsert`` uses to flip this row from diagnose → assess at insert
+  // time; rendering Background only when the flip is on the table keeps the
+  // UI honest about which proposals carry a per-(patient, condition)
+  // background. Without a condition_id there is no scope for carry-forward
+  // and the field would be free-text that the home-app assess command
+  // wouldn't persist anyway.
+  const hasConditionId = !!data.condition_id;
 
   const [editingCode, setEditingCode] = useState(!hasCode);
   const [editingText, setEditingText] = useState(false);
@@ -43,9 +54,27 @@ export function DiagnoseRow({ command, commandIndex, onEdit, onDelete, readOnly,
   const [searching, setSearching] = useState(false);
   const [searched, setSearched] = useState(false);
   const [assessment, setAssessment] = useState(data.today_assessment || '');
+  // KOALA_5635_BACKGROUND_TEXTAREA — local state mirrors AssessNarrative's
+  // pattern (soap-group.js): seed from ``data.background``, sync on
+  // external prop change ONLY when not editing so a late carry-forward
+  // fetch can't clobber in-progress typing. The state is intentionally NOT
+  // gated on ``hasConditionId`` so the hook order stays stable across
+  // renders (React rule of hooks).
+  const [background, setBackground] = useState(data.background || '');
   const inputRef = useRef(null);
   const containerRef = useRef(null);
   const textareaRef = useRef(null);
+  const backgroundRef = useRef(null);
+
+  // KOALA_5635_BACKGROUND_TEXTAREA — sync local ``background`` from data
+  // when the row isn't being edited. Mirrors AssessNarrative; needed
+  // because useState initializes once and the carry-forward fetch may
+  // resolve AFTER first render.
+  useEffect(() => {
+    if (!editingText) {
+      setBackground(data.background || '');
+    }
+  }, [data.background, editingText]);
 
   useEffect(() => {
     if (editingCode && inputRef.current) {
@@ -104,6 +133,16 @@ export function DiagnoseRow({ command, commandIndex, onEdit, onDelete, readOnly,
 
   const handleSelect = (result) => {
     const display = result.display || result.description || '';
+    // KOALA_5635_CLEAR_ON_ICD_CHANGE — when the ICD changes, the stamped
+    // condition_id is for the OLD code's matched patient condition.
+    // Carrying it forward would cause handleInsert's diagnose→assess flip
+    // (summary.js) to write background text scoped to the OLD condition
+    // against the NEW condition's Assessment row — a clinical-data-integrity
+    // cross-attachment. The spread still runs first (so unrelated proposal
+    // fields like _original_header / accepted survive) but condition_id and
+    // background are EXPLICITLY cleared AFTER it. The user can re-derive
+    // background via the next /generate-summary if they want it back; the
+    // alternative (silent cross-attachment) is worse than this small UX cost.
     const newData = {
       ...data,
       icd10_code: result.code,
@@ -112,8 +151,15 @@ export function DiagnoseRow({ command, commandIndex, onEdit, onDelete, readOnly,
       _original_header: data._original_header || data.condition_header || '',
       accepted: true,
       rejected: false,
+      condition_id: '',  // explicit clear; never preserve across ICD change
+      background: '',    // explicit clear; never preserve across ICD change
     };
     onEdit(commandIndex, newData, 'diagnose');
+    // KOALA_5635_CLEAR_ON_ICD_CHANGE — also mirror the clear into local
+    // ``background`` state so the textarea / read-only block reflects the
+    // cleared value without waiting for the prop-sync useEffect to run
+    // (avoids a render flash where stale background flickers visible).
+    setBackground('');
     setResults([]);
     setSearched(false);
     setQuery('');
@@ -123,20 +169,44 @@ export function DiagnoseRow({ command, commandIndex, onEdit, onDelete, readOnly,
   const handleClearCode = () => {
     if (readOnly) return;
     const originalHeader = command.data._original_header || data.condition_header || '';
-    const newData = { ...data, icd10_code: null, icd10_display: '', condition_header: originalHeader, accepted: false, rejected: false };
+    // KOALA_5635_CLEAR_ON_ICD_CHANGE — same reasoning as handleSelect:
+    // clearing the ICD also clears the (now-orphaned) condition_id and
+    // background. If the user picks a new code, the carry-forward will
+    // re-resolve from /generate-summary; if they pick the same code, the
+    // re-pick path also re-resolves. Preserving here would let the old
+    // condition_id leak into the next handleSelect spread.
+    const newData = {
+      ...data,
+      icd10_code: null,
+      icd10_display: '',
+      condition_header: originalHeader,
+      accepted: false,
+      rejected: false,
+      condition_id: '',  // explicit clear; never preserve across ICD clear
+      background: '',    // explicit clear; never preserve across ICD clear
+    };
     onEdit(commandIndex, newData, 'diagnose');
+    setBackground('');
     setEditingCode(true);
     setQuery('');
   };
 
   const handleSaveAssessment = () => {
+    // KOALA_5635_BACKGROUND_TEXTAREA — when condition_id is present we also
+    // persist ``background`` through the spread; for non-condition rows we
+    // still spread ``data`` so any pre-existing ``background`` field on the
+    // proposal (set by an upstream carry-forward) round-trips untouched.
     const newData = { ...data, today_assessment: assessment, accepted: true, rejected: false };
+    if (hasConditionId) {
+      newData.background = background;
+    }
     onEdit(commandIndex, newData, 'diagnose');
     setEditingText(false);
   };
 
   const handleCancelAssessment = () => {
     setAssessment(data.today_assessment || '');
+    setBackground(data.background || '');
     setEditingText(false);
   };
 
@@ -206,10 +276,26 @@ export function DiagnoseRow({ command, commandIndex, onEdit, onDelete, readOnly,
           class="diagnose-row-body${readOnly ? '' : ' editable'}"
           onClick=${() => !readOnly && setEditingText(true)}
         >
+          ${/* KOALA_5635_BACKGROUND_TEXTAREA — read-only Background block,
+              shown only when condition_id is stamped. Mirrors AssessNarrative
+              (soap-group.js) so a future merge can reconcile shape if rec-
+              diagnose is consolidated into the assess UI. */ ''}
+          ${hasConditionId && (data.background || '').length > 0 && html`
+            <div class="diagnose-body-label">Background</div>
+            ${(data.background || '').split('\n').map((line, i) => html`
+              <div key=${'b' + i} class="diagnose-body-line">${line}</div>
+            `)}
+            ${(data.background || '').length > 2048 && html`
+              <div class="char-counter over-limit">${data.background.length} / 2048 — text must be shortened before approving</div>
+            `}
+          `}
+          ${hasConditionId && (data.background || '').length > 0 && html`
+            <div class="diagnose-body-label">Today's assessment</div>
+          `}
           ${(data.today_assessment || '').split('\n').map((line, i) => html`
             <div key=${i} class="diagnose-body-line">${line}</div>
           `)}
-          ${!data.today_assessment && html`
+          ${!data.today_assessment && !(hasConditionId && (data.background || '').length > 0) && html`
             <div class="diagnose-body-empty">No assessment text</div>
           `}
           ${(data.today_assessment || '').length > 2048 && html`
@@ -220,6 +306,22 @@ export function DiagnoseRow({ command, commandIndex, onEdit, onDelete, readOnly,
 
       ${editingText && !readOnly && html`
         <div class="diagnose-edit-area">
+          ${/* KOALA_5635_BACKGROUND_TEXTAREA — editable Background textarea,
+              shown only when condition_id is stamped. Above the today's
+              assessment textarea to match AssessNarrative ordering. */ ''}
+          ${hasConditionId && html`
+            <div class="diagnose-body-label">Background</div>
+            <textarea
+              ref=${backgroundRef}
+              class="command-row-textarea"
+              maxLength=${2048}
+              value=${background}
+              onInput=${(e) => setBackground(e.target.value)}
+              onKeyDown=${handleTextKeyDown}
+            />
+            <div class="char-counter${background.length > 1900 ? background.length > 2048 ? ' over-limit' : ' near-limit' : ''}">${background.length} / 2048</div>
+            <div class="diagnose-body-label">Today's assessment</div>
+          `}
           <textarea
             ref=${textareaRef}
             class="command-row-textarea"
@@ -231,7 +333,7 @@ export function DiagnoseRow({ command, commandIndex, onEdit, onDelete, readOnly,
           <div class="char-counter${assessment.length > 1900 ? assessment.length > 2048 ? ' over-limit' : ' near-limit' : ''}">${assessment.length} / 2048</div>
           <div class="command-row-actions">
             <button type="button" class="form-btn form-btn-cancel" onClick=${handleCancelAssessment}>Cancel</button>
-            <button type="button" class="form-btn form-btn-save" disabled=${assessment.length > 2048} onClick=${handleSaveAssessment}>Save</button>
+            <button type="button" class="form-btn form-btn-save" disabled=${assessment.length > 2048 || (hasConditionId && background.length > 2048)} onClick=${handleSaveAssessment}>Save</button>
           </div>
         </div>
       `}

--- a/tests/hyperscribe/scribe/api/test_session_view.py
+++ b/tests/hyperscribe/scribe/api/test_session_view.py
@@ -3524,57 +3524,59 @@ def _read_diagnose_row_js() -> str:
     return js.read_text()
 
 
-def test_diagnose_row_renders_background_when_condition_id_present() -> None:
-    """KOALA-5635: the Background textarea / read-only block in DiagnoseRow
-    must be GATED on ``data.condition_id``. Without the gate, the field
-    would show for diagnose proposals that don't match an active condition
-    on the patient — there's no scope for carry-forward there, and the
-    home-app diagnose command doesn't persist background, so the field
-    would be a UX trap (typing into a field whose contents will be dropped).
+def test_diagnose_row_always_renders_background_section() -> None:
+    """KOALA-5635 (ROUND 3): the Background textarea / read-only block in
+    DiagnoseRow must render UNCONDITIONALLY, independent of
+    ``data.condition_id``. Round-2's ``hasConditionId`` gate was rejected
+    in Kevin's UAT — the field must be available on ALL condition cards in
+    ALL situations (new diagnosis, matched assess, AI rec, user-initiated,
+    prior-background-empty-or-not, AND after an ICD change). The
+    ``DiagnoseCommand`` in the canvas-plugins SDK accepts a ``background``
+    field, so there is no silent-drop risk on unmatched ICDs.
 
-    Pin: the marker ``KOALA_5635_BACKGROUND_TEXTAREA`` must be present
-    AND a ``hasConditionId`` constant must be derived from
-    ``!!data.condition_id``.
+    Pin assertions:
+      1. Marker ``KOALA_5635_BACKGROUND_ALWAYS_RENDER`` is present.
+      2. Marker ``KOALA_5635_BACKGROUND_TEXTAREA`` is still present (local
+         state pattern survives — only the render gate is dropped).
+      3. The ``hasConditionId`` constant must NOT exist in the file
+         (round-2 artifact; would re-introduce the gate if it survived).
     """
     src = _read_diagnose_row_js()
 
+    assert "KOALA_5635_BACKGROUND_ALWAYS_RENDER" in src, (
+        "diagnose-row.js is missing the KOALA_5635_BACKGROUND_ALWAYS_RENDER "
+        "marker. Kevin's UAT on PR #288 explicitly required the Background "
+        "field to render on every diagnose-row card regardless of whether "
+        "an active condition was matched. Drop the ``hasConditionId`` gate "
+        "and add this marker to flag the new behavior."
+    )
     assert "KOALA_5635_BACKGROUND_TEXTAREA" in src, (
-        "diagnose-row.js is missing the KOALA_5635_BACKGROUND_TEXTAREA marker. "
-        "The Background field on rec-diagnose rows must be added per KOALA-5635 "
-        "so the per-(patient, condition) carry-forward is editable BEFORE the "
-        "frontend flips diagnose→assess at insert time. Add the textarea, gate "
-        "it on ``data.condition_id``, and mark the branch with this marker."
+        "diagnose-row.js must still contain the KOALA_5635_BACKGROUND_TEXTAREA "
+        "marker — the local-state / prop-sync pattern that mirrors "
+        "AssessNarrative is unrelated to the render gate that was dropped."
     )
-    # The gate uses ``hasConditionId = !!data.condition_id`` (or equivalent).
-    # Regex tolerates whitespace variation but pins the predicate shape.
-    gate_pattern = re.compile(r"hasConditionId\s*=\s*!!\s*data\.condition_id")
-    assert gate_pattern.search(src), (
-        "diagnose-row.js must derive a ``hasConditionId`` constant from "
-        "``!!data.condition_id``. Without this gate, the Background field "
-        "would render for unmatched diagnose proposals where the home-app "
-        "command has no background field to persist."
+    assert "hasConditionId" not in src, (
+        "diagnose-row.js must not reference ``hasConditionId``. The "
+        "round-2 gate is dropped per Kevin's UAT — keeping the constant "
+        "would invite a future refactor to re-wire it as a render gate."
     )
 
 
-def test_diagnose_row_omits_background_when_no_condition_id() -> None:
-    """KOALA-5635: the Background textarea rendering must be wrapped in a
-    ``hasConditionId && ...`` conditional in BOTH the read-only and edit-mode
-    branches. If a future refactor removes the conditional and renders the
-    textarea unconditionally, this pin fails.
+def test_diagnose_row_renders_background_even_without_condition_id() -> None:
+    """KOALA-5635 (ROUND 3, inverted): the Background textarea rendering
+    must NOT be wrapped in a ``hasConditionId && ...`` conditional in
+    either the read-only or the edit-mode branch. Round-2 required at
+    least two such guards; round-3 inverts: zero occurrences.
 
-    Pin: at least two ``hasConditionId &&`` rendering guards exist in the
-    file (one for read-only label/content, one for edit-mode textarea).
+    Pin: zero occurrences of ``hasConditionId &&`` rendering guards.
     """
     src = _read_diagnose_row_js()
-    # Count occurrences of ``hasConditionId &&`` (rendering-time gate). At
-    # least 2 — one in the read-only branch, one in the edit-mode branch.
     occurrences = len(re.findall(r"hasConditionId\s*&&", src))
-    assert occurrences >= 2, (
-        "diagnose-row.js must gate Background rendering on ``hasConditionId``. "
+    assert occurrences == 0, (
+        "diagnose-row.js must NOT gate Background rendering on "
+        "``hasConditionId``. "
         f"Found {occurrences} occurrences of ``hasConditionId &&``; expected "
-        "at least 2 (read-only branch + edit-mode branch). A refactor that "
-        "drops the gate would let the field render for unmatched diagnose "
-        "proposals — UX trap; the value would not persist server-side."
+        "zero per Kevin's UAT — the field must render on every card."
     )
 
 
@@ -3698,6 +3700,116 @@ def test_diagnose_row_handle_clear_code_clears_background_and_condition_id() -> 
         "``background: ''``). Same reasoning as ``handleSelect``: prevent "
         "cross-attachment between the prior condition_id's background "
         "text and a freshly-selected ICD code."
+    )
+
+
+def test_diagnose_row_has_background_help_text() -> None:
+    """KOALA-5635 (ROUND 3): the Background field must render the helper
+    text ``Optional. You write this. Carries forward to every note.``
+    directly under the BACKGROUND label, per Kevin's v2 mock. This pins
+    the user-facing string so a future refactor can't quietly drop it.
+    """
+    src = _read_diagnose_row_js()
+    expected = "Optional. You write this. Carries forward to every note."
+    assert expected in src, (
+        f"diagnose-row.js must contain the Background helper text exactly: "
+        f"{expected!r}. Per Kevin's UAT mock the line sits under the "
+        "BACKGROUND label and explains that the field is user-written and "
+        "carries forward to subsequent notes."
+    )
+
+
+def test_diagnose_row_background_has_visible_char_counter() -> None:
+    """KOALA-5635 (ROUND 3): the Background field must render a visible
+    ``<count> / 2048`` character counter at all times, not only when the
+    user exceeds the limit. Round-2 only emitted the counter on
+    over-limit; round-3 makes it always visible to match the mock and
+    the Today's-assessment counter behavior.
+
+    Pins:
+      1. Edit-mode counter exists (``${background.length} / 2048``).
+      2. Read-only counter is rendered with a CONDITIONAL class template
+         (``char-counter${...near-limit/over-limit...}``) sitting on
+         ``data.background.length``. The HEAD shape was a hard-coded
+         ``class="char-counter over-limit"`` rendered only on the
+         over-limit branch — this pin rejects that shape.
+    """
+    src = _read_diagnose_row_js()
+    # The edit-mode counter is rendered as ``${background.length} / 2048``
+    # inside an unconditional ``<div class="char-counter...">``. Match the
+    # template-literal expression (allow flexible whitespace).
+    edit_counter_pattern = re.compile(r"\$\{background\.length\}\s*/\s*2048")
+    matches = edit_counter_pattern.findall(src)
+    assert matches, (
+        "diagnose-row.js must render a visible ``${background.length} / 2048`` "
+        "character counter on the Background textarea. Per Kevin's UAT mock "
+        "the counter must be visible at all character counts, not only when "
+        "the user exceeds 2048. Mirror the Today's-assessment counter shape."
+    )
+    # The read-only counter must be ALWAYS-VISIBLE — i.e. the surrounding
+    # ``class="char-counter..."`` attribute is a template literal that
+    # toggles ``near-limit``/``over-limit`` based on the length, not a
+    # hard-coded ``over-limit``-only branch (the round-2 shape).
+    #
+    # Pin the read-only template literal anchored on
+    # ``(data.background || '').length`` so a future refactor that switches
+    # back to "only render when over-limit" trips this assertion.
+    always_visible_pattern = re.compile(r'class="char-counter\$\{\(data\.background \|\| \'\'\)\.length\s*>')
+    assert always_visible_pattern.search(src), (
+        "diagnose-row.js must render the read-only Background ``<count> / "
+        "2048`` counter with a CONDITIONAL class template "
+        "(``char-counter${(data.background || '').length > ...``) so the "
+        "counter shows at every length and only the visual treatment "
+        "changes near/over the limit. The round-2 shape "
+        '(``class="char-counter over-limit"`` inside an over-limit-only '
+        "branch) is rejected — Kevin's UAT mock requires the counter at "
+        "all character counts."
+    )
+
+
+def test_diagnose_row_handle_save_persists_background_unconditionally() -> None:
+    """KOALA-5635 (ROUND 3): ``handleSaveAssessment`` must persist
+    ``background`` on EVERY save, not only when ``condition_id`` is
+    stamped. Round-2 gated the assignment on ``hasConditionId``; with the
+    render gate dropped, the save gate must also go — otherwise the user
+    types into a visible field whose contents are silently dropped on
+    save (the very UX trap Kevin's UAT was pushing back on).
+
+    Pin: inside ``handleSaveAssessment``, the body must NOT contain
+    ``if (hasConditionId)`` and must assign ``background`` directly in
+    the new-data object spread.
+    """
+    src = _read_diagnose_row_js()
+    handle_save_marker = "const handleSaveAssessment = () => {"
+    start = src.find(handle_save_marker)
+    assert start != -1, (
+        "Could not find ``handleSaveAssessment`` definition in diagnose-row.js. If renamed, update this test."
+    )
+    open_brace = src.find("{", start)
+    depth = 0
+    end = -1
+    for i in range(open_brace, len(src)):
+        if src[i] == "{":
+            depth += 1
+        elif src[i] == "}":
+            depth -= 1
+            if depth == 0:
+                end = i
+                break
+    assert end != -1, "handleSaveAssessment body braces unbalanced"
+    body = src[open_brace:end]
+    assert "hasConditionId" not in body, (
+        "``handleSaveAssessment`` must not reference ``hasConditionId``. "
+        "Round-2 gated the background save on the condition_id; round-3 "
+        "drops this gate so background persists for every diagnose-row "
+        "save (including unmatched ICDs — DiagnoseCommand accepts the "
+        "background field on the SDK side)."
+    )
+    save_pattern = re.compile(r"background\s*:\s*background\b")
+    assert save_pattern.search(body), (
+        "``handleSaveAssessment`` must assign ``background: background`` "
+        "(or equivalent shape) directly in the new-data object. Without "
+        "this, the user's typed background is silently dropped on save."
     )
 
 

--- a/tests/hyperscribe/scribe/api/test_session_view.py
+++ b/tests/hyperscribe/scribe/api/test_session_view.py
@@ -3508,6 +3508,199 @@ def test_recommend_commands_calls_prefill_assess_backgrounds(
     assert mock_prefill.call_args.args[1] == "5899e7bf-5ecb-4399-aceb-0e233bd4a8f1"
 
 
+# --- KOALA-5635: structural pins on diagnose-row.js (Background textarea) ---
+
+
+def _read_diagnose_row_js() -> str:
+    """Read the diagnose-row.js source for structural-pin tests.
+
+    These tests don't execute JS — they pin invariants by regex against the
+    source. The same pattern is used for summary.js elsewhere in this file
+    (see ``test_summary_js_cache_flip_to_approved_true_is_unconditional_on_success``).
+    """
+    from pathlib import Path
+
+    js = Path(__file__).resolve().parents[4] / "hyperscribe" / "scribe" / "static" / "diagnose-row.js"
+    return js.read_text()
+
+
+def test_diagnose_row_renders_background_when_condition_id_present() -> None:
+    """KOALA-5635: the Background textarea / read-only block in DiagnoseRow
+    must be GATED on ``data.condition_id``. Without the gate, the field
+    would show for diagnose proposals that don't match an active condition
+    on the patient — there's no scope for carry-forward there, and the
+    home-app diagnose command doesn't persist background, so the field
+    would be a UX trap (typing into a field whose contents will be dropped).
+
+    Pin: the marker ``KOALA_5635_BACKGROUND_TEXTAREA`` must be present
+    AND a ``hasConditionId`` constant must be derived from
+    ``!!data.condition_id``.
+    """
+    src = _read_diagnose_row_js()
+
+    assert "KOALA_5635_BACKGROUND_TEXTAREA" in src, (
+        "diagnose-row.js is missing the KOALA_5635_BACKGROUND_TEXTAREA marker. "
+        "The Background field on rec-diagnose rows must be added per KOALA-5635 "
+        "so the per-(patient, condition) carry-forward is editable BEFORE the "
+        "frontend flips diagnose→assess at insert time. Add the textarea, gate "
+        "it on ``data.condition_id``, and mark the branch with this marker."
+    )
+    # The gate uses ``hasConditionId = !!data.condition_id`` (or equivalent).
+    # Regex tolerates whitespace variation but pins the predicate shape.
+    gate_pattern = re.compile(r"hasConditionId\s*=\s*!!\s*data\.condition_id")
+    assert gate_pattern.search(src), (
+        "diagnose-row.js must derive a ``hasConditionId`` constant from "
+        "``!!data.condition_id``. Without this gate, the Background field "
+        "would render for unmatched diagnose proposals where the home-app "
+        "command has no background field to persist."
+    )
+
+
+def test_diagnose_row_omits_background_when_no_condition_id() -> None:
+    """KOALA-5635: the Background textarea rendering must be wrapped in a
+    ``hasConditionId && ...`` conditional in BOTH the read-only and edit-mode
+    branches. If a future refactor removes the conditional and renders the
+    textarea unconditionally, this pin fails.
+
+    Pin: at least two ``hasConditionId &&`` rendering guards exist in the
+    file (one for read-only label/content, one for edit-mode textarea).
+    """
+    src = _read_diagnose_row_js()
+    # Count occurrences of ``hasConditionId &&`` (rendering-time gate). At
+    # least 2 — one in the read-only branch, one in the edit-mode branch.
+    occurrences = len(re.findall(r"hasConditionId\s*&&", src))
+    assert occurrences >= 2, (
+        "diagnose-row.js must gate Background rendering on ``hasConditionId``. "
+        f"Found {occurrences} occurrences of ``hasConditionId &&``; expected "
+        "at least 2 (read-only branch + edit-mode branch). A refactor that "
+        "drops the gate would let the field render for unmatched diagnose "
+        "proposals — UX trap; the value would not persist server-side."
+    )
+
+
+def test_diagnose_row_handle_select_clears_background_and_condition_id() -> None:
+    """KOALA-5635 (Q2, ROUND 2): ``handleSelect`` must EXPLICITLY clear
+    both ``condition_id`` and ``background`` when the provider changes
+    the ICD code on a diagnose row. The earlier "spread preserves" shape
+    caused clinical-data-integrity cross-attachment:
+
+        - backend stamps condition_id=<diabetes> + diabetes background;
+        - user changes ICD to I10 (hypertension, also an active condition);
+        - handleInsert re-resolves to hypertension's condition_id but the
+          OLD diabetes background was copied via ``...data,``;
+        - diabetes context text gets written against the hypertension
+          Assessment row in the chart.
+
+    This pin REJECTS that shape: it requires the explicit clear lines AND
+    the KOALA_5635_CLEAR_ON_ICD_CHANGE marker inside the handleSelect body.
+
+    Pin assertions inside ``handleSelect``:
+      1. Marker ``KOALA_5635_CLEAR_ON_ICD_CHANGE`` is present.
+      2. ``condition_id:`` is assigned to an empty string (or null/undefined).
+      3. ``background:`` is assigned to an empty string (or null/undefined).
+    """
+    src = _read_diagnose_row_js()
+    handle_select_marker = "const handleSelect = (result) => {"
+    start = src.find(handle_select_marker)
+    assert start != -1, "Could not find ``handleSelect`` definition in diagnose-row.js. If renamed, update this test."
+    # Walk to the matching closing brace of the arrow function body.
+    open_brace = src.find("{", start)
+    depth = 0
+    end = -1
+    for i in range(open_brace, len(src)):
+        if src[i] == "{":
+            depth += 1
+        elif src[i] == "}":
+            depth -= 1
+            if depth == 0:
+                end = i
+                break
+    assert end != -1, "handleSelect body braces unbalanced"
+    body = src[open_brace:end]
+    assert "KOALA_5635_CLEAR_ON_ICD_CHANGE" in body, (
+        "``handleSelect`` must contain the KOALA_5635_CLEAR_ON_ICD_CHANGE "
+        "marker. Round-1 ``...data,`` spread-preserve was rejected by "
+        "Council on clinical-data-integrity grounds: carrying condition_id "
+        "across an ICD change causes cross-attachment of background text "
+        "to the wrong condition in the chart."
+    )
+    # ``condition_id`` is explicitly cleared. Accept '', null, or undefined.
+    clear_condition_id = re.compile(
+        r"condition_id\s*:\s*(?:''|\"\"|``|null|undefined)",
+    )
+    assert clear_condition_id.search(body), (
+        "``handleSelect`` must EXPLICITLY clear ``condition_id`` (e.g. "
+        "``condition_id: ''``). Round-1 relied on spread + no override, "
+        "which leaves the OLD condition_id intact — cross-attachment risk."
+    )
+    # ``background`` is explicitly cleared. Accept '', null, or undefined.
+    clear_background = re.compile(
+        r"background\s*:\s*(?:''|\"\"|``|null|undefined)",
+    )
+    assert clear_background.search(body), (
+        "``handleSelect`` must EXPLICITLY clear ``background`` (e.g. "
+        "``background: ''``). The user loses any typed background on an "
+        "ICD change — this is the user's explicit call per the round-2 "
+        "spec correction; silent drop is worse than overwriting with the "
+        "wrong condition's text."
+    )
+
+
+def test_diagnose_row_handle_clear_code_clears_background_and_condition_id() -> None:
+    """KOALA-5635 (Q2, ROUND 2): same shape as ``handleSelect`` — clearing
+    the ICD code must also explicitly clear ``condition_id`` and
+    ``background``. Preserving them across a clear would let the old
+    condition_id leak into the next ``handleSelect`` spread (the user
+    typically picks a new code right after clearing).
+
+    Pin assertions inside ``handleClearCode``:
+      1. Marker ``KOALA_5635_CLEAR_ON_ICD_CHANGE`` is present.
+      2. ``condition_id:`` is assigned to an empty string (or null/undefined).
+      3. ``background:`` is assigned to an empty string (or null/undefined).
+    """
+    src = _read_diagnose_row_js()
+    handle_clear_marker = "const handleClearCode = () => {"
+    start = src.find(handle_clear_marker)
+    assert start != -1, (
+        "Could not find ``handleClearCode`` definition in diagnose-row.js. If renamed, update this test."
+    )
+    open_brace = src.find("{", start)
+    depth = 0
+    end = -1
+    for i in range(open_brace, len(src)):
+        if src[i] == "{":
+            depth += 1
+        elif src[i] == "}":
+            depth -= 1
+            if depth == 0:
+                end = i
+                break
+    assert end != -1, "handleClearCode body braces unbalanced"
+    body = src[open_brace:end]
+    assert "KOALA_5635_CLEAR_ON_ICD_CHANGE" in body, (
+        "``handleClearCode`` must contain the KOALA_5635_CLEAR_ON_ICD_CHANGE "
+        "marker. Without it the round-1 shape (spread + no clear) would "
+        "let the old condition_id leak across a clear → re-select."
+    )
+    clear_condition_id = re.compile(
+        r"condition_id\s*:\s*(?:''|\"\"|``|null|undefined)",
+    )
+    assert clear_condition_id.search(body), (
+        "``handleClearCode`` must EXPLICITLY clear ``condition_id`` (e.g. "
+        "``condition_id: ''``). Otherwise a clear → re-select sequence "
+        "spreads the OLD condition_id into the new selection."
+    )
+    clear_background = re.compile(
+        r"background\s*:\s*(?:''|\"\"|``|null|undefined)",
+    )
+    assert clear_background.search(body), (
+        "``handleClearCode`` must EXPLICITLY clear ``background`` (e.g. "
+        "``background: ''``). Same reasoning as ``handleSelect``: prevent "
+        "cross-attachment between the prior condition_id's background "
+        "text and a freshly-selected ICD code."
+    )
+
+
 # --- /search-medications ---
 
 

--- a/tests/hyperscribe/scribe/commands/test_ap_split.py
+++ b/tests/hyperscribe/scribe/commands/test_ap_split.py
@@ -1,4 +1,9 @@
+from typing import Any
+from unittest.mock import MagicMock, patch
+
 from hyperscribe.scribe.commands.ap_split import (
+    _build_active_condition_icd10_index,
+    _normalize_icd10,
     match_condition,
     parse_ap_blocks,
     significant_words,
@@ -431,3 +436,286 @@ def test_split_plan_corresponding_note_problem_strips_whitespace() -> None:
     updated, unmatched = split_plan_into_diagnoses(commands, section_conditions)
     assert len(updated) == 1
     assert updated[0]["data"]["icd10_code"] == "R51.9"
+
+
+# --- KOALA-5635: condition_id stamping on diagnose proposals ---
+
+
+def _patch_active_conditions_values_list(rows: list[tuple[str, str | None, str | None]]) -> Any:
+    """Patch the ConditionModel.objects.active().for_patient(...).values_list(...) chain.
+
+    Round-2 (KOALA-5635): the helper was refactored from a
+    ``prefetch_related("codings")`` + full-ORM iteration to a
+    ``.values_list("id", "codings__code", "codings__system")`` shape per
+    CLAUDE.md's "never fetch full objects from the database if you only
+    need a couple properties." The new chain is:
+
+        ConditionModel.objects.active().for_patient(...).values_list(
+            "id", "codings__code", "codings__system",
+        )
+
+    which yields one row per (condition, coding) pair (LEFT JOIN over
+    codings). Conditions without codings surface with NULL code/system
+    and get skipped by the helper's ``not coding_code`` guard.
+    """
+    chain = MagicMock()
+    chain.active.return_value = chain
+    chain.for_patient.return_value = chain
+    chain.values_list.return_value = rows  # iterable yields tuples
+    return patch(
+        "canvas_sdk.v1.data.condition.Condition.objects",
+        chain,
+    )
+
+
+def test_normalize_icd10_strips_dots_and_uppercases() -> None:
+    """Mirrors the frontend handleInsert match step in summary.js."""
+    assert _normalize_icd10("i10") == "I10"
+    assert _normalize_icd10("E11.9") == "E119"
+    assert _normalize_icd10("e11.9") == "E119"
+    assert _normalize_icd10("") == ""
+    assert _normalize_icd10(None) == ""
+
+
+def test_build_active_condition_icd10_index_happy_path() -> None:
+    """Build a {normalized_icd10 → condition_id} index for the note's patient.
+
+    Round-2 mock shape mirrors the ``.values_list("id", "codings__code",
+    "codings__system")`` rows the refactored helper iterates over.
+    """
+    note = MagicMock()
+    note.patient.id = "patient-key-1"
+    note.id = "note-uuid-1"
+    rows = [
+        ("cond-a", "I10", "http://hl7.org/fhir/sid/icd-10-cm"),
+        ("cond-b", "E11.9", "http://hl7.org/fhir/sid/icd-10-cm"),
+    ]
+    with _patch_active_conditions_values_list(rows):
+        index = _build_active_condition_icd10_index(note)
+    assert index == {"I10": "cond-a", "E119": "cond-b"}
+
+
+def test_build_active_condition_icd10_index_skips_non_icd_systems() -> None:
+    """Codings whose ``system`` doesn't look like ICD-10 are ignored.
+
+    Without this filter, SNOMED/UMLS codings could collide with ICD-10
+    keys (different code spaces) and stamp the wrong condition_id.
+    """
+    note = MagicMock()
+    note.patient.id = "patient-key-1"
+    note.id = "note-uuid-1"
+    rows = [
+        # Same condition has both a SNOMED coding (skipped) and an ICD-10
+        # coding (kept). The .values_list LEFT JOIN naturally yields one
+        # row per (condition, coding) pair.
+        ("cond-a", "12345", "http://snomed.info/sct"),
+        ("cond-a", "I10", "http://hl7.org/fhir/sid/icd-10-cm"),
+    ]
+    with _patch_active_conditions_values_list(rows):
+        index = _build_active_condition_icd10_index(note)
+    assert index == {"I10": "cond-a"}
+
+
+def test_build_active_condition_icd10_index_skips_null_coding_rows() -> None:
+    """A condition with no codings produces a row with NULL code/system
+    under the LEFT JOIN in ``.values_list("id", "codings__code", "codings__system")``.
+    The helper must skip those rows (the ``if not coding_code`` guard).
+
+    Without this pin, a follow-up refactor could regress by attempting to
+    normalize an empty string and stamping a bogus key.
+    """
+    note = MagicMock()
+    note.patient.id = "patient-key-1"
+    note.id = "note-uuid-1"
+    rows = [
+        ("cond-orphan", None, None),  # condition without any codings
+        ("cond-a", "I10", "http://hl7.org/fhir/sid/icd-10-cm"),
+    ]
+    with _patch_active_conditions_values_list(rows):
+        index = _build_active_condition_icd10_index(note)
+    assert index == {"I10": "cond-a"}
+
+
+def test_build_active_condition_icd10_index_coerces_uuid_to_str() -> None:
+    """KOALA-5635 round-2: ``.values_list`` on Postgres returns ``uuid.UUID``
+    for UUIDField columns (not str). The downstream carry-forward filter
+    ``Assessment.objects.filter(condition__id=...)`` compares against the
+    SDK string convention, so the helper must coerce.
+
+    Pin the coercion explicitly — a regression here would silently break
+    integration with carry_forward_assess_background.
+    """
+    import uuid as _uuid
+
+    note = MagicMock()
+    note.patient.id = "patient-key-1"
+    note.id = "note-uuid-1"
+    raw_uuid = _uuid.UUID("12345678-1234-5678-1234-567812345678")
+    rows = [(raw_uuid, "I10", "http://hl7.org/fhir/sid/icd-10-cm")]
+    with _patch_active_conditions_values_list(rows):
+        index = _build_active_condition_icd10_index(note)
+    assert index == {"I10": str(raw_uuid)}
+    # Belt-and-suspenders: the value MUST be a str, not a UUID instance.
+    assert isinstance(index["I10"], str)
+
+
+def test_build_active_condition_icd10_index_no_patient_returns_empty() -> None:
+    """Defensive: a note without a patient must not raise."""
+    note = MagicMock()
+    note.patient = None
+    note.id = "note-uuid-1"
+    assert _build_active_condition_icd10_index(note) == {}
+
+
+def test_build_active_condition_icd10_index_swallows_orm_errors() -> None:
+    """Carry-forward is best-effort: ORM exceptions must NOT propagate.
+
+    A transient DB blip during /generate-summary mustn't kill the request;
+    stamping is purely additive convenience. Round-2: broad ``except
+    Exception:`` is retained at THIS site because the failure mode is
+    transient ORM error during a queryset chain (vs malformed input,
+    which the two ``note_uuid`` sites now pre-validate with ``uuid.UUID``).
+    """
+    note = MagicMock()
+    note.patient.id = "patient-key-1"
+    note.id = "note-uuid-1"
+    chain = MagicMock()
+    chain.active.return_value = chain
+    chain.for_patient.return_value = chain
+    chain.values_list.side_effect = RuntimeError("transient db error")
+    with patch("canvas_sdk.v1.data.condition.Condition.objects", chain):
+        index = _build_active_condition_icd10_index(note)
+    assert index == {}
+
+
+def test_split_plan_stamps_condition_id_when_icd_matches_active_condition() -> None:
+    """KOALA-5635: split_plan_into_diagnoses stamps ``data.condition_id``
+    on diagnose proposals whose ``icd10_code`` matches an active condition
+    on the note's patient.
+
+    This is what makes the per-(patient, condition) background carry-forward
+    eligible for rec-diagnose proposals — without ``condition_id``, the
+    carry_forward_assess_background helper short-circuits.
+    """
+    commands = [
+        {
+            "command_type": "plan",
+            "data": {"narrative": "Hypertension\n- Continue lisinopril"},
+            "section_key": "assessment_and_plan",
+        },
+    ]
+    section_conditions = {
+        "assessment_and_plan": [
+            {"display": "Hypertension", "coding": [{"code": "I10", "display": "Essential hypertension"}]},
+        ],
+    }
+    note = MagicMock()
+    note.patient.id = "patient-key-1"
+    note.id = "note-uuid-1"
+    rows = [("cond-htn", "I10", "http://hl7.org/fhir/sid/icd-10-cm")]
+    with _patch_active_conditions_values_list(rows):
+        updated, _ = split_plan_into_diagnoses(commands, section_conditions, note=note)
+    assert len(updated) == 1
+    assert updated[0]["command_type"] == "diagnose"
+    assert updated[0]["data"]["icd10_code"] == "I10"
+    assert updated[0]["data"]["condition_id"] == "cond-htn"
+
+
+def test_split_plan_stamps_condition_id_normalizes_dots_and_case() -> None:
+    """The active-condition index lookup uses the same normalization as the
+    frontend handleInsert match step (strip dots, uppercase). A proposal
+    with ``icd10_code="e11.9"`` must match an active condition coded
+    ``E119`` and vice-versa.
+    """
+    commands = [
+        {
+            "command_type": "plan",
+            "data": {"narrative": "Type 2 diabetes\n- Continue metformin"},
+            "section_key": "assessment_and_plan",
+        },
+    ]
+    section_conditions = {
+        "assessment_and_plan": [
+            {"display": "Type 2 diabetes", "coding": [{"code": "E11.9", "display": "Type 2 diabetes"}]},
+        ],
+    }
+    note = MagicMock()
+    note.patient.id = "patient-key-1"
+    note.id = "note-uuid-1"
+    # Active condition stored WITHOUT the dot to prove the normalization.
+    rows = [("cond-dm2", "E119", "http://hl7.org/fhir/sid/icd-10-cm")]
+    with _patch_active_conditions_values_list(rows):
+        updated, _ = split_plan_into_diagnoses(commands, section_conditions, note=note)
+    assert updated[0]["data"]["condition_id"] == "cond-dm2"
+
+
+def test_split_plan_no_stamp_when_icd_does_not_match_active_condition() -> None:
+    """Diagnose proposals whose ICD does NOT match any active condition stay
+    unstamped — they remain plain diagnose rows, no carry-forward eligibility,
+    no Background field in the UI."""
+    commands = [
+        {
+            "command_type": "plan",
+            "data": {"narrative": "Migraine\n- Start sumatriptan"},
+            "section_key": "assessment_and_plan",
+        },
+    ]
+    section_conditions = {
+        "assessment_and_plan": [
+            {"display": "Migraine", "coding": [{"code": "G43.909", "display": "Migraine"}]},
+        ],
+    }
+    note = MagicMock()
+    note.patient.id = "patient-key-1"
+    note.id = "note-uuid-1"
+    # Patient has a condition, but a different ICD than the diagnose.
+    rows = [("cond-htn", "I10", "http://hl7.org/fhir/sid/icd-10-cm")]
+    with _patch_active_conditions_values_list(rows):
+        updated, _ = split_plan_into_diagnoses(commands, section_conditions, note=note)
+    assert updated[0]["command_type"] == "diagnose"
+    assert "condition_id" not in updated[0]["data"]
+
+
+def test_split_plan_no_stamp_when_note_is_none() -> None:
+    """Backward compatibility: callers that don't pass ``note`` get the
+    pre-KOALA-5635 behavior (no stamping). The single new wiring site is
+    ``post_generate_summary``; other tests / call sites that build the
+    diagnose list without DB context must keep working as-is."""
+    commands = [
+        {
+            "command_type": "plan",
+            "data": {"narrative": "Hypertension\n- Continue lisinopril"},
+            "section_key": "assessment_and_plan",
+        },
+    ]
+    section_conditions = {
+        "assessment_and_plan": [
+            {"display": "Hypertension", "coding": [{"code": "I10", "display": "Essential hypertension"}]},
+        ],
+    }
+    updated, _ = split_plan_into_diagnoses(commands, section_conditions)
+    assert updated[0]["command_type"] == "diagnose"
+    assert "condition_id" not in updated[0]["data"]
+
+
+def test_split_plan_no_stamp_when_icd_code_absent() -> None:
+    """When the diagnose proposal has no ICD code (no match in Nabla's
+    section_conditions), the active-condition lookup is irrelevant —
+    nothing to match against. Proposal stays unstamped."""
+    commands = [
+        {
+            "command_type": "plan",
+            "data": {"narrative": "Some unmatched header\n- Monitor"},
+            "section_key": "assessment_and_plan",
+        },
+    ]
+    section_conditions: dict[str, list[dict[str, Any]]] = {"assessment_and_plan": []}
+    note = MagicMock()
+    note.patient.id = "patient-key-1"
+    note.id = "note-uuid-1"
+    rows = [("cond-htn", "I10", "http://hl7.org/fhir/sid/icd-10-cm")]
+    with _patch_active_conditions_values_list(rows):
+        updated, _ = split_plan_into_diagnoses(commands, section_conditions, note=note)
+    assert updated[0]["command_type"] == "diagnose"
+    assert updated[0]["data"]["icd10_code"] is None
+    assert "condition_id" not in updated[0]["data"]

--- a/tests/hyperscribe/scribe/commands/test_builder.py
+++ b/tests/hyperscribe/scribe/commands/test_builder.py
@@ -21,6 +21,7 @@ from hyperscribe.scribe.commands.builder import (
     build_effects,
     build_metadata_effects,
     prefill_assess_backgrounds,
+    prefill_diagnose_backgrounds,
     validate_proposals,
 )
 
@@ -2246,3 +2247,128 @@ def test_build_amend_delete_effects_emits_real_enter_in_error_perform_effect_typ
     assert attempted[0]["command_uuid"] == "old-perform-uuid-aaaa-bbbb-cccccccccccc"
     # No PHI in attempted.
     assert "display" not in attempted[0]
+
+
+# --- KOALA-5635: prefill_diagnose_backgrounds (dict-shaped) ---
+
+
+def test_prefill_diagnose_backgrounds_filters_diagnose_only_and_loads_note() -> None:
+    """KOALA-5635 — ``prefill_diagnose_backgrounds`` is the dict-shaped
+    diagnose carry-forward, called at the post-A&P-split site in
+    ``post_generate_summary``. It must filter to diagnose proposals (the
+    upstream assess prefill already handled assess), load the ``Note`` once,
+    and delegate to ``carry_forward_assess_background`` per proposal.
+
+    Pins:
+    - Non-diagnose proposals do NOT trigger the carry-forward delegate.
+    - Malformed ``data`` (non-dict) is tolerated without raising — same
+      defensive shape as ``prefill_assess_backgrounds``.
+    """
+    proposals: list[dict[str, Any]] = [
+        {"command_type": "diagnose", "data": {"condition_id": "cond-1", "background": None}},
+        {"command_type": "assess", "data": {"condition_id": "cond-2", "background": None}},
+        # Defensive: malformed proposal must not crash the loop.
+        {"command_type": "diagnose", "data": None},
+    ]
+    # Round-2: ``prefill_diagnose_backgrounds`` now pre-validates the UUID
+    # via ``uuid.UUID(str(note_uuid))`` BEFORE the ORM lookup. Use a real
+    # UUID so the validation passes and the Note.objects mock path runs.
+    valid_uuid = "5899e7bf-5ecb-4399-aceb-0e233bd4a8f1"
+    fake_note = MagicMock()
+    fake_note.id = valid_uuid
+    with (
+        patch("hyperscribe.scribe.commands.builder.Note.objects") as mock_note_qs,
+        patch("hyperscribe.scribe.commands.builder.carry_forward_assess_background") as mock_carry,
+    ):
+        mock_note_qs.select_related.return_value.get.return_value = fake_note
+        prefill_diagnose_backgrounds(proposals, valid_uuid)
+    # Only one valid diagnose proposal (the one with a dict ``data``) is delegated.
+    # The assess proposal is intentionally NOT processed here; the upstream
+    # ``prefill_assess_backgrounds_for_proposals`` already handled it.
+    mock_carry.assert_called_once_with(proposals[0]["data"], fake_note)
+
+
+def test_prefill_diagnose_backgrounds_no_diagnose_proposals_short_circuits() -> None:
+    """If there are no diagnose proposals, skip the Note lookup entirely.
+
+    This is the symmetric N+1/latency guard to the assess sibling — a
+    request whose A&P split produced no diagnose rows (e.g. all conditions
+    matched and the frontend will flip to assess at insert time, or no
+    plan block at all) should not pay for an unnecessary Note query.
+    """
+    proposals: list[dict[str, Any]] = [
+        {"command_type": "assess", "data": {"condition_id": "cond-1", "background": None}},
+        {"command_type": "plan", "data": {"narrative": "Start naproxen"}},
+    ]
+    with patch("hyperscribe.scribe.commands.builder.Note.objects") as mock_note_qs:
+        prefill_diagnose_backgrounds(proposals, "note-uuid-1")
+    mock_note_qs.select_related.assert_not_called()
+
+
+def test_prefill_diagnose_backgrounds_silent_on_malformed_note_uuid() -> None:
+    """A non-UUID ``note_uuid`` must NOT raise — same best-effort contract
+    as the assess sibling.
+
+    Round-2 shape: the function pre-validates the UUID with ``uuid.UUID``
+    BEFORE the ORM lookup. The plugin sandbox does not expose
+    ``django.core.exceptions``, so ``Note.objects.get(id=<bad uuid>)``
+    would raise an uncatchable ``ValidationError``. Pre-validation absorbs
+    that path; the lookup catch can then narrow to ``Note.DoesNotExist``.
+
+    Pin: a malformed UUID short-circuits the function entirely — the
+    ``Note.objects`` lookup is NEVER reached, and ``carry_forward_assess_background``
+    is NOT called.
+    """
+    proposals: list[dict[str, Any]] = [
+        {"command_type": "diagnose", "data": {"condition_id": "cond-1", "background": None}},
+    ]
+    with (
+        patch("hyperscribe.scribe.commands.builder.Note.objects") as mock_note_qs,
+        patch("hyperscribe.scribe.commands.builder.carry_forward_assess_background") as mock_carry,
+    ):
+        # Must not raise even though Note.objects is patched (irrelevant
+        # because pre-validation returns before reaching the lookup).
+        prefill_diagnose_backgrounds(proposals, "not-a-uuid")
+    # Note.objects.select_related must NOT be called when the UUID is
+    # malformed — round-2 pre-validation contract.
+    mock_note_qs.select_related.assert_not_called()
+    mock_carry.assert_not_called()
+    assert proposals[0]["data"]["background"] is None
+
+
+def test_prefill_diagnose_backgrounds_empty_note_uuid_short_circuits() -> None:
+    """Empty ``note_uuid`` skips the Note lookup entirely — same shape as
+    the assess sibling at the unit-test boundary."""
+    proposals: list[dict[str, Any]] = [
+        {"command_type": "diagnose", "data": {"condition_id": "cond-1", "background": None}},
+    ]
+    with patch("hyperscribe.scribe.commands.builder.Note.objects") as mock_note_qs:
+        prefill_diagnose_backgrounds(proposals, "")
+    mock_note_qs.select_related.assert_not_called()
+
+
+def test_prefill_diagnose_backgrounds_silent_on_note_does_not_exist() -> None:
+    """KOALA-5635 round-2: when the UUID is well-formed but no Note matches
+    in the DB, the lookup raises ``Note.DoesNotExist``. The narrowed catch
+    (``except Note.DoesNotExist:``) absorbs it without crashing
+    ``/generate-summary``.
+
+    Pin: a valid-shape UUID with no matching note short-circuits gracefully —
+    ``carry_forward_assess_background`` is NOT called and the proposal's
+    ``background`` is left unchanged (None).
+    """
+    from canvas_sdk.v1.data.note import Note as NoteModel
+
+    proposals: list[dict[str, Any]] = [
+        {"command_type": "diagnose", "data": {"condition_id": "cond-1", "background": None}},
+    ]
+    valid_uuid = "5899e7bf-5ecb-4399-aceb-0e233bd4a8f1"
+    with (
+        patch("hyperscribe.scribe.commands.builder.Note.objects") as mock_note_qs,
+        patch("hyperscribe.scribe.commands.builder.carry_forward_assess_background") as mock_carry,
+    ):
+        mock_note_qs.select_related.return_value.get.side_effect = NoteModel.DoesNotExist
+        # Must not raise.
+        prefill_diagnose_backgrounds(proposals, valid_uuid)
+    mock_carry.assert_not_called()
+    assert proposals[0]["data"]["background"] is None

--- a/tests/hyperscribe/scribe/commands/test_carry_forward.py
+++ b/tests/hyperscribe/scribe/commands/test_carry_forward.py
@@ -27,9 +27,11 @@ from unittest.mock import MagicMock, patch
 
 from canvas_sdk.test_utils import factories
 from canvas_sdk.v1.data.assessment import Assessment
-from canvas_sdk.v1.data.condition import Condition
+from canvas_sdk.v1.data.condition import Condition, ConditionCoding
 from canvas_sdk.v1.data.note import CurrentNoteStateEvent, NoteStates
 
+from hyperscribe.scribe.commands.ap_split import split_plan_into_diagnoses
+from hyperscribe.scribe.commands.builder import prefill_diagnose_backgrounds
 from hyperscribe.scribe.commands.carry_forward import (
     carry_forward_assess_background,
 )
@@ -394,3 +396,110 @@ def test_carry_forward_integration_different_patient_does_not_leak() -> None:
 
     # No cross-patient leak: the proposal stays unset.
     assert proposal_data["background"] is None
+
+
+def test_split_plan_stamp_and_prefill_diagnose_background_integration() -> None:
+    """KOALA-5635 integration: end-to-end exercise of the rec-diagnose
+    background carry-forward path against the real ORM.
+
+    Setup:
+      - One patient with TWO notes:
+        * ``prior_note``: state SIGNED, with a committed Assessment on
+          condition ``cond_htn`` whose ``background`` is a known string.
+        * ``current_note``: the "in-progress" note where the new diagnose
+          proposal lives (will be the note passed to ``split_plan_into_diagnoses``).
+      - ``cond_htn`` has an ICD-10 coding of ``I10`` so the icd-matching
+        in ``_build_active_condition_icd10_index`` picks it up.
+
+    Expectation:
+      1. ``split_plan_into_diagnoses(commands, sec, note=current_note)``
+         stamps ``data["condition_id"]`` = str(cond_htn.id) on the produced
+         diagnose proposal (icd10_code "I10" matches the active condition's
+         normalized "I10").
+      2. ``prefill_diagnose_backgrounds(commands_list, note_uuid)`` then
+         resolves the prior Assessment by (patient, condition_id) and
+         carries the background forward onto the proposal's data.
+
+    Why a single integration test instead of two: the two helpers are
+    chained in ``post_generate_summary`` (split then prefill); a refactor
+    that breaks either one in real ORM terms (typo'd filter kwarg, missing
+    coding fetch, stale db_table reference) would fail here. Every other
+    test for these helpers mocks the ORM.
+    """
+    patient = factories.PatientFactory.create()
+    user = factories.CanvasUserFactory.create()
+    prior_note = factories.NoteFactory.create(patient=patient)
+    current_note = factories.NoteFactory.create(patient=patient)
+
+    CurrentNoteStateEvent.objects.create(note=prior_note, state=NoteStates.SIGNED)
+
+    cond_htn = Condition.objects.create(
+        patient=patient,
+        deleted=False,
+        onset_date=datetime.date(2024, 1, 1),
+        resolution_date=datetime.date(2024, 12, 31),
+        clinical_status="active",
+        surgical=False,
+        committer=user,
+    )
+    # Active condition needs an ICD-10 coding for the index lookup to pick
+    # it up — the helper filters codings to those whose ``system`` matches
+    # /icd/i. Match the home-app FHIR convention.
+    ConditionCoding.objects.create(
+        condition=cond_htn,
+        system="http://hl7.org/fhir/sid/icd-10-cm",
+        code="I10",
+        display="Essential hypertension",
+    )
+
+    Assessment.objects.create(
+        patient=patient,
+        note=prior_note,
+        condition=cond_htn,
+        status="stable",
+        narrative="Stable on lisinopril",
+        background="Diagnosed 2020-03-15; controlled on lisinopril 10mg",
+        care_team="",
+        committer_id=user.dbid,
+    )
+
+    # Simulated post-extract-commands state with a plan command Nabla
+    # produced for hypertension. ``section_conditions`` is what
+    # ``_match_conditions_to_sections`` would emit in the real flow.
+    commands: list[dict[str, Any]] = [
+        {
+            "command_type": "plan",
+            "data": {"narrative": "Hypertension\n- Continue lisinopril 10mg"},
+            "section_key": "assessment_and_plan",
+        },
+    ]
+    section_conditions = {
+        "assessment_and_plan": [
+            {
+                "display": "Hypertension",
+                "coding": [{"code": "I10", "display": "Essential hypertension"}],
+            },
+        ],
+    }
+
+    # Step 1: split — stamps condition_id on the produced diagnose proposal.
+    updated, _ = split_plan_into_diagnoses(commands, section_conditions, note=current_note)
+    assert len(updated) == 1
+    assert updated[0]["command_type"] == "diagnose"
+    assert updated[0]["data"]["icd10_code"] == "I10"
+    assert updated[0]["data"]["condition_id"] == str(cond_htn.id), (
+        "split_plan_into_diagnoses must stamp the SDK condition_id (= "
+        "str(condition.id)) on the diagnose proposal when its icd10_code "
+        "matches an active condition on the patient. Without the stamp, "
+        "the per-(patient, condition) carry-forward short-circuits."
+    )
+
+    # Step 2: prefill — resolves the prior signed Assessment by (patient,
+    # condition_id) and writes its ``background`` onto the proposal.
+    prefill_diagnose_backgrounds(updated, str(current_note.id))
+    assert updated[0]["data"]["background"] == "Diagnosed 2020-03-15; controlled on lisinopril 10mg", (
+        "prefill_diagnose_backgrounds must carry forward the prior "
+        "Assessment.background for the same (patient, condition). A typo in "
+        "the filter kwargs or a missing condition_id stamp would fail here "
+        "even though every mock-based unit test passes."
+    )


### PR DESCRIPTION
[KOALA-5635](https://canvasmedical.atlassian.net/browse/KOALA-5635)

Surfaces the background carry-forward field on **Recommended Diagnosis** cards in the Scribe Summary tab. Previously this field only appeared on manually-added Assess Condition cards; Nabla-suggested A&P entries (rec-diagnose) had no `condition_id` stamped at split time and the prefill function filtered to `command_type='assess'` only, so the textarea never had data to bind to.

Backend: `split_plan_into_diagnoses` now looks up active patient conditions and stamps `data.condition_id` on diagnose proposals whose ICD-10 matches (normalized: dots stripped, uppercased — mirrors the frontend `handleInsert` match). A parallel `prefill_diagnose_backgrounds` in `builder.py` delegates to the existing `carry_forward_assess_background` helper. Frontend `DiagnoseRow` renders an editable Background textarea above today's-assessment, gated on `data.condition_id` being truthy.

On ICD change (`handleSelect`) or clear (`handleClearCode`), both `condition_id` and `background` are explicitly cleared after the spread. This prevents a cross-attachment bug where preserved background text scoped to the OLD condition could land against a NEW condition's Assessment via `handleInsert`'s diagnose→assess flip. The user-accepted tradeoff: typed text is lost on any ICD change (including within-condition typo fixes) in exchange for a clinical-data-integrity guarantee.

Sandbox-aware exception narrowing: `django.core.exceptions.ValidationError` is not in `plugin_runner/sandbox.py` ALLOWED_MODULES, so an upfront `uuid.UUID(str(note_uuid))` pre-validation is the sandbox-safe equivalent of a broad except for malformed-uuid handling.

Localhost UAT verified: rec-diagnose card renders the textarea with prefilled content when condition matches; clicking the ICD prefix clears the field; selecting a non-matching new ICD doesn't surface the old background. Pre-existing fixture fix from #287 bundled to unblock CI until that PR merges. Known followups: dormant `ValidationError` gap in sibling `prefill_assess_backgrounds*` functions; ICD-9 vs ICD-10 filter tightening.

[KOALA-5635]: https://canvasmedical.atlassian.net/browse/KOALA-5635?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ