### PR TITLE
feat(nabla): detailed HPI + validated social/family history prompts

### DIFF
--- a/hyperscribe/scribe/clients/nabla/backend.py
+++ b/hyperscribe/scribe/clients/nabla/backend.py
@@ -250,24 +250,30 @@ class NablaBackend(ScribeBackend):
                 {
                     "section_key": "HISTORY_OF_PRESENT_ILLNESS",
                     "style": "PARAGRAPH",
-                    "level_of_detail": "DEFAULT",
+                    "level_of_detail": "DETAILED",
                     "custom_instruction": hpi_custom_instructions,
                 },
                 {
                     "section_key": "SOCIAL_HISTORY",
                     "custom_instruction": (
-                        "Be thorough. Include all relevant details discussed for: "
-                        "Living Situation, Social Support, Caregiving Resources, "
-                        "Occupation, Alcohol, Tobacco, Recreational Drugs, and Exposures."
+                        "Document only the patient's own social history, and only what is actually "
+                        "discussed in this encounter. Do not attribute anyone else's family, children, "
+                        "activities, or history to the patient; exclude social details belonging to the "
+                        "clinician, a caregiver, or a companion in the room. Never state that a topic was "
+                        "not discussed or that no information was provided. If the patient's own social "
+                        "history is not discussed, leave this section empty."
                     ),
                 },
                 {
                     "section_key": "FAMILY_HISTORY",
                     "custom_instruction": (
-                        "Be thorough. Document all family members mentioned, their relationship "
-                        "to the patient, and any medical conditions or causes of death "
-                        "discussed. Distinguish between the patient's own history and "
-                        "family members' history."
+                        "Family history covers medical conditions or causes of death in the patient's "
+                        "own biological relatives — not social anecdotes or a healthy relative's "
+                        "activities. Document only what is actually discussed; name the relative and "
+                        "relationship. Do not attribute the relatives of the clinician, a caregiver, or "
+                        "a companion in the room to the patient; when the relationship or speaker is "
+                        "unclear, omit rather than guess. Never add filler such as \"no other family "
+                        "history discussed.\" If none is discussed, leave empty."
                     ),
                 },
                 {

--- a/tests/hyperscribe/scribe/clients/nabla/test_backend.py
+++ b/tests/hyperscribe/scribe/clients/nabla/test_backend.py
@@ -158,6 +158,61 @@ def test_generate_note_physical_exam_excludes_vitals() -> None:
     assert "vitals section" in instruction_lower
 
 
+def _section_entry(payload: dict, section_key: str) -> dict:
+    entries = [e for e in payload["note_sections_customization"] if e.get("section_key") == section_key]
+    assert len(entries) == 1, f"expected exactly one {section_key} customization entry"
+    return entries[0]
+
+
+def test_generate_note_hpi_uses_detailed_level_of_detail() -> None:
+    backend, mock_rest_client = _make_backend()
+    mock_rest_client.generate_note.return_value = {"title": "Note", "sections": []}
+
+    backend.generate_note(Transcript())
+
+    payload = mock_rest_client.generate_note.call_args.args[0]
+    hpi_entry = _section_entry(payload, "HISTORY_OF_PRESENT_ILLNESS")
+    assert hpi_entry["level_of_detail"] == "DETAILED"
+
+
+def test_generate_note_social_history_instruction() -> None:
+    backend, mock_rest_client = _make_backend()
+    mock_rest_client.generate_note.return_value = {"title": "Note", "sections": []}
+
+    backend.generate_note(Transcript())
+
+    payload = mock_rest_client.generate_note.call_args.args[0]
+    instruction = _section_entry(payload, "SOCIAL_HISTORY")["custom_instruction"]
+    lower = instruction.lower()
+
+    # Old "be thorough / include all" filler-prone phrasing is gone.
+    assert "be thorough" not in lower
+    # Core guardrails of the validated rewrite.
+    assert "patient's own social history" in instruction
+    assert "only what is actually discussed" in instruction
+    assert "caregiver, or a companion in the room" in instruction
+    assert "never state that a topic was not discussed" in lower
+    assert "leave this section empty" in instruction
+
+
+def test_generate_note_family_history_instruction() -> None:
+    backend, mock_rest_client = _make_backend()
+    mock_rest_client.generate_note.return_value = {"title": "Note", "sections": []}
+
+    backend.generate_note(Transcript())
+
+    payload = mock_rest_client.generate_note.call_args.args[0]
+    instruction = _section_entry(payload, "FAMILY_HISTORY")["custom_instruction"]
+    lower = instruction.lower()
+
+    assert "be thorough" not in lower
+    assert "biological relatives" in instruction
+    assert "omit rather than guess" in instruction
+    # No-filler guardrail, quoted example phrasing preserved.
+    assert 'no other family history discussed.' in instruction
+    assert "if none is discussed, leave empty" in lower
+
+
 def test_generate_normalized_data() -> None:
     backend, mock_rest_client = _make_backend()
     mock_rest_client.generate_normalized_data.return_value = {


### PR DESCRIPTION
## Summary
Three low-risk changes to the Nabla `generate-note` payload (`hyperscribe/scribe/clients/nabla/backend.py`), per the Current iteration of the prompt rollout plan. No change to the HPI `custom_instruction` text this round — HPI gets the detail-level flag only.

| # | Change | Type |
|---|--------|------|
| 1 | HPI `level_of_detail`: `DEFAULT` → `DETAILED` | field only |
| 2 | `SOCIAL_HISTORY` `custom_instruction` → validated rewrite | prompt text |
| 3 | `FAMILY_HISTORY` `custom_instruction` → validated rewrite | prompt text |

### 1. HPI `level_of_detail` → `DETAILED`
HPI **only** (kept uppercase, matching the value working in prod). Providers asked for more HPI detail; validation showed richer/more complete HPI with no section leakage.

### 2. `SOCIAL_HISTORY` rewrite
Document only the patient's own social history actually discussed; no third-party (clinician/caregiver/companion) attribution; no "not discussed / no information provided" filler; leave empty when none discussed.

### 3. `FAMILY_HISTORY` rewrite
Cover only biological relatives' conditions/causes of death; name relative + relationship; omit rather than guess when speaker/relationship unclear; no filler; leave empty when none discussed.

## Tests
- Added 3 unit tests in `tests/hyperscribe/scribe/clients/nabla/test_backend.py` locking in `DETAILED`, the new social rewrite, and the new family rewrite (and asserting the old "be thorough" phrasing is gone). No prior test asserted on the old strings/value.
- Full `tests/hyperscribe/scribe` suite: **1095 passed**.

## Rollback
All three are single-value edits; revert the strings/flag to restore prior behavior. No data migration, no schema change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)