### PR TITLE
fix: stop vitals card auto-creating in Scribe Manual mode (KOALA-5802)

### DIFF
--- a/hyperscribe/scribe/charges/enrichment.py
+++ b/hyperscribe/scribe/charges/enrichment.py
@@ -58,9 +58,7 @@ def build_assessment_index(note: Any) -> dict[str, list[str]]:
     return dict(index)
 
 
-def _resolve_assessment_ids(
-    pointers: list[dict[str, Any]], index: dict[str, list[str]]
-) -> list[str]:
+def _resolve_assessment_ids(pointers: list[dict[str, Any]], index: dict[str, list[str]]) -> list[str]:
     """Resolve a charge's diagnosis pointers to Assessment ids via the code
     index. De-duplicates while preserving order. When an ICD code maps to more
     than one assessment (rare: two assessments of the same condition on one
@@ -102,11 +100,9 @@ def _find_billing_line_item(note: Any, command_uuid: str) -> Any | None:
         # the frontend retries. Log so we can tell timing apart from a real miss.
         log.info("enrich_charges: command %s not present yet", command_uuid)
         return None
-    bli = (
-        BillingLineItem.objects.filter(
-            note=note, command_id=command.dbid, status=BillingLineItemStatus.ACTIVE
-        ).first()
-    )
+    bli = BillingLineItem.objects.filter(
+        note=note, command_id=command.dbid, status=BillingLineItemStatus.ACTIVE
+    ).first()
     if bli is None:
         # Fallback to the SDK-documented cpt + note lookup in case command_id
         # isn't populated the way we expect. cpt lives in the perform command's
@@ -119,9 +115,7 @@ def _find_billing_line_item(note: Any, command_uuid: str) -> Any | None:
                 cpt = perform.get("value")
             cpt = cpt or data.get("cpt_code")
         if cpt:
-            qs = BillingLineItem.objects.filter(
-                note=note, cpt=cpt, status=BillingLineItemStatus.ACTIVE
-            )
+            qs = BillingLineItem.objects.filter(note=note, cpt=cpt, status=BillingLineItemStatus.ACTIVE)
             count = qs.count()
             if count > 1:
                 # Multiple ACTIVE BLIs share this CPT — .first() would pick one
@@ -131,13 +125,17 @@ def _find_billing_line_item(note: Any, command_uuid: str) -> Any | None:
                 log.warning(
                     "enrich_charges: ambiguous cpt %s matches %d BLIs on note"
                     " — skipping fallback to avoid silent miswrite",
-                    cpt, count,
+                    cpt,
+                    count,
                 )
             else:
                 bli = qs.first()
         log.info(
             "enrich_charges: cmd=%s dbid=%s cpt=%s bli_found=%s (command_id miss)",
-            command_uuid, command.dbid, cpt, bli is not None,
+            command_uuid,
+            command.dbid,
+            cpt,
+            bli is not None,
         )
     return bli
 
@@ -166,7 +164,10 @@ def build_charge_enrichment_effects(
     index = build_assessment_index(note)
     log.info(
         "enrich_charges: note=%s charges=%d removed=%d assessment_codes=%d",
-        note_uuid, len(charges), len(removed_command_uuids), len(index),
+        note_uuid,
+        len(charges),
+        len(removed_command_uuids),
+        len(index),
     )
     effects: list[Effect] = []
     enriched: list[dict[str, Any]] = []
@@ -212,12 +213,14 @@ def build_charge_enrichment_effects(
                 modifiers=modifiers,
             ).apply()
         )
-        enriched.append({
-            "command_uuid": command_uuid,
-            "billing_line_item_id": str(bli.id),
-            "assessment_ids": assessment_ids,
-            "modifiers": modifier_codes,
-        })
+        enriched.append(
+            {
+                "command_uuid": command_uuid,
+                "billing_line_item_id": str(bli.id),
+                "assessment_ids": assessment_ids,
+                "modifiers": modifier_codes,
+            }
+        )
 
     for command_uuid in removed_command_uuids:
         bli = _find_billing_line_item(note, command_uuid)
@@ -228,7 +231,9 @@ def build_charge_enrichment_effects(
 
     log.info(
         "enrich_charges result: enriched=%d errors=%d effects=%d (%s)",
-        len(enriched), len(errors), len(effects),
+        len(enriched),
+        len(errors),
+        len(effects),
         ",".join(f"{e['command_uuid']}:{e['reason']}" for e in errors) or "ok",
     )
     return effects, enriched, errors

--- a/hyperscribe/scribe/clients/nabla/backend.py
+++ b/hyperscribe/scribe/clients/nabla/backend.py
@@ -272,8 +272,8 @@ class NablaBackend(ScribeBackend):
                         "activities. Document only what is actually discussed; name the relative and "
                         "relationship. Do not attribute the relatives of the clinician, a caregiver, or "
                         "a companion in the room to the patient; when the relationship or speaker is "
-                        "unclear, omit rather than guess. Never add filler such as \"no other family "
-                        "history discussed.\" If none is discussed, leave empty."
+                        'unclear, omit rather than guess. Never add filler such as "no other family '
+                        'history discussed." If none is discussed, leave empty.'
                     ),
                 },
                 {

--- a/hyperscribe/scribe/static/summary.js
+++ b/hyperscribe/scribe/static/summary.js
@@ -1252,7 +1252,8 @@ export function Scribe({ noteId, patientId, staffId, staffName, providerName, pr
     const manualCommands = [
       { command_type: 'rfv', display: '', data: { comment: '' }, selected: true, section_key: 'chief_complaint', already_documented: false },
       { command_type: 'hpi', display: '', data: { narrative: '' }, selected: true, section_key: 'history_of_present_illness', already_documented: false },
-      { command_type: 'vitals', display: '', data: {}, selected: true, section_key: 'vitals', already_documented: false },
+      // Vitals is intentionally NOT pre-populated: an empty vitals card auto-opens its editor and blocks
+      // commit until saved/cancelled (KOALA-5802). It's added on demand via the "+ Vitals" button instead.
       { command_type: 'plan', display: '', data: { narrative: '' }, selected: true, section_key: 'assessment_and_plan', already_documented: false },
     ];
     // Add PE from template if available.

--- a/tests/hyperscribe/scribe/api/test_session_view_charges.py
+++ b/tests/hyperscribe/scribe/api/test_session_view_charges.py
@@ -158,14 +158,23 @@ def _post_instance(body: dict, staff_id="staff-key-abc") -> ScribeSessionView:
 @patch("hyperscribe.scribe.api.session_view.build_charge_enrichment_effects")
 def test_enrich_charges_happy_path(mock_build, mock_audit, mock_auth):
     effect = _MagicMock(spec=Effect)
-    mock_build.return_value = ([effect], [{"command_uuid": "c1", "billing_line_item_id": "b1",
-                                          "assessment_ids": ["a1"], "modifiers": ["25"]}], [])
-    view = _post_instance({
-        "note_uuid": "note-1",
-        "charges": [{"command_uuid": "c1",
-                     "diagnosis_pointers": [{"command_uuid": "d1", "icd10_code": "M25.511"}],
-                     "modifiers": ["25"]}],
-    })
+    mock_build.return_value = (
+        [effect],
+        [{"command_uuid": "c1", "billing_line_item_id": "b1", "assessment_ids": ["a1"], "modifiers": ["25"]}],
+        [],
+    )
+    view = _post_instance(
+        {
+            "note_uuid": "note-1",
+            "charges": [
+                {
+                    "command_uuid": "c1",
+                    "diagnosis_pointers": [{"command_uuid": "d1", "icd10_code": "M25.511"}],
+                    "modifiers": ["25"],
+                }
+            ],
+        }
+    )
     result = view.post_enrich_charges()
 
     body = json.loads(result[0].content)  # JSONResponse first, then effects
@@ -182,12 +191,17 @@ def test_enrich_charges_accepts_charge_without_pointer(mock_build, mock_audit, m
     # Zero-pointer charges are advisory-only; the backend emits a clear effect
     # (no error) so sign is never blocked. Covers advisory-only new charges and
     # amendment unlink-all.
-    mock_build.return_value = ([], [{"command_uuid": "c1", "billing_line_item_id": "b1",
-                                     "assessment_ids": [], "modifiers": []}], [])
-    view = _post_instance({
-        "note_uuid": "note-1",
-        "charges": [{"command_uuid": "c1", "diagnosis_pointers": [], "modifiers": []}],
-    })
+    mock_build.return_value = (
+        [],
+        [{"command_uuid": "c1", "billing_line_item_id": "b1", "assessment_ids": [], "modifiers": []}],
+        [],
+    )
+    view = _post_instance(
+        {
+            "note_uuid": "note-1",
+            "charges": [{"command_uuid": "c1", "diagnosis_pointers": [], "modifiers": []}],
+        }
+    )
     result = view.post_enrich_charges()
     assert result[0].status_code == HTTPStatus.OK
     body = json.loads(result[0].content)
@@ -218,21 +232,23 @@ def test_enrich_charges_returns_200_with_partial_errors(mock_build, mock_audit, 
         [{"command_uuid": "ok", "billing_line_item_id": "b1", "assessment_ids": ["a1"], "modifiers": []}],
         [{"command_uuid": "bad", "reason": "billing_line_item_not_found"}],
     )
-    view = _post_instance({
-        "note_uuid": "note-1",
-        "charges": [
-            {
-                "command_uuid": "ok",
-                "diagnosis_pointers": [{"command_uuid": "d1", "icd10_code": "M25.511"}],
-                "modifiers": [],
-            },
-            {
-                "command_uuid": "bad",
-                "diagnosis_pointers": [{"command_uuid": "d2", "icd10_code": "K21.9"}],
-                "modifiers": [],
-            },
-        ],
-    })
+    view = _post_instance(
+        {
+            "note_uuid": "note-1",
+            "charges": [
+                {
+                    "command_uuid": "ok",
+                    "diagnosis_pointers": [{"command_uuid": "d1", "icd10_code": "M25.511"}],
+                    "modifiers": [],
+                },
+                {
+                    "command_uuid": "bad",
+                    "diagnosis_pointers": [{"command_uuid": "d2", "icd10_code": "K21.9"}],
+                    "modifiers": [],
+                },
+            ],
+        }
+    )
     result = view.post_enrich_charges()
     assert result[0].status_code == HTTPStatus.OK
     body = json.loads(result[0].content)

--- a/tests/hyperscribe/scribe/charges/test_enrichment.py
+++ b/tests/hyperscribe/scribe/charges/test_enrichment.py
@@ -22,9 +22,7 @@ def test_normalize_icd10_strips_dots_and_uppercases():
 
 def _assessment(assessment_id, codes):
     """A fake Assessment whose condition has the given coding codes."""
-    condition = SimpleNamespace(
-        codings=SimpleNamespace(all=lambda: [SimpleNamespace(code=c) for c in codes])
-    )
+    condition = SimpleNamespace(codings=SimpleNamespace(all=lambda: [SimpleNamespace(code=c) for c in codes]))
     return SimpleNamespace(id=assessment_id, condition=condition)
 
 
@@ -42,9 +40,7 @@ def test_build_assessment_index_maps_normalized_code_to_ids(mock_assessment):
 
     assert index["M25511"] == ["aid-1"]
     assert index["K219"] == ["aid-2"]
-    mock_assessment.objects.filter.assert_called_once_with(
-        note=note, entered_in_error_id__isnull=True, deleted=False
-    )
+    mock_assessment.objects.filter.assert_called_once_with(note=note, entered_in_error_id__isnull=True, deleted=False)
 
 
 @patch("hyperscribe.scribe.charges.enrichment.Assessment")
@@ -89,6 +85,7 @@ def test_update_effect_built_for_charge_with_pointer_and_modifier(
     mock_note, mock_index, mock_command, mock_bli, mock_update
 ):
     from canvas_sdk.v1.data.billing import BillingLineItemStatus
+
     _patch_note(mock_note)
     mock_index.return_value = {"M25511": ["aid-1"]}
     mock_command.objects.get.return_value = SimpleNamespace(dbid=42)
@@ -98,24 +95,28 @@ def test_update_effect_built_for_charge_with_pointer_and_modifier(
     mock_bli.objects.filter.return_value = bli_qs
     mock_update.return_value = SimpleNamespace(apply=lambda: "UPDATE_EFFECT")
 
-    charges = [{
-        "command_uuid": VALID_UUID,
-        "diagnosis_pointers": [{"command_uuid": "d0", "icd10_code": "M25.511"}],
-        "modifiers": ["25"],
-    }]
+    charges = [
+        {
+            "command_uuid": VALID_UUID,
+            "diagnosis_pointers": [{"command_uuid": "d0", "icd10_code": "M25.511"}],
+            "modifiers": ["25"],
+        }
+    ]
     effects, enriched, errors = build_charge_enrichment_effects(charges, [], "note-uuid")
 
     assert effects == ["UPDATE_EFFECT"]
     assert errors == []
-    assert enriched == [{"command_uuid": VALID_UUID, "billing_line_item_id": "bli-1",
-                         "assessment_ids": ["aid-1"], "modifiers": ["25"]}]
+    assert enriched == [
+        {"command_uuid": VALID_UUID, "billing_line_item_id": "bli-1", "assessment_ids": ["aid-1"], "modifiers": ["25"]}
+    ]
     mock_update.assert_called_once_with(
         billing_line_item_id="bli-1",
         assessment_ids=["aid-1"],
         modifiers=[{"code": "25", "system": CPT_MODIFIER_SYSTEM}],
     )
     mock_bli.objects.filter.assert_called_once_with(
-        note=mock_note.objects.get.return_value, command_id=42,
+        note=mock_note.objects.get.return_value,
+        command_id=42,
         status=BillingLineItemStatus.ACTIVE,
     )
 
@@ -125,9 +126,7 @@ def test_update_effect_built_for_charge_with_pointer_and_modifier(
 @patch("hyperscribe.scribe.charges.enrichment.Command")
 @patch("hyperscribe.scribe.charges.enrichment.build_assessment_index")
 @patch("hyperscribe.scribe.charges.enrichment.Note")
-def test_missing_bli_records_error_and_no_effect(
-    mock_note, mock_index, mock_command, mock_bli, mock_update
-):
+def test_missing_bli_records_error_and_no_effect(mock_note, mock_index, mock_command, mock_bli, mock_update):
     _patch_note(mock_note)
     mock_index.return_value = {"M25511": ["aid-1"]}
     mock_command.objects.get.return_value = SimpleNamespace(dbid=42)
@@ -135,11 +134,13 @@ def test_missing_bli_records_error_and_no_effect(
     bli_qs.first.return_value = None
     mock_bli.objects.filter.return_value = bli_qs
 
-    charges = [{
-        "command_uuid": VALID_UUID,
-        "diagnosis_pointers": [{"command_uuid": "d0", "icd10_code": "M25.511"}],
-        "modifiers": [],
-    }]
+    charges = [
+        {
+            "command_uuid": VALID_UUID,
+            "diagnosis_pointers": [{"command_uuid": "d0", "icd10_code": "M25.511"}],
+            "modifiers": [],
+        }
+    ]
     effects, enriched, errors = build_charge_enrichment_effects(charges, [], "note-uuid")
 
     assert effects == []
@@ -153,9 +154,7 @@ def test_missing_bli_records_error_and_no_effect(
 @patch("hyperscribe.scribe.charges.enrichment.Command")
 @patch("hyperscribe.scribe.charges.enrichment.build_assessment_index")
 @patch("hyperscribe.scribe.charges.enrichment.Note")
-def test_removed_charge_emits_remove_effect(
-    mock_note, mock_index, mock_command, mock_bli, mock_remove
-):
+def test_removed_charge_emits_remove_effect(mock_note, mock_index, mock_command, mock_bli, mock_remove):
     _patch_note(mock_note)
     mock_index.return_value = {}
     mock_command.objects.get.return_value = SimpleNamespace(dbid=99)
@@ -188,19 +187,19 @@ def test_unknown_note_returns_error(mock_note):
 @patch("hyperscribe.scribe.charges.enrichment.Command")
 @patch("hyperscribe.scribe.charges.enrichment.build_assessment_index")
 @patch("hyperscribe.scribe.charges.enrichment.Note")
-def test_unresolvable_command_uuid_records_error(
-    mock_note, mock_index, mock_command, mock_bli, mock_update
-):
+def test_unresolvable_command_uuid_records_error(mock_note, mock_index, mock_command, mock_bli, mock_update):
     _patch_note(mock_note)
     mock_index.return_value = {"M25511": ["aid-1"]}
     mock_command.DoesNotExist = Exception
     mock_command.objects.get.side_effect = mock_command.DoesNotExist
 
-    charges = [{
-        "command_uuid": VALID_UUID,
-        "diagnosis_pointers": [{"command_uuid": "d0", "icd10_code": "M25.511"}],
-        "modifiers": [],
-    }]
+    charges = [
+        {
+            "command_uuid": VALID_UUID,
+            "diagnosis_pointers": [{"command_uuid": "d0", "icd10_code": "M25.511"}],
+            "modifiers": [],
+        }
+    ]
     effects, enriched, errors = build_charge_enrichment_effects(charges, [], "note-uuid")
     assert effects == []
     assert errors == [{"command_uuid": VALID_UUID, "reason": "billing_line_item_not_found"}]
@@ -212,9 +211,7 @@ def test_unresolvable_command_uuid_records_error(
 @patch("hyperscribe.scribe.charges.enrichment.Command")
 @patch("hyperscribe.scribe.charges.enrichment.build_assessment_index")
 @patch("hyperscribe.scribe.charges.enrichment.Note")
-def test_empty_pointers_clears_bli_without_error(
-    mock_note, mock_index, mock_command, mock_bli, mock_update
-):
+def test_empty_pointers_clears_bli_without_error(mock_note, mock_index, mock_command, mock_bli, mock_update):
     """When diagnosis_pointers is empty the backend emits an explicit
     UpdateBillingLineItem(assessment_ids=[]) clear — covers advisory-only new
     charges (no-op, BLI was already empty) and amendment unlink-all (clears old
@@ -256,11 +253,13 @@ def test_pointer_not_in_index_reports_error_and_does_not_clear(
     bli_qs.first.return_value = bli
     mock_bli.objects.filter.return_value = bli_qs
 
-    charges = [{
-        "command_uuid": VALID_UUID,
-        "diagnosis_pointers": [{"command_uuid": "d0", "icd10_code": "Z00.00"}],
-        "modifiers": [],
-    }]
+    charges = [
+        {
+            "command_uuid": VALID_UUID,
+            "diagnosis_pointers": [{"command_uuid": "d0", "icd10_code": "Z00.00"}],
+            "modifiers": [],
+        }
+    ]
     effects, enriched, errors = build_charge_enrichment_effects(charges, [], "note-uuid")
 
     assert effects == []
@@ -290,14 +289,16 @@ def test_partial_pointer_resolution_reports_error_and_does_not_write(
     bli_qs.first.return_value = bli
     mock_bli.objects.filter.return_value = bli_qs
 
-    charges = [{
-        "command_uuid": VALID_UUID,
-        "diagnosis_pointers": [
-            {"command_uuid": "d0", "icd10_code": "M25.511"},
-            {"command_uuid": "d1", "icd10_code": "E11.9"},
-        ],
-        "modifiers": [],
-    }]
+    charges = [
+        {
+            "command_uuid": VALID_UUID,
+            "diagnosis_pointers": [
+                {"command_uuid": "d0", "icd10_code": "M25.511"},
+                {"command_uuid": "d1", "icd10_code": "E11.9"},
+            ],
+            "modifiers": [],
+        }
+    ]
     effects, enriched, errors = build_charge_enrichment_effects(charges, [], "note-uuid")
 
     assert effects == []
@@ -311,9 +312,7 @@ def test_partial_pointer_resolution_reports_error_and_does_not_write(
 @patch("hyperscribe.scribe.charges.enrichment.Command")
 @patch("hyperscribe.scribe.charges.enrichment.build_assessment_index")
 @patch("hyperscribe.scribe.charges.enrichment.Note")
-def test_all_pointers_resolve_writes_full_set(
-    mock_note, mock_index, mock_command, mock_bli, mock_update
-):
+def test_all_pointers_resolve_writes_full_set(mock_note, mock_index, mock_command, mock_bli, mock_update):
     """When EVERY sent code resolves, the full assessment_ids set is written and
     no error is recorded (guards against the partial-resolution check over-firing
     on a fully-resolvable multi-pointer charge)."""
@@ -326,14 +325,16 @@ def test_all_pointers_resolve_writes_full_set(
     mock_bli.objects.filter.return_value = bli_qs
     mock_update.return_value = SimpleNamespace(apply=lambda: "UPDATE_EFFECT")
 
-    charges = [{
-        "command_uuid": VALID_UUID,
-        "diagnosis_pointers": [
-            {"command_uuid": "d0", "icd10_code": "M25.511"},
-            {"command_uuid": "d1", "icd10_code": "E11.9"},
-        ],
-        "modifiers": [],
-    }]
+    charges = [
+        {
+            "command_uuid": VALID_UUID,
+            "diagnosis_pointers": [
+                {"command_uuid": "d0", "icd10_code": "M25.511"},
+                {"command_uuid": "d1", "icd10_code": "E11.9"},
+            ],
+            "modifiers": [],
+        }
+    ]
     effects, enriched, errors = build_charge_enrichment_effects(charges, [], "note-uuid")
 
     assert errors == []
@@ -357,8 +358,10 @@ def test_multiple_charges_accumulate_enriched_and_errors_independently(
     mock_index.return_value = {"M25511": ["aid-1"]}
     mock_command.objects.get.return_value = SimpleNamespace(dbid=42)
     # first charge's BLI is found; second charge's BLI is missing
-    found_qs = MagicMock(); found_qs.first.return_value = SimpleNamespace(id="bli-1")
-    missing_qs = MagicMock(); missing_qs.first.return_value = None
+    found_qs = MagicMock()
+    found_qs.first.return_value = SimpleNamespace(id="bli-1")
+    missing_qs = MagicMock()
+    missing_qs.first.return_value = None
     mock_bli.objects.filter.side_effect = [found_qs, missing_qs]
     mock_update.return_value = SimpleNamespace(apply=lambda: "UPDATE_EFFECT")
 
@@ -400,7 +403,7 @@ def test_find_billing_line_item_fallback_ambiguous_cpt_returns_none(mock_command
     primary_qs.first.return_value = None  # command_id lookup misses
 
     fallback_qs = MagicMock()
-    fallback_qs.count.return_value = 2   # two BLIs share this CPT
+    fallback_qs.count.return_value = 2  # two BLIs share this CPT
 
     mock_bli.objects.filter.side_effect = [primary_qs, fallback_qs]
 
@@ -408,9 +411,7 @@ def test_find_billing_line_item_fallback_ambiguous_cpt_returns_none(mock_command
 
     assert result is None
     fallback_qs.first.assert_not_called()  # must not pick blindly
-    mock_bli.objects.filter.assert_any_call(
-        note=note, cpt="99213", status=BillingLineItemStatus.ACTIVE
-    )
+    mock_bli.objects.filter.assert_any_call(note=note, cpt="99213", status=BillingLineItemStatus.ACTIVE)
 
 
 @patch("hyperscribe.scribe.charges.enrichment.BillingLineItem")
@@ -418,7 +419,6 @@ def test_find_billing_line_item_fallback_ambiguous_cpt_returns_none(mock_command
 def test_find_billing_line_item_fallback_unambiguous_cpt_returns_bli(mock_command, mock_bli):
     """When the primary command_id lookup misses but exactly one ACTIVE BLI
     shares the CPT, the fallback may safely call .first() and return it."""
-    from canvas_sdk.v1.data.billing import BillingLineItemStatus
 
     note = SimpleNamespace(dbid=1)
     expected_bli = SimpleNamespace(id="bli-1")
@@ -470,14 +470,13 @@ def test_resolve_assessment_ids_deduplicates_across_pointers():
 
 # ── Coverage gap: idempotent removal path (BLI already absent) ──
 
+
 @patch("hyperscribe.scribe.charges.enrichment.RemoveBillingLineItem")
 @patch("hyperscribe.scribe.charges.enrichment.BillingLineItem")
 @patch("hyperscribe.scribe.charges.enrichment.Command")
 @patch("hyperscribe.scribe.charges.enrichment.build_assessment_index")
 @patch("hyperscribe.scribe.charges.enrichment.Note")
-def test_removed_charge_already_absent_is_silently_skipped(
-    mock_note, mock_index, mock_command, mock_bli, mock_remove
-):
+def test_removed_charge_already_absent_is_silently_skipped(mock_note, mock_index, mock_command, mock_bli, mock_remove):
     """When the BLI for a removed command can't be found, no error is recorded
     and no RemoveBillingLineItem effect is emitted (idempotent removal)."""
     _patch_note(mock_note)

--- a/tests/hyperscribe/scribe/clients/nabla/test_backend.py
+++ b/tests/hyperscribe/scribe/clients/nabla/test_backend.py
@@ -209,7 +209,7 @@ def test_generate_note_family_history_instruction() -> None:
     assert "biological relatives" in instruction
     assert "omit rather than guess" in instruction
     # No-filler guardrail, quoted example phrasing preserved.
-    assert 'no other family history discussed.' in instruction
+    assert "no other family history discussed." in instruction
     assert "if none is discussed, leave empty" in lower
 
 


### PR DESCRIPTION
## Summary

In Scribe **Manual mode**, the vitals card was pre-populated automatically when the mode started. Because the card had no data, `VitalsRow` immediately opened its editor, which registered as an unsaved edit and **blocked commit/finalize** until the user saved or cancelled it — unnecessary friction when no vitals are being recorded.

This removes the auto-created vitals command from `handleStartManual`. Vitals is now added **on demand** via the existing **"+ Vitals"** button, matching how every other objective card works. The "Vitals" section header and its "+ Vitals" affordance remain visible (via `ENSURE_KEYS`), so the on-demand path is always available.

## Change

- `hyperscribe/scribe/static/summary.js`: drop the `vitals` entry from the `manualCommands` array in `handleStartManual`. The narrative commands (rfv, hpi, plan) and PE-from-template logic are unchanged.

This is the only functional change.

## Additional (non-functional) changes

This PR also includes auto-formatter reflow in the following files. These are **purely formatting** (line re-wrapping at a wider line length, and one escaped-quote → single-quote string-style swap) — verified behavior-identical with a whitespace-insensitive diff, and unrelated to KOALA-5802:

- `hyperscribe/scribe/charges/enrichment.py`
- `hyperscribe/scribe/clients/nabla/backend.py`
- `tests/hyperscribe/scribe/api/test_session_view_charges.py`
- `tests/hyperscribe/scribe/charges/test_enrichment.py`
- `tests/hyperscribe/scribe/clients/nabla/test_backend.py`

## Scope

- **Manual-mode only.** AI mode never auto-created vitals (`handleStartAi` creates no default commands), so it is untouched.
- Auto-open-on-add behavior in `VitalsRow` is intentionally unchanged — it's the correct on-demand behavior when the user clicks "+ Vitals".

## Testing

Deployed to `scribeqa-playground` and verified the plugin loads cleanly (21/21 handlers, no errors). Manual UAT:
- Manual mode → no vitals card present; commit/finalize not blocked by an unsaved vitals edit.
- "+ Vitals" → card appears and opens for entry on demand.
- AI mode → unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
