### PR TITLE
feat: block note lock until Scribe tab is finalized (KOALA-5622)

### DIFF
--- a/hyperscribe/CANVAS_MANIFEST.json
+++ b/hyperscribe/CANVAS_MANIFEST.json
@@ -174,6 +174,15 @@
         }
       },
       {
+        "class": "hyperscribe.scribe.handlers.note_lock_guard:NoteLockGuard",
+        "description": "Block locking a Scribe-documented note until the Scribe tab is finalized",
+        "data_access": {
+          "event": "NOTE_STATE_CHANGE_EVENT_PRE_CREATE",
+          "read": [],
+          "write": []
+        }
+      },
+      {
         "class": "hyperscribe.scribe.print.button:PrintScribeNoteButton",
         "description": "Note header dropdown button that launches a print preview of the scribe summary",
         "data_access": {

--- a/hyperscribe/scribe/handlers/note_lock_guard.py
+++ b/hyperscribe/scribe/handlers/note_lock_guard.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+from canvas_sdk.effects import Effect
+from canvas_sdk.effects.validation import EventValidationError, ValidationError
+from canvas_sdk.events import EventType
+from canvas_sdk.handlers.base import BaseHandler
+from canvas_sdk.v1.data.note import Note
+
+from hyperscribe.libraries.constants import Constants
+from hyperscribe.models.scribe import ScribeSummary, ScribeTranscript
+
+# Mirrors session_view.FROM_THE_NOTE_SECTION / scribe_data.FROM_THE_NOTE_SECTION.
+# Commands carrying this section_key are reflections of commands the provider
+# added directly to the note body (the "Additional Commands" rail), not Scribe
+# work product, so they do not count as Scribe usage for the lock gate.
+_FROM_THE_NOTE_SECTION = "from_the_note"
+
+
+def _scribe_pending_finalization(note_dbid: int) -> bool:
+    """Return True when Scribe was meaningfully used on this note but is not finalized.
+
+    "Finalized" is ``ScribeSummary.approved`` (the frontend's own definition:
+    ``amending = wasFinalized && !approved``). The flag is persisted to the DB in
+    real time via ``/save-summary``, so reading it here reflects both first-time
+    generation (never approved) and amendment-in-progress (approved reset to False).
+
+    Synced note-body commands (``section_key == "from_the_note"``) do NOT count as
+    Scribe usage.
+    """
+    summary = ScribeSummary.objects.filter(note_id=note_dbid).values("commands", "note_data", "approved").first()
+    if summary and summary["approved"]:
+        return False  # finalized -> allow lock
+
+    # A recording transcript is meaningful Scribe usage.
+    if ScribeTranscript.objects.filter(note_id=note_dbid).values_list("items", flat=True).first():
+        return True
+
+    if not summary:
+        return False  # no Scribe content at all -> gate ignored
+
+    real_commands = [
+        command
+        for command in (summary["commands"] or [])
+        if (command or {}).get("section_key") != _FROM_THE_NOTE_SECTION
+    ]
+    if real_commands:
+        return True
+
+    sections = (summary.get("note_data") or {}).get("sections") or []
+    return any((section.get("text") or "").strip() for section in sections)
+
+
+class NoteLockGuard(BaseHandler):
+    """Blocks locking a note documented with Scribe until the Scribe tab is finalized."""
+
+    RESPONDS_TO = [EventType.Name(EventType.NOTE_STATE_CHANGE_EVENT_PRE_CREATE)]
+
+    def compute(self) -> list[Effect]:
+        # Only gate the Lock/Sign transition; pushing charges (PSH) is not gated.
+        if self.event.context.get("state") != "LKD":
+            return []
+
+        note_uuid = self.event.context.get("note_id")
+        note_dbid = Note.objects.filter(id=note_uuid).values_list("dbid", flat=True).first()
+        if not note_dbid:
+            return []
+
+        if not _scribe_pending_finalization(note_dbid):
+            return []
+
+        tab_name = self.secrets.get(Constants.SECRET_SCRIBE_TAB_NAME) or "Scribe"
+        return [
+            EventValidationError(
+                errors=[
+                    ValidationError(
+                        message=(
+                            f"This note can't be signed until the {tab_name} tab is finalized. "
+                            f"Open {tab_name}, review the summary, and click Approve."
+                        )
+                    )
+                ]
+            ).apply()
+        ]

--- a/tests/hyperscribe/scribe/handlers/test_note_lock_guard.py
+++ b/tests/hyperscribe/scribe/handlers/test_note_lock_guard.py
@@ -1,0 +1,185 @@
+import json
+from unittest.mock import MagicMock, patch
+
+from canvas_sdk.events import Event, EventType
+from canvas_sdk.handlers.base import BaseHandler
+from canvas_generated.messages.events_pb2 import Event as EventRequest
+
+from hyperscribe.scribe.handlers.note_lock_guard import NoteLockGuard, _scribe_pending_finalization
+
+MODULE = "hyperscribe.scribe.handlers.note_lock_guard"
+
+
+def _make_event(state: str = "LKD", note_id: str = "note-uuid") -> Event:
+    return Event(EventRequest(context=json.dumps({"state": state, "note_id": note_id})))
+
+
+def _configure_models(
+    mock_note: MagicMock,
+    mock_summary: MagicMock,
+    mock_transcript: MagicMock,
+    *,
+    note_dbid: int | None = 42,
+    summary: dict | None = None,
+    transcript_items: list | None = None,
+) -> None:
+    mock_note.objects.filter.return_value.values_list.return_value.first.return_value = note_dbid
+    mock_summary.objects.filter.return_value.values.return_value.first.return_value = summary
+    mock_transcript.objects.filter.return_value.values_list.return_value.first.return_value = transcript_items
+
+
+def test_class() -> None:
+    assert issubclass(NoteLockGuard, BaseHandler)
+
+
+def test_responds_to_pre_create() -> None:
+    assert NoteLockGuard.RESPONDS_TO == [EventType.Name(EventType.NOTE_STATE_CHANGE_EVENT_PRE_CREATE)]
+
+
+# --- compute: state filtering ---
+
+
+@patch(f"{MODULE}.ScribeTranscript")
+@patch(f"{MODULE}.ScribeSummary")
+@patch(f"{MODULE}.Note")
+def test_non_lock_state_is_ignored(mock_note: MagicMock, mock_summary: MagicMock, mock_transcript: MagicMock) -> None:
+    for state in ("PSH", "ULK", "NEW", "DLT"):
+        tested = NoteLockGuard(_make_event(state=state), {})
+        assert tested.compute() == []
+    # Never touched the models when the state is not a lock.
+    mock_note.objects.filter.assert_not_called()
+
+
+@patch(f"{MODULE}.ScribeTranscript")
+@patch(f"{MODULE}.ScribeSummary")
+@patch(f"{MODULE}.Note")
+def test_note_not_found_is_ignored(mock_note: MagicMock, mock_summary: MagicMock, mock_transcript: MagicMock) -> None:
+    _configure_models(mock_note, mock_summary, mock_transcript, note_dbid=None)
+    tested = NoteLockGuard(_make_event(), {})
+    assert tested.compute() == []
+
+
+# --- compute: gate decisions ---
+
+
+@patch(f"{MODULE}.ScribeTranscript")
+@patch(f"{MODULE}.ScribeSummary")
+@patch(f"{MODULE}.Note")
+def test_never_used_allows_lock(mock_note: MagicMock, mock_summary: MagicMock, mock_transcript: MagicMock) -> None:
+    _configure_models(mock_note, mock_summary, mock_transcript, summary=None, transcript_items=None)
+    tested = NoteLockGuard(_make_event(), {})
+    assert tested.compute() == []
+
+
+@patch(f"{MODULE}.ScribeTranscript")
+@patch(f"{MODULE}.ScribeSummary")
+@patch(f"{MODULE}.Note")
+def test_approved_summary_allows_lock(
+    mock_note: MagicMock, mock_summary: MagicMock, mock_transcript: MagicMock
+) -> None:
+    # Approved short-circuits even with a recording present.
+    _configure_models(
+        mock_note,
+        mock_summary,
+        mock_transcript,
+        summary={"approved": True, "commands": [], "note_data": {}},
+        transcript_items=[{"text": "hi"}],
+    )
+    tested = NoteLockGuard(_make_event(), {})
+    assert tested.compute() == []
+
+
+@patch(f"{MODULE}.ScribeTranscript")
+@patch(f"{MODULE}.ScribeSummary")
+@patch(f"{MODULE}.Note")
+def test_pending_summary_blocks_lock(mock_note: MagicMock, mock_summary: MagicMock, mock_transcript: MagicMock) -> None:
+    _configure_models(
+        mock_note,
+        mock_summary,
+        mock_transcript,
+        summary={"approved": False, "commands": [{"section_key": "history_of_present_illness"}], "note_data": {}},
+        transcript_items=None,
+    )
+    tested = NoteLockGuard(_make_event(), {})
+    result = tested.compute()
+    assert len(result) == 1
+    payload = json.loads(result[0].payload)
+    assert "click Approve" in payload["data"]["errors"][0]["message"]
+
+
+@patch(f"{MODULE}.ScribeTranscript")
+@patch(f"{MODULE}.ScribeSummary")
+@patch(f"{MODULE}.Note")
+def test_block_message_uses_tab_name_secret(
+    mock_note: MagicMock, mock_summary: MagicMock, mock_transcript: MagicMock
+) -> None:
+    _configure_models(
+        mock_note,
+        mock_summary,
+        mock_transcript,
+        summary={"approved": False, "commands": [{"section_key": "physical_exam"}], "note_data": {}},
+    )
+    tested = NoteLockGuard(_make_event(), {"ScribeTabName": "Copilot"})
+    result = tested.compute()
+    message = json.loads(result[0].payload)["data"]["errors"][0]["message"]
+    assert "Copilot" in message
+    assert "Scribe." not in message
+
+
+# --- _scribe_pending_finalization predicate ---
+
+
+@patch(f"{MODULE}.ScribeTranscript")
+@patch(f"{MODULE}.ScribeSummary")
+def test_predicate_from_the_note_only_is_not_usage(mock_summary: MagicMock, mock_transcript: MagicMock) -> None:
+    mock_summary.objects.filter.return_value.values.return_value.first.return_value = {
+        "approved": False,
+        "commands": [{"section_key": "from_the_note"}, {"section_key": "from_the_note"}],
+        "note_data": {},
+    }
+    mock_transcript.objects.filter.return_value.values_list.return_value.first.return_value = None
+    assert _scribe_pending_finalization(42) is False
+
+
+@patch(f"{MODULE}.ScribeTranscript")
+@patch(f"{MODULE}.ScribeSummary")
+def test_predicate_real_command_is_usage(mock_summary: MagicMock, mock_transcript: MagicMock) -> None:
+    mock_summary.objects.filter.return_value.values.return_value.first.return_value = {
+        "approved": False,
+        "commands": [{"section_key": "from_the_note"}, {"section_key": "assess"}],
+        "note_data": {},
+    }
+    mock_transcript.objects.filter.return_value.values_list.return_value.first.return_value = None
+    assert _scribe_pending_finalization(42) is True
+
+
+@patch(f"{MODULE}.ScribeTranscript")
+@patch(f"{MODULE}.ScribeSummary")
+def test_predicate_note_section_text_is_usage(mock_summary: MagicMock, mock_transcript: MagicMock) -> None:
+    mock_summary.objects.filter.return_value.values.return_value.first.return_value = {
+        "approved": False,
+        "commands": [],
+        "note_data": {"sections": [{"text": "  patient reports..."}]},
+    }
+    mock_transcript.objects.filter.return_value.values_list.return_value.first.return_value = None
+    assert _scribe_pending_finalization(42) is True
+
+
+@patch(f"{MODULE}.ScribeTranscript")
+@patch(f"{MODULE}.ScribeSummary")
+def test_predicate_blank_section_text_is_not_usage(mock_summary: MagicMock, mock_transcript: MagicMock) -> None:
+    mock_summary.objects.filter.return_value.values.return_value.first.return_value = {
+        "approved": False,
+        "commands": [],
+        "note_data": {"sections": [{"text": "   \n  "}]},
+    }
+    mock_transcript.objects.filter.return_value.values_list.return_value.first.return_value = None
+    assert _scribe_pending_finalization(42) is False
+
+
+@patch(f"{MODULE}.ScribeTranscript")
+@patch(f"{MODULE}.ScribeSummary")
+def test_predicate_recording_without_summary_is_usage(mock_summary: MagicMock, mock_transcript: MagicMock) -> None:
+    mock_summary.objects.filter.return_value.values.return_value.first.return_value = None
+    mock_transcript.objects.filter.return_value.values_list.return_value.first.return_value = [{"text": "hi"}]
+    assert _scribe_pending_finalization(42) is True


### PR DESCRIPTION
## Summary

Prevents a provider from signing/locking a note that was documented with Scribe while the Scribe tab is still **un-finalized** — either before the AI summary is approved, or after an amendment has been started but not re-approved. Notes that never used Scribe are unaffected.

## How it works

- New handler `NoteLockGuard` (`hyperscribe/scribe/handlers/note_lock_guard.py`) responds to `NOTE_STATE_CHANGE_EVENT_PRE_CREATE` and returns an `EventValidationError` to abort the lock (message surfaced in the UI).
- "Finalized" maps to **`ScribeSummary.approved`** — the frontend's own definition (`amending = wasFinalized && !approved`), persisted to the DB in real time via `/save-summary`. So the gate reads current state without diffing anything:
  - First-time draft not yet approved → **block**
  - Amendment started, not re-approved (`approved` reset to `false`) → **block**
  - Recording made, never generated/approved → **block**
  - Approved (finalized / re-finalized) → **allow**
- "Scribe was used" excludes commands synced from the note body (`section_key == "from_the_note"` / the Additional Commands rail) — those aren't Scribe work product.
- Only the Lock transition (`state == "LKD"`) is gated; push-charges (`PSH`) is not.

## Testing

- 13 new unit tests in `tests/hyperscribe/scribe/handlers/test_note_lock_guard.py` covering state filtering, the usage predicate (including `from_the_note` exclusion and blank-section handling), approved short-circuit, and the configurable tab-name message.
- Full unit suite green (`tests/`: 2561 passed); ruff + mypy clean.
- Verified live on a Canvas instance: handler fires on `NOTE_STATE_CHANGE_EVENT_PRE_CREATE` and blocks/allows as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)