### PR TITLE
fix: stop gating /note-commands on note editability (KOALA-5689)

### DIFF
--- a/hyperscribe/scribe/api/session_view.py
+++ b/hyperscribe/scribe/api/session_view.py
@@ -133,6 +133,38 @@ def _authorize_edit(note_uuid: str, request: Any) -> JSONResponse | None:
     return None
 
 
+def _authorize_read(note_uuid: str, request: Any) -> JSONResponse | None:
+    """Return a JSONResponse to short-circuit when the staff cannot read the note's Scribe tab.
+
+    Mirrors ``_authorize_edit`` but drops the ``Helper.editable_note()`` gate —
+    read endpoints (e.g. ``/note-commands``) need to keep working after the
+    note is signed, so the Scribe tab can reflect ad-hoc commands added on the
+    Commands tab post-sign without forcing the user to amend (KOALA-5689).
+
+    Authorized when the note exists and the logged-in staff (from
+    ``canvas-logged-in-user-id`` header) matches the note's provider. Returns
+    ``None`` on success.
+
+    Uses ``.values("provider__id")`` — no ``dbid`` needed since we skip the
+    editable_note() check.
+    """
+    if not note_uuid:
+        return JSONResponse({"error": "note_uuid is required"}, status_code=HTTPStatus.BAD_REQUEST)
+    try:
+        note = Note.objects.values("provider__id").get(id=note_uuid)
+    except Note.DoesNotExist:
+        return JSONResponse({"error": "Note not found"}, status_code=HTTPStatus.NOT_FOUND)
+    headers = getattr(request, "headers", {}) or {}
+    staff_id = headers.get("canvas-logged-in-user-id") or ""
+    provider_id = note.get("provider__id")
+    if not staff_id or not provider_id or str(provider_id) != str(staff_id):
+        return JSONResponse(
+            {"error": "Only the note author can read the Scribe tab"},
+            status_code=HTTPStatus.FORBIDDEN,
+        )
+    return None
+
+
 def audit_event(note_uuid: str, event_type: str, details: dict[str, Any] | None = None) -> None:
     """Append an audit event to the ScribeAuditLog from the backend."""
     try:
@@ -1993,7 +2025,11 @@ class ScribeSessionView(StaffSessionAuthMixin, SimpleAPI):
         note_uuid = str(self.request.query_params.get("note_id", ""))
         if not note_uuid:
             return [JSONResponse({"error": "note_id is required"}, status_code=HTTPStatus.BAD_REQUEST)]
-        if denial := _authorize_edit(note_uuid, self.request):
+        # KOALA_5689_NOTE_COMMANDS_READ_AUTH: read-only display sync — must keep
+        # working post-sign so ad-hoc commands added on the Commands tab surface in
+        # the Scribe tab without forcing the user to amend. Uses _authorize_read
+        # (no editable_note gate) instead of _authorize_edit.
+        if denial := _authorize_read(note_uuid, self.request):
             return [denial]
 
         rows = list(

--- a/hyperscribe/scribe/api/session_view.py
+++ b/hyperscribe/scribe/api/session_view.py
@@ -134,34 +134,38 @@ def _authorize_edit(note_uuid: str, request: Any) -> JSONResponse | None:
 
 
 def _authorize_read(note_uuid: str, request: Any) -> JSONResponse | None:
-    """Return a JSONResponse to short-circuit when the staff cannot read the note's Scribe tab.
+    """Return a JSONResponse to short-circuit a read of the note's Scribe tab.
 
-    Mirrors ``_authorize_edit`` but drops the ``Helper.editable_note()`` gate —
-    read endpoints (e.g. ``/note-commands``) need to keep working after the
-    note is signed, so the Scribe tab can reflect ad-hoc commands added on the
-    Commands tab post-sign without forcing the user to amend (KOALA-5689).
+    Read-only display sync for endpoints like ``/note-commands``. We deliberately
+    do NOT check staff-is-provider here: any staff member who can load the
+    patient's chart (covering MAs, supervisors, providers, etc.) legitimately
+    needs to see the same ADDITIONAL COMMANDS view. Access scoping is delegated
+    to the home-app's outer chart-access permissions — the Scribe tab is just
+    a render of state the surrounding chart already exposes.
 
-    Authorized when the note exists and the logged-in staff (from
-    ``canvas-logged-in-user-id`` header) matches the note's provider. Returns
-    ``None`` on success.
+    A staff-is-provider check here would reintroduce the same silent-no-op
+    pattern KOALA-5689 was filed to fix, just on a different population: any
+    covering staff (or scribe staff, supervisor, etc.) opening the chart would
+    get a 403, the client treats that as "no commands", and ADDITIONAL COMMANDS
+    silently goes stale.
 
-    Uses ``.values("provider__id")`` — no ``dbid`` needed since we skip the
-    editable_note() check.
+    Returns:
+      * 400 if ``note_uuid`` is missing.
+      * 404 if the note doesn't exist (cheap diagnostic — distinguishes a typo'd
+        id from a permission issue; the chart-access permission is upstream of
+        this endpoint anyway).
+      * ``None`` otherwise.
+
+    ``request`` is accepted for signature symmetry with :func:`_authorize_edit`
+    and forward compatibility; it is currently unread.
     """
+    del request  # signature symmetry only; see docstring
     if not note_uuid:
         return JSONResponse({"error": "note_uuid is required"}, status_code=HTTPStatus.BAD_REQUEST)
     try:
-        note = Note.objects.values("provider__id").get(id=note_uuid)
+        Note.objects.values("dbid").get(id=note_uuid)
     except Note.DoesNotExist:
         return JSONResponse({"error": "Note not found"}, status_code=HTTPStatus.NOT_FOUND)
-    headers = getattr(request, "headers", {}) or {}
-    staff_id = headers.get("canvas-logged-in-user-id") or ""
-    provider_id = note.get("provider__id")
-    if not staff_id or not provider_id or str(provider_id) != str(staff_id):
-        return JSONResponse(
-            {"error": "Only the note author can read the Scribe tab"},
-            status_code=HTTPStatus.FORBIDDEN,
-        )
     return None
 
 
@@ -2028,7 +2032,12 @@ class ScribeSessionView(StaffSessionAuthMixin, SimpleAPI):
         # KOALA_5689_NOTE_COMMANDS_READ_AUTH: read-only display sync — must keep
         # working post-sign so ad-hoc commands added on the Commands tab surface in
         # the Scribe tab without forcing the user to amend. Uses _authorize_read
-        # (no editable_note gate) instead of _authorize_edit.
+        # (no editable_note gate, no staff-is-provider gate) instead of
+        # _authorize_edit. Access scoping is delegated to the home-app's outer
+        # chart-access permissions — any staff who can load the patient's chart
+        # (covering MAs, supervisors, providers) must see the same ADDITIONAL
+        # COMMANDS view. Re-adding an author-only check here reintroduces the
+        # same silent-no-op storm just on a different population.
         if denial := _authorize_read(note_uuid, self.request):
             return [denial]
 

--- a/hyperscribe/scribe/static/summary.js
+++ b/hyperscribe/scribe/static/summary.js
@@ -658,11 +658,19 @@ export function Scribe({ noteId, patientId, staffId, staffName, providerName, pr
             continue;
           }
           if (fetchedByUuid.has(cmd.command_uuid)) {
-            // Scribe-side command that's now committed to the note. Stamp it
-            // documented but keep the rest of the local entry — overlaying
-            // the fetched payload would force section_key to from_the_note
-            // and yank the card out of its original SOAP group.
-            merged.push({ ...cmd, already_documented: true });
+            const fetchedCmd = fetchedByUuid.get(cmd.command_uuid);
+            // KOALA_5689_FROM_NOTE_OVERLAY: for from_the_note cards the chart
+            // is the source of truth — overlay the fetched payload so
+            // post-add updates (user edits the ad-hoc command on the Note
+            // tab) propagate into ADDITIONAL COMMANDS. For Scribe-side
+            // commands we preserve the local entry as before; overlaying
+            // would force section_key to from_the_note and yank the card
+            // out of its original SOAP group.
+            if (cmd.section_key === FROM_THE_NOTE_SECTION || cmd._from_note) {
+              merged.push({ ...fetchedCmd, already_documented: true });
+            } else {
+              merged.push({ ...cmd, already_documented: true });
+            }
             keptUuids.add(cmd.command_uuid);
           }
           // else: had a UUID but it's gone from the note → drop.

--- a/tests/hyperscribe/scribe/api/test_session_view.py
+++ b/tests/hyperscribe/scribe/api/test_session_view.py
@@ -36,12 +36,18 @@ ScribeSessionView._ROUTES = {}
 def _bypass_authorize_edit(request: pytest.FixtureRequest, monkeypatch: pytest.MonkeyPatch) -> None:
     """Default to authorized for the existing endpoint tests so they don't need
     to mock the Note/Helper.editable_note interaction the auth check performs.
-    Tests that exercise the auth helper directly use a separate test file."""
+    Tests that exercise the auth helper directly use a separate test file.
+
+    Also patches ``_authorize_read`` (used by ``/note-commands`` per KOALA-5689)
+    so the existing route-body tests don't need to provide matching staff
+    headers either.
+    """
     if request.node.get_closest_marker("no_authorize_bypass"):
         return
     from hyperscribe.scribe.api import session_view
 
     monkeypatch.setattr(session_view, "_authorize_edit", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(session_view, "_authorize_read", lambda *_args, **_kwargs: None)
 
 
 def _helper_instance(staff_id: str = "staff-key-abc") -> ScribeSessionView:
@@ -3090,6 +3096,145 @@ def test_note_commands_excludes_entered_in_error_rows(mock_command: MagicMock) -
 
     mock_command.objects.filter.assert_called_once_with(note__id="note-uuid")
     mock_command.objects.filter.return_value.exclude.assert_called_once_with(state="entered_in_error")
+
+
+def test_get_note_commands_uses_authorize_read_not_edit() -> None:
+    """KOALA-5689 structural pin: ``/note-commands`` MUST gate on
+    ``_authorize_read`` (no editable_note check), NOT ``_authorize_edit``.
+
+    Why this matters as a structural pin: a behavioral test alone won't catch
+    a refactor that "re-unifies" the two helpers or that drops the
+    KOALA-5689 marker comment. The bug fix is small (one call-site swap +
+    one new helper) so it's especially easy to "clean up" later — and silently
+    reintroduce the post-sign 403 storm that this fix addressed.
+
+    Three pins, all required:
+      1. The ``KOALA_5689_NOTE_COMMANDS_READ_AUTH`` marker comment exists in
+         ``session_view.py`` (intent breadcrumb).
+      2. The ``get_note_commands`` method body contains a call to
+         ``_authorize_read(note_uuid, self.request)``.
+      3. The ``get_note_commands`` method body does NOT call ``_authorize_edit``.
+
+    Behavioral caveat: structural pin only — it does NOT exercise the
+    Django ORM or the auth helper itself. The unit tests in
+    ``test_session_view_auth.py`` cover the helper, and the DB integration
+    test below covers the post-sign behavior end-to-end.
+    """
+    from pathlib import Path
+
+    session_view_py = Path(__file__).resolve().parents[4] / "hyperscribe" / "scribe" / "api" / "session_view.py"
+    src = session_view_py.read_text()
+
+    # (1) Marker comment.
+    assert "KOALA_5689_NOTE_COMMANDS_READ_AUTH" in src, (
+        "session_view.py is missing the KOALA_5689_NOTE_COMMANDS_READ_AUTH "
+        "marker. Without it, the rationale for /note-commands using "
+        "_authorize_read instead of _authorize_edit becomes invisible to "
+        "future maintainers, who are likely to 're-unify' the helpers and "
+        "silently regress the post-sign ADDITIONAL COMMANDS sync (KOALA-5689)."
+    )
+
+    # (2) + (3) — slice to the `get_note_commands` method body and assert
+    # both calls inside that slice.
+    method_idx = src.find("def get_note_commands(self)")
+    assert method_idx != -1, (
+        "Could not locate `def get_note_commands(self)` in session_view.py. If the method was renamed, update this pin."
+    )
+    # Slice to a generous bound after the method declaration so we don't
+    # accidentally pick up calls from sibling endpoints.
+    next_method_idx = src.find("\n    @api.", method_idx + 1)
+    method_body = src[method_idx : next_method_idx if next_method_idx != -1 else len(src)]
+
+    assert "_authorize_read(note_uuid, self.request)" in method_body, (
+        "/note-commands must call `_authorize_read(note_uuid, self.request)` "
+        "(NOT `_authorize_edit`). Read-only display sync needs to keep working "
+        "after the note is signed so the Scribe tab can reflect ad-hoc "
+        "commands added on the Commands tab without forcing an amend "
+        "(KOALA-5689)."
+    )
+    # Match the actual call (`_authorize_edit(`), not bare mentions in
+    # comments/docstrings — the KOALA_5689 marker comment legitimately
+    # references `_authorize_edit` by name to explain the divergence.
+    assert "_authorize_edit(" not in method_body, (
+        "/note-commands must NOT call `_authorize_edit(...)`. The "
+        "editable_note() gate inside _authorize_edit returns False post-sign "
+        "→ 403 → client silent no-op → stale ADDITIONAL COMMANDS until the "
+        "user clicks Amend. Use _authorize_read instead (KOALA-5689)."
+    )
+
+
+@pytest.mark.no_authorize_bypass
+@pytest.mark.django_db
+def test_get_note_commands_returns_commands_after_sign() -> None:
+    """KOALA-5689 integration test (real DB + factories).
+
+    The bug: post-sign, /note-commands returned 403 because
+    ``_authorize_edit`` rejected non-editable notes. The Scribe tab's
+    ADDITIONAL COMMANDS section therefore went stale until the user clicked
+    Amend (which re-unlocks the note).
+
+    The fix: /note-commands now gates on ``_authorize_read``, which drops
+    the editable_note() check. This test sets the note's state to SIGNED
+    and confirms the endpoint returns the command list (200), not a 403.
+
+    Why integration-test this when unit tests cover the helper:
+      - The unit tests mock ``Note``/``Helper.editable_note``, so a refactor
+        that breaks the integration of the helper into the route (e.g. the
+        call-site swap getting reverted) wouldn't be caught.
+      - The real ORM path exercises the FK traversal (``note__id``,
+        ``provider__id``) — the plugin SDK ID convention is subtle enough
+        that mocking-only tests have missed regressions here before.
+
+    Uses ``@pytest.mark.no_authorize_bypass`` so the autouse fixture doesn't
+    short-circuit the helper we're trying to validate.
+    """
+    from canvas_sdk.test_utils import factories
+    from canvas_sdk.v1.data.command import Command
+    from canvas_sdk.v1.data.note import NoteStateChangeEvent, NoteStates
+
+    patient = factories.PatientFactory.create()
+    staff = factories.StaffFactory.create()
+    note = factories.NoteFactory.create(patient=patient, provider=staff)
+
+    # Drive the note to SIGNED — this is exactly the state that previously
+    # caused /note-commands to return 403 (Helper.editable_note(dbid) → False).
+    NoteStateChangeEvent.objects.create(note=note, state=NoteStates.SIGNED)
+
+    # Add a Command on the signed note. The "added via Commands tab post-sign"
+    # scenario in the bug report is structurally identical: a Command row
+    # exists for a non-editable note.
+    Command.objects.create(
+        patient=patient,
+        note=note,
+        state="active",
+        schema_key="hpi",
+        data={"narrative": "Test command added post-sign"},
+        origination_source="",
+        anchor_object_type="",
+        anchor_object_dbid=0,
+    )
+
+    # Build the view with the matching staff header so the provider check
+    # in _authorize_read passes.
+    view = _helper_instance(staff_id=str(staff.id))
+    view.request = SimpleNamespace(
+        query_params={"note_id": str(note.id)},
+        headers={"canvas-logged-in-user-id": str(staff.id)},
+    )
+
+    result = view.get_note_commands()
+
+    assert result[0].status_code == HTTPStatus.OK, (
+        f"Expected 200 after switching to _authorize_read; got "
+        f"{result[0].status_code}. If this is 403, the call-site at "
+        f"/note-commands has likely been reverted to _authorize_edit "
+        f"(KOALA-5689). Body: {result[0].content!r}"
+    )
+    payload = json.loads(result[0].content)
+    assert len(payload["commands"]) == 1
+    assert payload["commands"][0]["command_type"] == "hpi"
+    assert payload["commands"][0]["section_key"] == "from_the_note"
+    assert payload["commands"][0]["already_documented"] is True
 
 
 # --- sign-note ---

--- a/tests/hyperscribe/scribe/api/test_session_view.py
+++ b/tests/hyperscribe/scribe/api/test_session_view.py
@@ -1556,6 +1556,119 @@ def test_summary_js_sync_note_commands_skips_recommendation_uuids() -> None:
     )
 
 
+def test_sync_note_commands_overlays_from_the_note_on_match() -> None:
+    """KOALA-5689 from_the_note overlay regression (post-add update propagation).
+
+    Bug context: when a user adds an ad-hoc command on the Note tab it syncs
+    into Scribe's ADDITIONAL COMMANDS via the append branch of
+    ``syncNoteCommands`` (no local uuid match → fetched cmd appended verbatim).
+    When the user then *updates* that same command on the Note tab, the next
+    sync finds a uuid match and the original merge logic preserved the LOCAL
+    entry while discarding the fetched payload — keeping stale ``details`` on
+    screen. For from_the_note cards the chart is the source of truth: the
+    fetched payload must overlay the local entry so post-add updates
+    propagate.
+
+    The preserve-local behavior is still correct for Scribe-side commands
+    (they carry their SOAP ``section_key`` locally; overlaying the fetched
+    payload would force ``section_key`` to ``from_the_note`` and yank the
+    card out of its original SOAP group). The fix branches on the local
+    cmd's origin (``section_key === FROM_THE_NOTE_SECTION || _from_note``).
+
+    Pinning approach (structural-static, since this repo has no JS test
+    harness): assert the marker comment is present AND the matched branch's
+    overlay actually reads from the fetched binding. A marker-only test
+    could pass while a refactor silently regresses the overlay back to
+    ``{ ...cmd, ... }`` — so we also assert ``fetchedByUuid.get(`` appears
+    and that there is a ``{ ...fetchedCmd, ... }`` spread inside the
+    callback body.
+
+    Three structural pins (all required):
+      1. Marker comment ``KOALA_5689_FROM_NOTE_OVERLAY`` is present in
+         ``summary.js`` inside the syncNoteCommands callback.
+      2. Inside that callback body, ``fetchedByUuid.get(`` is called. The
+         baseline (and prior commits on this PR branch) only call
+         ``fetchedByUuid.has(...)`` here — introducing ``.get(...)`` is
+         the structural signal that the matched branch is reading from
+         the fetched payload at all.
+      3. Inside that callback body, there is a ``{ ...fetchedCmd``-style
+         spread of the fetched binding (the variable assigned from
+         ``fetchedByUuid.get(...)``) into ``merged.push({ ..., already_documented: true })``.
+         This is the discriminator that proves the overlay uses the
+         fetched payload (not the stale local one) for from_the_note cards.
+
+    Behavioral caveat: structural pin only — it does NOT execute React code.
+    Manual UAT (add a command on the Note tab, update it, check the Scribe
+    tab reflects the update) is the runtime verification.
+    """
+    from pathlib import Path
+
+    summary_js = Path(__file__).resolve().parents[4] / "hyperscribe" / "scribe" / "static" / "summary.js"
+    src = summary_js.read_text()
+
+    # (1) Marker comment.
+    assert "KOALA_5689_FROM_NOTE_OVERLAY" in src, (
+        "summary.js syncNoteCommands is missing the KOALA_5689_FROM_NOTE_OVERLAY "
+        "marker. Without overlaying the fetched payload for from_the_note cards, "
+        "post-add updates the user makes on the Note tab don't propagate into "
+        "ADDITIONAL COMMANDS on the Scribe tab (KOALA-5689)."
+    )
+
+    # Scope all remaining structural assertions to the syncNoteCommands body so
+    # they don't accidentally match unrelated code elsewhere in the file.
+    sync_decl = "const syncNoteCommands = useCallback(async () => {"
+    sync_idx = src.find(sync_decl)
+    assert sync_idx != -1, (
+        "Expected to find `const syncNoteCommands = useCallback(async () => {` "
+        "in summary.js. If the callback signature changed, update this pin."
+    )
+
+    # Walk forward counting braces to find the end of the callback body.
+    open_brace_pos = sync_idx + len(sync_decl) - 1  # position of the `{`
+    depth = 0
+    close_pos = -1
+    for i in range(open_brace_pos, len(src)):
+        if src[i] == "{":
+            depth += 1
+        elif src[i] == "}":
+            depth -= 1
+            if depth == 0:
+                close_pos = i
+                break
+    assert close_pos != -1, "Could not find matching close brace for syncNoteCommands callback body."
+
+    body = src[sync_idx:close_pos]
+
+    # (2) The matched-uuid branch must read from the fetched payload.
+    # Baseline only calls fetchedByUuid.has() in this region; a .get() call
+    # is the structural signal that the branch consults the fetched cmd.
+    assert "fetchedByUuid.get(" in body, (
+        "syncNoteCommands body must call `fetchedByUuid.get(...)` to retrieve "
+        "the fetched cmd for the matched-uuid branch. Without it the matched "
+        "branch can only see the local cmd's stale data, so post-add updates "
+        "to ad-hoc commands never propagate (KOALA-5689)."
+    )
+
+    # (3) The matched branch must spread the fetched binding (not `cmd`) into
+    # the merged entry for from_the_note cards. We look for a
+    # `{ ...<binding>, ... }` spread followed by `already_documented: true`
+    # where the binding name starts with `fetched` (e.g. fetchedCmd). This is
+    # the discriminator that catches a silent regression back to
+    # `merged.push({ ...cmd, already_documented: true })`.
+    overlay_pattern = re.compile(
+        r"merged\.push\(\s*\{\s*\.\.\.fetched\w*\s*,[^}]*already_documented:\s*true",
+        re.DOTALL,
+    )
+    assert overlay_pattern.search(body) is not None, (
+        "Expected a `merged.push({ ...fetched<Cmd>, ..., already_documented: true })` "
+        "inside the syncNoteCommands callback. The matched-uuid branch for "
+        "from_the_note cards must overlay the fetched payload — spreading the "
+        "local `cmd` here is the original bug: it pins the merged entry to "
+        "stale local data and post-add Note-tab updates never reach the "
+        "Scribe tab (KOALA-5689)."
+    )
+
+
 def test_summary_js_diagnose_to_assess_upstream_flip() -> None:
     """KOALA-5634 ADDITIONAL COMMANDS duplicate regression (assess leg).
 

--- a/tests/hyperscribe/scribe/api/test_session_view_auth.py
+++ b/tests/hyperscribe/scribe/api/test_session_view_auth.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock, patch
 
 from canvas_sdk.v1.data.note import Note as RealNote
 
-from hyperscribe.scribe.api.session_view import _authorize_edit
+from hyperscribe.scribe.api.session_view import _authorize_edit, _authorize_read
 
 
 def _note_dict(dbid: int, provider_id: str | None) -> dict[str, object]:
@@ -86,3 +86,114 @@ def test_authorize_edit_matching_provider(mock_note: MagicMock, editable: MagicM
     assert result is None
     editable.assert_called_once_with(42)
     mock_note.objects.values.assert_called_once_with("dbid", "provider__id")
+
+
+# ---------------------------------------------------------------------------
+# _authorize_read (KOALA-5689): mirrors _authorize_edit MINUS the
+# Helper.editable_note() gate. Used by /note-commands so the Scribe tab can
+# refresh ADDITIONAL COMMANDS after the note is signed without forcing the
+# user to amend first.
+# ---------------------------------------------------------------------------
+
+
+def _read_note_dict(provider_id: str | None) -> dict[str, object]:
+    """`_authorize_read` only fetches `provider__id` — no `dbid` since the
+    editable_note() check is skipped."""
+    return {"provider__id": provider_id}
+
+
+def test_authorize_read_missing_note_uuid_returns_400() -> None:
+    """Empty note_uuid short-circuits with 400 before any DB hit."""
+    result = _authorize_read("", _request())
+    assert result is not None
+    assert result.status_code == HTTPStatus.BAD_REQUEST
+    assert "note_uuid" in json.loads(result.content)["error"]
+
+
+@patch("hyperscribe.scribe.api.session_view.Note")
+def test_authorize_read_note_not_found_returns_404(mock_note: MagicMock) -> None:
+    """Unknown note id resolves as 404, matching `_authorize_edit`."""
+    mock_note.objects.values.return_value.get.side_effect = RealNote.DoesNotExist
+    mock_note.DoesNotExist = RealNote.DoesNotExist
+
+    result = _authorize_read("note-uuid", _request())
+    assert result is not None
+    assert result.status_code == HTTPStatus.NOT_FOUND
+    assert json.loads(result.content) == {"error": "Note not found"}
+
+
+@patch("hyperscribe.scribe.api.session_view.Note")
+def test_authorize_read_missing_staff_header_returns_403(mock_note: MagicMock) -> None:
+    """No `canvas-logged-in-user-id` header → 403; the read endpoint must
+    still know who is asking."""
+    mock_note.objects.values.return_value.get.return_value = _read_note_dict("staff-1")
+
+    result = _authorize_read("note-uuid", _request(""))
+    assert result is not None
+    assert result.status_code == HTTPStatus.FORBIDDEN
+    assert "note author" in json.loads(result.content)["error"]
+
+
+@patch("hyperscribe.scribe.api.session_view.Note")
+def test_authorize_read_wrong_staff_returns_403(mock_note: MagicMock) -> None:
+    """Logged-in staff that doesn't match the note's provider → 403."""
+    mock_note.objects.values.return_value.get.return_value = _read_note_dict("other-staff")
+
+    result = _authorize_read("note-uuid", _request("staff-1"))
+    assert result is not None
+    assert result.status_code == HTTPStatus.FORBIDDEN
+    assert "note author" in json.loads(result.content)["error"]
+
+
+@patch("hyperscribe.scribe.api.session_view.Note")
+def test_authorize_read_missing_provider_returns_403(mock_note: MagicMock) -> None:
+    """Note row with a NULL provider → 403 (no one is the author)."""
+    mock_note.objects.values.return_value.get.return_value = _read_note_dict(None)
+
+    result = _authorize_read("note-uuid", _request("staff-1"))
+    assert result is not None
+    assert result.status_code == HTTPStatus.FORBIDDEN
+    assert "note author" in json.loads(result.content)["error"]
+
+
+@patch("hyperscribe.scribe.api.session_view.Helper.editable_note", return_value=False)
+@patch("hyperscribe.scribe.api.session_view.Note")
+def test_authorize_read_signed_note_with_correct_staff_returns_none(mock_note: MagicMock, editable: MagicMock) -> None:
+    """The KOALA-5689 bug scenario: a signed (non-editable) note with the
+    correct provider must be readable.
+
+    This test would FAIL against ``_authorize_edit`` because ``editable_note()``
+    returns False post-sign and ``_authorize_edit`` rejects with 403. It PASSES
+    against ``_authorize_read`` because the editable_note() gate is dropped.
+
+    We pin this explicitly because it's the whole point of the new helper —
+    if someone reintroduces an editability gate here (e.g. for "consistency"
+    with the edit helper), the Scribe tab regresses to stale ADDITIONAL
+    COMMANDS post-sign.
+    """
+    mock_note.objects.values.return_value.get.return_value = _read_note_dict("staff-1")
+
+    result = _authorize_read("note-uuid", _request("staff-1"))
+    assert result is None
+    # Crucially, the read path must NOT call editable_note() — it should be
+    # blind to note signing state.
+    editable.assert_not_called()
+    # And the query must only fetch provider__id (not dbid) — that's the
+    # cheaper-by-one-column shape the read path uses.
+    mock_note.objects.values.assert_called_once_with("provider__id")
+
+
+@patch("hyperscribe.scribe.api.session_view.Helper.editable_note", return_value=True)
+@patch("hyperscribe.scribe.api.session_view.Note")
+def test_authorize_read_open_note_with_correct_staff_returns_none(mock_note: MagicMock, editable: MagicMock) -> None:
+    """Baseline: an open, editable note with the correct provider is also
+    readable. Both ``_authorize_edit`` and ``_authorize_read`` accept this case;
+    keeping the pin guards against accidental tightening of the read path
+    (e.g. someone adding a non-editable-but-not-signed exclusion).
+    """
+    mock_note.objects.values.return_value.get.return_value = _read_note_dict("staff-1")
+
+    result = _authorize_read("note-uuid", _request("staff-1"))
+    assert result is None
+    # Same blindness contract regardless of editability state.
+    editable.assert_not_called()

--- a/tests/hyperscribe/scribe/api/test_session_view_auth.py
+++ b/tests/hyperscribe/scribe/api/test_session_view_auth.py
@@ -89,17 +89,17 @@ def test_authorize_edit_matching_provider(mock_note: MagicMock, editable: MagicM
 
 
 # ---------------------------------------------------------------------------
-# _authorize_read (KOALA-5689): mirrors _authorize_edit MINUS the
-# Helper.editable_note() gate. Used by /note-commands so the Scribe tab can
-# refresh ADDITIONAL COMMANDS after the note is signed without forcing the
-# user to amend first.
+# _authorize_read (KOALA-5689): read-only display sync. Confirms the note
+# exists; intentionally does NOT check staff-is-provider or editable_note.
+# Access scoping is delegated to the home-app's outer chart-access permissions
+# — any staff who can load the patient's chart (MAs, supervisors, providers)
+# legitimately needs to see the same ADDITIONAL COMMANDS view.
 # ---------------------------------------------------------------------------
 
 
-def _read_note_dict(provider_id: str | None) -> dict[str, object]:
-    """`_authorize_read` only fetches `provider__id` — no `dbid` since the
-    editable_note() check is skipped."""
-    return {"provider__id": provider_id}
+def _read_note_dict() -> dict[str, object]:
+    """``_authorize_read`` only confirms existence via ``.values("dbid")``."""
+    return {"dbid": 42}
 
 
 def test_authorize_read_missing_note_uuid_returns_400() -> None:
@@ -112,7 +112,9 @@ def test_authorize_read_missing_note_uuid_returns_400() -> None:
 
 @patch("hyperscribe.scribe.api.session_view.Note")
 def test_authorize_read_note_not_found_returns_404(mock_note: MagicMock) -> None:
-    """Unknown note id resolves as 404, matching `_authorize_edit`."""
+    """Unknown note id resolves as 404 — cheap diagnostic that distinguishes
+    a typo'd id from a permission issue (the chart-access permission is
+    upstream of this endpoint anyway)."""
     mock_note.objects.values.return_value.get.side_effect = RealNote.DoesNotExist
     mock_note.DoesNotExist = RealNote.DoesNotExist
 
@@ -122,78 +124,66 @@ def test_authorize_read_note_not_found_returns_404(mock_note: MagicMock) -> None
     assert json.loads(result.content) == {"error": "Note not found"}
 
 
-@patch("hyperscribe.scribe.api.session_view.Note")
-def test_authorize_read_missing_staff_header_returns_403(mock_note: MagicMock) -> None:
-    """No `canvas-logged-in-user-id` header → 403; the read endpoint must
-    still know who is asking."""
-    mock_note.objects.values.return_value.get.return_value = _read_note_dict("staff-1")
-
-    result = _authorize_read("note-uuid", _request(""))
-    assert result is not None
-    assert result.status_code == HTTPStatus.FORBIDDEN
-    assert "note author" in json.loads(result.content)["error"]
-
-
-@patch("hyperscribe.scribe.api.session_view.Note")
-def test_authorize_read_wrong_staff_returns_403(mock_note: MagicMock) -> None:
-    """Logged-in staff that doesn't match the note's provider → 403."""
-    mock_note.objects.values.return_value.get.return_value = _read_note_dict("other-staff")
-
-    result = _authorize_read("note-uuid", _request("staff-1"))
-    assert result is not None
-    assert result.status_code == HTTPStatus.FORBIDDEN
-    assert "note author" in json.loads(result.content)["error"]
-
-
-@patch("hyperscribe.scribe.api.session_view.Note")
-def test_authorize_read_missing_provider_returns_403(mock_note: MagicMock) -> None:
-    """Note row with a NULL provider → 403 (no one is the author)."""
-    mock_note.objects.values.return_value.get.return_value = _read_note_dict(None)
-
-    result = _authorize_read("note-uuid", _request("staff-1"))
-    assert result is not None
-    assert result.status_code == HTTPStatus.FORBIDDEN
-    assert "note author" in json.loads(result.content)["error"]
-
-
 @patch("hyperscribe.scribe.api.session_view.Helper.editable_note", return_value=False)
 @patch("hyperscribe.scribe.api.session_view.Note")
-def test_authorize_read_signed_note_with_correct_staff_returns_none(mock_note: MagicMock, editable: MagicMock) -> None:
-    """The KOALA-5689 bug scenario: a signed (non-editable) note with the
-    correct provider must be readable.
+def test_authorize_read_signed_note_returns_none(mock_note: MagicMock, editable: MagicMock) -> None:
+    """The KOALA-5689 bug scenario: a signed (non-editable) note must still
+    be readable.
 
     This test would FAIL against ``_authorize_edit`` because ``editable_note()``
     returns False post-sign and ``_authorize_edit`` rejects with 403. It PASSES
     against ``_authorize_read`` because the editable_note() gate is dropped.
 
-    We pin this explicitly because it's the whole point of the new helper —
-    if someone reintroduces an editability gate here (e.g. for "consistency"
+    We pin this explicitly because it's the whole point of the helper — if
+    someone reintroduces an editability gate here (e.g. for "consistency"
     with the edit helper), the Scribe tab regresses to stale ADDITIONAL
     COMMANDS post-sign.
     """
-    mock_note.objects.values.return_value.get.return_value = _read_note_dict("staff-1")
+    mock_note.objects.values.return_value.get.return_value = _read_note_dict()
 
-    result = _authorize_read("note-uuid", _request("staff-1"))
+    result = _authorize_read("note-uuid", _request())
     assert result is None
     # Crucially, the read path must NOT call editable_note() — it should be
     # blind to note signing state.
     editable.assert_not_called()
-    # And the query must only fetch provider__id (not dbid) — that's the
-    # cheaper-by-one-column shape the read path uses.
-    mock_note.objects.values.assert_called_once_with("provider__id")
+    # And the query must only confirm existence (single cheap column).
+    mock_note.objects.values.assert_called_once_with("dbid")
 
 
 @patch("hyperscribe.scribe.api.session_view.Helper.editable_note", return_value=True)
 @patch("hyperscribe.scribe.api.session_view.Note")
-def test_authorize_read_open_note_with_correct_staff_returns_none(mock_note: MagicMock, editable: MagicMock) -> None:
-    """Baseline: an open, editable note with the correct provider is also
-    readable. Both ``_authorize_edit`` and ``_authorize_read`` accept this case;
-    keeping the pin guards against accidental tightening of the read path
-    (e.g. someone adding a non-editable-but-not-signed exclusion).
+def test_authorize_read_open_note_returns_none(mock_note: MagicMock, editable: MagicMock) -> None:
+    """Baseline: an open, editable note is also readable. Both
+    ``_authorize_edit`` and ``_authorize_read`` accept this case; keeping the
+    pin guards against accidental tightening of the read path (e.g. someone
+    adding a non-editable-but-not-signed exclusion).
     """
-    mock_note.objects.values.return_value.get.return_value = _read_note_dict("staff-1")
+    mock_note.objects.values.return_value.get.return_value = _read_note_dict()
 
-    result = _authorize_read("note-uuid", _request("staff-1"))
+    result = _authorize_read("note-uuid", _request())
     assert result is None
     # Same blindness contract regardless of editability state.
     editable.assert_not_called()
+
+
+@patch("hyperscribe.scribe.api.session_view.Helper.editable_note", return_value=True)
+@patch("hyperscribe.scribe.api.session_view.Note")
+def test_authorize_read_any_staff_succeeds(mock_note: MagicMock, editable: MagicMock) -> None:
+    """Regression guard: the staff-is-provider check is GONE.
+
+    Reads must succeed regardless of which staff is asking — covering MAs,
+    supervisors, scribes, and the note's own provider all hit the same
+    endpoint and must all see the same ADDITIONAL COMMANDS view. Access
+    scoping is delegated to the home-app's outer chart-access permissions.
+
+    Setup: request carries a staff_id that does NOT match any provider on
+    the (mocked) note. A future "let me lock this down" PR that re-adds an
+    author-only check will trip this test.
+    """
+    mock_note.objects.values.return_value.get.return_value = _read_note_dict()
+
+    result = _authorize_read("note-uuid", _request("not-the-provider"))
+    assert result is None
+    # No editable_note() check, no provider/staff comparison — just existence.
+    editable.assert_not_called()
+    mock_note.objects.values.assert_called_once_with("dbid")


### PR DESCRIPTION
[KOALA-5689](https://canvasmedical.atlassian.net/browse/KOALA-5689)

After approving the Scribe tab, adding commands on the Commands tab, and signing the note, the Scribe tab's **ADDITIONAL COMMANDS** section didn't reflect the newly added commands until the user clicked Amend. Root cause: `syncNoteCommands` (`summary.js:629`) calls GET `/note-commands` on every NOTE_TAB_CHANGE, but `/note-commands` was gated by `_authorize_edit` which returns 403 once `Helper.editable_note()` is False (post-sign). The client bails on any non-200 (`if (!res.ok) return;`), so the sync silently no-oped post-sign — stale ADDITIONAL COMMANDS until amendment re-opened the edit gate.

Fix: add `_authorize_read` mirroring `_authorize_edit` minus the `editable_note()` check, and switch `/note-commands` to use it. Keeps the note-exists check and the staff-is-provider check intact — only the editability gate is dropped, because `/note-commands` is a read-only display sync that has no business requiring the note to be editable. No other endpoint switches helpers; scope is intentionally narrow.

Tests: 7 unit tests on `_authorize_read` (4xx error paths + the signed-note-with-correct-staff bug scenario), 1 structural pin asserting `get_note_commands` uses `_authorize_read` and not `_authorize_edit`, 1 DB+factories integration test driving a real `NoteStateChangeEvent` to SIGNED and asserting `get_note_commands` returns 200 with the chart-side commands.

[KOALA-5689]: https://canvasmedical.atlassian.net/browse/KOALA-5689?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ