### PR TITLE
Relocate Hide Rejected Recommendations toggle to top bar (KOALA-5807)

### DIFF
--- a/hyperscribe/scribe/static/styles.css
+++ b/hyperscribe/scribe/static/styles.css
@@ -478,8 +478,8 @@ h2 { margin-bottom: 4px; }
 }
 @keyframes approve-spin { to { transform: rotate(360deg); } }
 
-.hide-rejected-toggle { display: flex; justify-content: flex-end; padding: 8px 8px 0; }
 .hide-rejected-label { display: flex; align-items: center; gap: 8px; font-size: 13px; font-weight: 500; color: #6b7280; cursor: pointer; user-select: none; }
+.hide-rejected-label--top-bar { margin-left: auto; white-space: nowrap; }
 .toggle-switch { width: 36px; height: 20px; border-radius: 10px; background: #d1d5db; position: relative; transition: background 0.2s; flex-shrink: 0; }
 .toggle-switch.on { background: #16a34a; }
 .toggle-knob { width: 16px; height: 16px; border-radius: 50%; background: #fff; position: absolute; top: 2px; left: 2px; transition: left 0.2s; box-shadow: 0 1px 2px rgba(0,0,0,0.15); }

--- a/hyperscribe/scribe/static/summary.js
+++ b/hyperscribe/scribe/static/summary.js
@@ -2726,6 +2726,14 @@ export function Scribe({ noteId, patientId, staffId, staffName, providerName, pr
               Regenerate${!selectedTemplate ? ' (select visit type)' : ''}
             </button>
           `}
+          ${recommendations.length > 0 && html`
+            <label class="hide-rejected-label hide-rejected-label--top-bar" onClick=${() => setHideRejected(prev => !prev)}>
+              Hide Rejected Recommendations
+              <div class="toggle-switch${hideRejected ? ' on' : ''}">
+                <div class="toggle-knob" />
+              </div>
+            </label>
+          `}
         </div>
       `}
       ${(isRecording || recording.entries.length > 0) && html`
@@ -2825,16 +2833,6 @@ export function Scribe({ noteId, patientId, staffId, staffName, providerName, pr
         </div>
       `}
       ${error && html`<p class="error" style="padding: 0 16px;">${error}</p>`}
-      ${canEdit && recommendations.length > 0 && html`
-        <div class="hide-rejected-toggle">
-          <label class="hide-rejected-label" onClick=${() => setHideRejected(prev => !prev)}>
-            <div class="toggle-switch${hideRejected ? ' on' : ''}">
-              <div class="toggle-knob" />
-            </div>
-            Hide Rejected Recommendations
-          </label>
-        </div>
-      `}
       <div class=${`summary-body${inserting ? ' summary-body--inserting' : ''}`}>
         ${renderSoapGroups(effectiveSections, commandBySectionKey, handleEdit, handleDelete, {
           adHocCommands,


### PR DESCRIPTION
## Summary
Relocates the **Hide Rejected Recommendations** toggle from its standalone row (below the Transcript panel, above the SUBJECTIVE section) into the unified top bar, in line with the visit-type / template selector — matching the provided mockups.

## Changes
- **`summary.js`** — Moved the toggle markup into the `.unified-top-bar` row (already gated on `canEdit`); still renders only when `recommendations.length > 0`. Reordered the label so the text precedes the switch.
- **`styles.css`** — Removed the now-unused `.hide-rejected-toggle` wrapper rule; added a `.hide-rejected-label--top-bar` modifier (`margin-left: auto` to right-align, `white-space: nowrap`).

## Why low-risk
- No changes to toggle behavior, state (`hideRejected`/`setHideRejected`), or the filtering logic that consumes it.
- Reuses existing `.hide-rejected-label` / `.toggle-switch` / `.toggle-knob` styles.
- Side benefit: the top bar is `position: sticky`, so the toggle now stays visible while scrolling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)