### PR TITLE
Enable Anthropic prompt caching on system prompts

### DIFF
--- a/hyperscribe/llms/llm_anthropic.py
+++ b/hyperscribe/llms/llm_anthropic.py
@@ -18,7 +18,14 @@ class LlmAnthropic(LlmBase):
         roles = {self.ROLE_SYSTEM: "user", self.ROLE_USER: "user", self.ROLE_MODEL: "assistant"}
         for prompt in self.prompts:
             role = roles[prompt.role]
-            part = {"type": "text", "text": "\n".join(prompt.text)}
+            part: dict = {"type": "text", "text": "\n".join(prompt.text)}
+            # Cache the stable system instructions (Anthropic prompt caching) so the
+            # repeated stage calls within a session reuse the prefix instead of
+            # re-billing it on every audio cycle. The volatile transcript/data lives in
+            # the user prompt, which stays uncached. System prompts below the model's
+            # minimum cacheable size are silently left uncached, so this is a safe no-op.
+            if prompt.role == self.ROLE_SYSTEM:
+                part["cache_control"] = {"type": "ephemeral"}
             # contiguous parts for the same role are merged
             if messages and messages[-1]["role"] == role:
                 messages[-1]["content"].append(part)

--- a/tests/hyperscribe/llms/test_llm_anthropic.py
+++ b/tests/hyperscribe/llms/test_llm_anthropic.py
@@ -41,7 +41,7 @@ def test_to_dict():
             {
                 "role": "user",
                 "content": [
-                    {"type": "text", "text": "line 1\nline 2\nline 3"},
+                    {"type": "text", "text": "line 1\nline 2\nline 3", "cache_control": {"type": "ephemeral"}},
                     {"type": "text", "text": "line 4\nline 5\nline 6"},
                 ],
             },
@@ -62,7 +62,7 @@ def test_to_dict():
             {
                 "role": "user",
                 "content": [
-                    {"type": "text", "text": "line 1\nline 2\nline 3"},
+                    {"type": "text", "text": "line 1\nline 2\nline 3", "cache_control": {"type": "ephemeral"}},
                     {"type": "text", "text": "line 4\nline 5\nline 6"},
                 ],
             },

--- a/uv.lock
+++ b/uv.lock
@@ -2,6 +2,10 @@ version = 1
 revision = 3
 requires-python = ">=3.11, <3.13"
 
+[options]
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer-span = "P7D"
+
 [[package]]
 name = "annotated-types"
 version = "0.7.0"


### PR DESCRIPTION
Marks the system-prompt content block in `LlmAnthropic.to_dict()` with `cache_control: {"type": "ephemeral"}` so Anthropic prompt caching kicks in.

Why this helps here: each scribe stage (transcript segmentation, instruction identification, parameter extraction, per-command selection) sets a large, stable system prompt and a volatile `user` prompt that carries the transcript/data. Those stage system prompts are re-sent on every audio cycle within a session, so the same prefix is billed over and over. Caching the system block lets repeated cycles read the cached prefix (~0.1x cost) instead of reprocessing it at full price, while the per-cycle transcript stays in the user prompt and remains uncached.

The breakpoint sits on the system block only. Caching is a prefix match, so everything up to and including that block is cached and the trailing user content is not — exactly the stable-prefix / varying-suffix split.

The default text model is Sonnet 4.5 (`ANTHROPIC_CHAT_TEXT`), whose minimum cacheable prefix is ~1024 tokens. The high-frequency stage system prompts clear that comfortably. The small per-command system prompts (e.g. allergy selection) fall below the minimum and are silently left uncached by the API — no write, no cost, so adding the marker unconditionally is a safe no-op there rather than something to gate on.

One accounting note for reviewers: once caching is live, the Anthropic `usage` splits into `input_tokens` (uncached remainder), `cache_creation_input_tokens`, and `cache_read_input_tokens`. `LlmAnthropic.request()` records only `input_tokens` as the prompt count, so the logged prompt-token total will drop for cached calls (it will no longer include the cached prefix). That is expected and roughly tracks billed cost, but if anyone relies on that number as a true total-prompt-size metric, it would need to sum the three fields. Left as-is here to keep the change scoped to caching.

Tests: `to_dict` expectations updated; `tests/hyperscribe/llms/test_llm_anthropic.py` passes. ruff + mypy clean.

(Authored by Claude together with Beau.)