### PR TITLE
feat: add comments to charges + charge-matrix UX polish

### DIFF
--- a/hyperscribe/scribe/static/charge-matrix.js
+++ b/hyperscribe/scribe/static/charge-matrix.js
@@ -6,6 +6,10 @@ const html = htm.bind(h);
 
 export const MAX_POINTERS = 4;
 export const MAX_MODIFIERS = 4;
+// Soft cap on a charge comment — warns past it, never blocks typing/saving.
+// The underlying perform.notes field is an unconstrained string; this is a UX
+// guideline so the popover stays sane, not a hard limit.
+export const MAX_COMMENT = 500;
 
 // Common modifiers seeded into the picker. code -> description.
 export const MODIFIER_SEED = [
@@ -56,6 +60,26 @@ export function ModifierPicker({ selected, onToggle, onClose }) {
           <span class="cm-popover-code">${freeCode}</span>
           <span class="cm-popover-desc">Use code "${freeCode}"</span>
         </button>` : null}
+      </div>
+    </div>`;
+}
+
+// Free-text comment editor for a charge — the saved text lands as the perform
+// command's `notes`. Soft cap (warns past MAX_COMMENT, never blocks). Save with
+// empty text clears the comment (handled by the caller).
+export function CommentEditor({ value, onSave, onCancel }) {
+  const [text, setText] = useState(value || '');
+  const over = text.length > MAX_COMMENT;
+  return html`
+    <div class="cm-popover cm-popover-comment" role="dialog">
+      <textarea class="cm-comment-ta" autofocus placeholder="Add a comment for this charge…"
+        value=${text} onInput=${e => setText(e.target.value)}></textarea>
+      <div class="cm-comment-foot">
+        <span class="cm-comment-count${over ? ' over' : ''}">${text.length} / ${MAX_COMMENT}</span>
+        <div class="cm-comment-actions">
+          <button class="cm-comment-btn cm-comment-btn-ghost" onClick=${onCancel}>Cancel</button>
+          <button class="cm-comment-btn cm-comment-btn-primary" onClick=${() => onSave(text.trim())}>Save</button>
+        </div>
       </div>
     </div>`;
 }
@@ -111,9 +135,11 @@ export function ChargeMatrix({
   diagnoses, charges, isAmending, readOnly, searchCharges, suggested,
   onTogglePointer, onReorderDiagnoses,
   onAddModifier, onRemoveModifier, onAddCharge, onRemoveCharge,
+  onSetComment, onClearComment,
 }) {
-  // Single popover state so only one (modifier or charge-search) is ever open.
-  // { kind: 'mod', id: <charge uuid> } | { kind: 'charge' } | null
+  // Single popover state so only one popover is ever open.
+  // { kind: 'mod', id } | { kind: 'commentEdit', id } | { kind: 'commentRead', id }
+  // | { kind: 'charge' } | null
   const [popover, setPopover] = useState(null);
 
   // Close the open popover (modifier picker / CPT search) on an outside click
@@ -123,7 +149,8 @@ export function ChargeMatrix({
     if (!popover) return undefined;
     const onPointerDown = (e) => {
       const t = e.target;
-      if (t && t.closest && (t.closest('.cm-popover') || t.closest('.cm-modadd') || t.closest('.cm-add-btn'))) return;
+      if (t && t.closest && (t.closest('.cm-popover') || t.closest('.cm-modadd') || t.closest('.cm-add-btn')
+          || t.closest('.cm-noteadd') || t.closest('.cm-notechip'))) return;
       setPopover(null);
     };
     const onKeyDown = (e) => { if (e.key === 'Escape') setPopover(null); };
@@ -142,6 +169,10 @@ export function ChargeMatrix({
   const suggestedAvailable = (suggested || []).filter(s => !existingCpts.has(s.cpt_code));
   const lockedCount = isAmending ? dxs.filter(d => d.locked).length : 0;
   const colSpan = chs.length + 2; // diagnosis col + charge cols + add col
+  // Diagnoses present but no charges yet (and the note is editable): show a
+  // ghost charge column nudging the provider to add a charge to bill the visit.
+  // It replaces the orphaned "+" add column 1-for-1, so colSpan is unchanged.
+  const showGhostCharge = !readOnly && chs.length === 0 && dxs.length > 0;
 
   function handleDrop(e, targetIdx) {
     e.preventDefault();
@@ -164,6 +195,14 @@ export function ChargeMatrix({
   const headerCells = chs.map(charge => {
     const mods = charge.modifiers || [];
     const open = popover && popover.kind === 'mod' && popover.id === charge.command_uuid;
+    const comment = charge.comment || '';
+    const cmtEdit = popover && popover.kind === 'commentEdit' && popover.id === charge.command_uuid;
+    const cmtRead = popover && popover.kind === 'commentRead' && popover.id === charge.command_uuid;
+    // Editable whenever the matrix is. Editing a comment on a charge already on
+    // the signed claim is handled in summary.js by entering the old charge in
+    // error and re-entering a clone with the new comment (with explicit BLI
+    // cleanup so /enrich-charges stays unambiguous).
+    const commentEditable = !readOnly;
     return html`
       <th class="cm-charge-head" key=${charge.command_uuid}>
         <div class="cm-cpt-row">
@@ -171,7 +210,7 @@ export function ChargeMatrix({
           ${!readOnly ? html`<button class="cm-colremove" title="Remove charge"
             onClick=${() => onRemoveCharge(charge.command_uuid)}>×</button>` : null}
         </div>
-        <div class="cm-mods">
+        <div class="cm-affordances">
           ${mods.map(code => readOnly
             ? html`<span class="cm-modchip cm-modchip-static" key=${code}>${code}</span>`
             : html`<span class="cm-modchip" key=${code} title="Remove modifier"
@@ -182,6 +221,16 @@ export function ChargeMatrix({
             ? html`<button class="cm-modadd"
                 onClick=${() => setPopover(open ? null : { kind: 'mod', id: charge.command_uuid })}>+ Modifier</button>`
             : null}
+          ${comment
+            ? html`<span class="cm-notechip" title="View comment"
+                onClick=${() => setPopover(cmtRead ? null : { kind: 'commentRead', id: charge.command_uuid })}>
+                <svg class="cm-notechip-icon" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg>
+                <span class="cm-notechip-label">${comment}</span>
+              </span>`
+            : (commentEditable
+                ? html`<button class="cm-noteadd"
+                    onClick=${() => setPopover(cmtEdit ? null : { kind: 'commentEdit', id: charge.command_uuid })}>+ Comment</button>`
+                : null)}
         </div>
         ${open && !readOnly ? html`<${ModifierPicker} selected=${mods}
             onToggle=${code => {
@@ -193,6 +242,28 @@ export function ChargeMatrix({
               }
             }}
             onClose=${() => setPopover(null)} />` : null}
+        ${cmtEdit && commentEditable ? html`<${CommentEditor} value=${comment}
+            onSave=${text => {
+              if (text) onSetComment(charge.command_uuid, text);
+              else onClearComment(charge.command_uuid);
+              setPopover(null);
+            }}
+            onCancel=${() => setPopover(null)} />` : null}
+        ${cmtRead ? html`
+          <div class="cm-popover cm-popover-comment" role="dialog">
+            <div class="cm-comment-read">${comment}</div>
+            ${commentEditable
+              ? html`<div class="cm-comment-foot">
+                  <span></span>
+                  <div class="cm-comment-actions">
+                    <button class="cm-comment-btn cm-comment-btn-danger"
+                      onClick=${() => { onClearComment(charge.command_uuid); setPopover(null); }}>Remove</button>
+                    <button class="cm-comment-btn cm-comment-btn-ghost"
+                      onClick=${() => setPopover({ kind: 'commentEdit', id: charge.command_uuid })}>Edit</button>
+                  </div>
+                </div>`
+              : html`<div class="cm-comment-meta">Read-only — note finalized.</div>`}
+          </div>` : null}
       </th>`;
   });
 
@@ -238,7 +309,9 @@ export function ChargeMatrix({
               onChange=${() => onTogglePointer(charge.command_uuid, dx.command_uuid)} />
           </td>`;
         })}
-        <td class="cm-add-cell"></td>
+        ${showGhostCharge
+          ? html`<td class="cm-ghost-cell"><span class="cm-ghost-check"></span></td>`
+          : html`<td class="cm-add-cell"></td>`}
       </tr>`;
   };
 
@@ -271,7 +344,7 @@ export function ChargeMatrix({
             <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M4 3h16v18l-3-2-2 2-2-2-2 2-2-2-3 2z"/><path d="M8 8h8M8 12h8"/></svg>
           </div>
           <div class="cm-empty-title">No charges yet</div>
-          <div class="cm-empty-hint">Add a diagnosis in the Plan, then add a charge here to link them.</div>
+          <div class="cm-empty-hint">Add a condition above, then a charge here.</div>
           ${!readOnly ? html`<div class="cm-empty-add">
             <button class="cm-empty-btn" onClick=${() => setPopover(chargeOpen ? null : { kind: 'charge' })}>
               <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" aria-hidden="true"><path d="M12 5v14M5 12h14"/></svg>
@@ -290,16 +363,24 @@ export function ChargeMatrix({
           <tr>
             <th class="cm-dx-head"></th>
             ${headerCells}
-            <th class="cm-add-head">
-              ${!readOnly ? html`
-                <button class="cm-add-btn" title="Add charge"
-                  onClick=${() => setPopover(chargeOpen ? null : { kind: 'charge' })}>+</button>
-                ${chargePicker}` : null}
-            </th>
+            ${showGhostCharge
+              ? html`<th class="cm-ghost-head">
+                  <button class="cm-empty-btn" onClick=${() => setPopover(chargeOpen ? null : { kind: 'charge' })}>
+                    <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" aria-hidden="true"><path d="M12 5v14M5 12h14"/></svg>
+                    Add charge
+                  </button>
+                  ${chargePicker}
+                </th>`
+              : html`<th class="cm-add-head">
+                  ${!readOnly ? html`
+                    <button class="cm-add-btn" title="Add charge"
+                      onClick=${() => setPopover(chargeOpen ? null : { kind: 'charge' })}>+</button>
+                    ${chargePicker}` : null}
+                </th>`}
           </tr>
         </thead>
         <tbody>${dxs.length === 0
-          ? html`<tr><td class="cm-empty" colSpan=${colSpan}>Add a diagnosis in the Plan to link it to this charge.</td></tr>`
+          ? html`<tr><td class="cm-empty" colSpan=${colSpan}>Add a condition above to link this charge.</td></tr>`
           : bodyRows}</tbody>
         ${chs.length > 0 ? html`
           <tfoot>

--- a/hyperscribe/scribe/static/soap-group.js
+++ b/hyperscribe/scribe/static/soap-group.js
@@ -647,7 +647,7 @@ function AddConditionSearch({ onAdd, patientId }) {
   `;
 }
 
-export function SoapGroup({ title, groupColor, sections, commandBySectionKey, onEditCommand, onDeleteCommand, adHocCommands, assignees, onAddTask, onAddOrder, onAddPlan, onAddVitals, onAddMedication, onAddAllergy, onAddStopMedication, onAddRemoveAllergy, onAddResolveCondition, onAddHistory, onAddQuestionnaire, onAddCharge, readOnly, isAmending = false, sectionConditions, patientId, noteId, staffId, staffName, recommendations, onEditRecommendation, onDeleteRecommendation, onAcceptRecommendation, onRejectRecommendation, onAddCondition, unmatchedConditions, diagnosisSuggestions, onAddNow, hideRejected, alertFacilityEnabled, onEditingChange, questionnaireScores, chargeMatrixDiagnoses = [], chargeMatrixCharges = [], searchCharges = () => {}, suggestedCharges = [], onToggleChargePointer = () => {}, onReorderDiagnoses = () => {}, onAddChargeModifier = () => {}, onRemoveChargeModifier = () => {}, onRemoveChargeByUuid = () => {}, examTemplates, onCarryForwardExam }) {
+export function SoapGroup({ title, groupColor, sections, commandBySectionKey, onEditCommand, onDeleteCommand, adHocCommands, assignees, onAddTask, onAddOrder, onAddPlan, onAddVitals, onAddMedication, onAddAllergy, onAddStopMedication, onAddRemoveAllergy, onAddResolveCondition, onAddHistory, onAddQuestionnaire, onAddCharge, readOnly, isAmending = false, sectionConditions, patientId, noteId, staffId, staffName, recommendations, onEditRecommendation, onDeleteRecommendation, onAcceptRecommendation, onRejectRecommendation, onAddCondition, unmatchedConditions, diagnosisSuggestions, onAddNow, hideRejected, alertFacilityEnabled, onEditingChange, questionnaireScores, chargeMatrixDiagnoses = [], chargeMatrixCharges = [], searchCharges = () => {}, suggestedCharges = [], onToggleChargePointer = () => {}, onReorderDiagnoses = () => {}, onAddChargeModifier = () => {}, onRemoveChargeModifier = () => {}, onSetChargeComment = () => {}, onClearChargeComment = () => {}, onRemoveChargeByUuid = () => {}, examTemplates, onCarryForwardExam }) {
   const isCharges = title === 'CHARGES';
   const coveredKeys = getCoveredKeys(commandBySectionKey);
 
@@ -1469,6 +1469,8 @@ export function SoapGroup({ title, groupColor, sections, commandBySectionKey, on
           onReorderDiagnoses=${onReorderDiagnoses}
           onAddModifier=${onAddChargeModifier}
           onRemoveModifier=${onRemoveChargeModifier}
+          onSetComment=${onSetChargeComment}
+          onClearComment=${onClearChargeComment}
           onAddCharge=${onAddCharge}
           onRemoveCharge=${onRemoveChargeByUuid}
         />` : null}

--- a/hyperscribe/scribe/static/styles.css
+++ b/hyperscribe/scribe/static/styles.css
@@ -1692,31 +1692,60 @@ h2 { margin-bottom: 4px; }
   font-weight: 600;
 }
 .cm-dx-head { width: auto; }
-.cm-charge-head { position: relative; width: 170px; border-left: 1px solid #eef1f4; }
+.cm-charge-head { position: relative; width: 206px; border-left: 1px solid #eef1f4; }
 .cm-add-head { position: relative; width: 52px; border-left: 1px solid #eef1f4; }
 
-.cm-cpt-row { display: inline-flex; align-items: center; gap: 6px; }
+/* Ghost charge column — shown when there are diagnoses but no charges yet.
+   Soft red wash nudges the provider to add a charge; the divider stays neutral
+   (no red vertical line) and the "Add charge" button reuses .cm-empty-btn. */
+.cm-ghost-head { position: relative; width: 206px; border-left: 1px dashed #cfd8e0; background: #fdeeec; }
+.cm-ghost-cell { border-left: 1px dashed #cfd8e0; background: #fdeeec; text-align: center; }
+.cm-ghost-check { display: inline-block; width: 18px; height: 18px; border: 1.5px dashed #cbd5de; border-radius: 4px; vertical-align: middle; }
+
+.cm-cpt-row { display: flex; align-items: center; justify-content: center; }
 .cm-cpt { font-family: ui-monospace, Menlo, Consolas, monospace; font-size: 15px; font-weight: 700; color: #052B49; }
+/* Pulled out of flow so the CPT stays centered in the cell whether or not the
+   remove button is showing. */
 .cm-colremove {
+  position: absolute; top: 9px; right: 10px;
   border: none; background: transparent; color: #b3bdc7; font-size: 15px; line-height: 1;
   cursor: pointer; padding: 0 2px; border-radius: 4px; opacity: 0; transition: opacity .12s, color .12s;
 }
 .cm-charge-head:hover .cm-colremove { opacity: 1; }
 .cm-colremove:hover { color: #c0392b; background: #fbeceb; }
 
-.cm-mods { display: flex; flex-wrap: wrap; gap: 6px; justify-content: center; margin-top: 7px; }
+/* Modifier + comment affordances share one centered, wrapping row so the
+   "+ Modifier" and "+ Comment" buttons sit side by side rather than stacked. */
+.cm-affordances { display: flex; flex-wrap: wrap; gap: 6px; justify-content: center; margin-top: 7px; }
 .cm-modchip {
-  display: inline-flex; align-items: center; gap: 3px; height: 22px; padding: 0 8px;
-  border-radius: 6px; background: #eef3f8; border: 1px solid #d7e2ee; color: #2c5277;
-  font-family: ui-monospace, Menlo, monospace; font-size: 12px; font-weight: 600; cursor: pointer;
+  display: inline-flex; align-items: center; gap: 4px; height: 22px; padding: 0 8px;
+  border-radius: 6px; background: #f3f5f7; border: 1px solid #e2e7ec; color: #475569;
+  font-size: 12px; font-weight: 600; cursor: pointer;
 }
-.cm-modchip:hover { background: #e3ecf5; }
-.cm-modchip-x { color: #8aa0b6; font-weight: 400; }
+.cm-modchip:hover { background: #eaeef2; }
+.cm-modchip-x { color: #94a3b8; font-weight: 400; }
 .cm-modadd {
   height: 22px; padding: 0 8px; border: 1px dashed #cfd8e0; border-radius: 6px; background: #fff;
   color: #6a7682; font-size: 12px; font-weight: 600; cursor: pointer; transition: background .12s;
 }
 .cm-modadd:hover { background: #f5f8fb; }
+
+/* -- charge comment (perform.notes) -- */
+.cm-noteadd {
+  display: inline-flex; align-items: center; gap: 4px; height: 22px; padding: 0 8px;
+  border: 1px dashed #cfd8e0; border-radius: 6px; background: #fff;
+  color: #6a7682; font-size: 12px; font-weight: 600; cursor: pointer; transition: background .12s;
+}
+.cm-noteadd:hover { background: #f5f8fb; }
+.cm-noteadd svg { stroke: currentColor; }
+.cm-notechip {
+  display: inline-flex; align-items: center; gap: 4px; height: 22px; max-width: 150px; padding: 0 8px;
+  border-radius: 6px; background: #f3f5f7; border: 1px solid #e2e7ec; color: #475569;
+  font-size: 12px; font-weight: 600; cursor: pointer; transition: background .12s;
+}
+.cm-notechip:hover { background: #eaeef2; }
+.cm-notechip-icon { stroke: #94a3b8; flex-shrink: 0; }
+.cm-notechip-label { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 
 .cm-add-btn {
   width: 30px; height: 30px; border: none; background: transparent; color: #052B49;
@@ -1819,6 +1848,30 @@ h2 { margin-bottom: 4px; }
 .cm-popover-desc { color: #5b6b7a; font-size: 13px; flex: 1; }
 .cm-popover-check { color: #059669; font-weight: 700; }
 .cm-popover-empty { padding: 12px 8px; color: #6a7682; font-size: 13px; text-align: center; }
+
+/* -- comment editor / reader popover -- */
+.cm-popover-comment { width: 280px; max-height: none; }
+.cm-comment-ta {
+  width: 100%; box-sizing: border-box; min-height: 78px; resize: vertical; padding: 8px 9px;
+  border: 1px solid #d1d5db; border-radius: 6px; font-size: 13px; font-family: inherit; line-height: 1.45; color: #1b2733;
+}
+.cm-comment-ta:focus { outline: none; border-color: #93b4d4; box-shadow: 0 0 0 3px rgba(82,130,180,.12); }
+.cm-comment-read {
+  font-size: 13px; color: #1b2733; line-height: 1.5; white-space: pre-wrap; word-break: break-word;
+  background: #fcfdfe; border: 1px solid #f0f2f4; border-radius: 6px; padding: 9px 10px; max-height: 160px; overflow: auto;
+}
+.cm-comment-foot { display: flex; align-items: center; justify-content: space-between; gap: 8px; margin-top: 8px; }
+.cm-comment-count { font-size: 11px; color: #93a0ac; }
+.cm-comment-count.over { color: #c0392b; font-weight: 600; }
+.cm-comment-meta { font-size: 11px; color: #93a0ac; margin-top: 7px; }
+.cm-comment-actions { display: flex; gap: 6px; }
+.cm-comment-btn { height: 28px; padding: 0 12px; border-radius: 6px; font-size: 12px; font-weight: 600; cursor: pointer; border: 1px solid transparent; font-family: inherit; }
+.cm-comment-btn-ghost { background: #fff; border-color: #d3dce4; color: #6a7682; }
+.cm-comment-btn-ghost:hover { background: #f5f8fb; }
+.cm-comment-btn-primary { background: #052B49; color: #fff; }
+.cm-comment-btn-primary:hover { background: #0a3a5e; }
+.cm-comment-btn-danger { background: #fff; border-color: #f0d2d0; color: #c0392b; }
+.cm-comment-btn-danger:hover { background: #fbeceb; }
 
 /* -- sign gate error (layers onto .summary-footer-warning) -- */
 .cm-sign-error { color: #c0392b; font-weight: 600; margin-top: 4px; }

--- a/hyperscribe/scribe/static/summary.js
+++ b/hyperscribe/scribe/static/summary.js
@@ -348,7 +348,7 @@ function buildCommandBySectionKey(commands) {
   return map;
 }
 
-function renderSoapGroups(sections, commandBySectionKey, onEditCommand, onDeleteCommand, { adHocCommands, objectiveAdHocCommands, historyAdHocCommands, subjectiveAdHocCommands, chargeAdHocCommands, assignees, onAddTask, onAddOrder, onAddPlan, onAddMedication, onAddAllergy, onAddStopMedication, onAddRemoveAllergy, onAddResolveCondition, onAddHistory, onAddQuestionnaire, onAddCharge, onAddTemplateCharge, onRemoveChargeByCpt, templateCharges, readOnly, isAmending, sectionConditions, patientId, noteId, staffId, staffName, recommendations, onEditRecommendation, onDeleteRecommendation, onAcceptRecommendation, onRejectRecommendation, onAddCondition, unmatchedConditions, diagnosisSuggestions, onAddNow, onAddVitals, hideRejected, alertFacilityEnabled, onEditingChange, questionnaireScores, chargeMatrixDiagnoses, chargeMatrixCharges, searchCharges, suggestedCharges, onToggleChargePointer, onReorderDiagnoses, onAddChargeModifier, onRemoveChargeModifier, onRemoveChargeByUuid, examTemplates, onCarryForwardExam } = {}) {
+function renderSoapGroups(sections, commandBySectionKey, onEditCommand, onDeleteCommand, { adHocCommands, objectiveAdHocCommands, historyAdHocCommands, subjectiveAdHocCommands, chargeAdHocCommands, assignees, onAddTask, onAddOrder, onAddPlan, onAddMedication, onAddAllergy, onAddStopMedication, onAddRemoveAllergy, onAddResolveCondition, onAddHistory, onAddQuestionnaire, onAddCharge, onAddTemplateCharge, onRemoveChargeByCpt, templateCharges, readOnly, isAmending, sectionConditions, patientId, noteId, staffId, staffName, recommendations, onEditRecommendation, onDeleteRecommendation, onAcceptRecommendation, onRejectRecommendation, onAddCondition, unmatchedConditions, diagnosisSuggestions, onAddNow, onAddVitals, hideRejected, alertFacilityEnabled, onEditingChange, questionnaireScores, chargeMatrixDiagnoses, chargeMatrixCharges, searchCharges, suggestedCharges, onToggleChargePointer, onReorderDiagnoses, onAddChargeModifier, onRemoveChargeModifier, onSetChargeComment, onClearChargeComment, onRemoveChargeByUuid, examTemplates, onCarryForwardExam } = {}) {
   return SOAP_GROUPS
     .map(group => {
       const matching = sections.filter(s => group.keys.has(s.key.toLowerCase()));
@@ -390,6 +390,8 @@ function renderSoapGroups(sections, commandBySectionKey, onEditCommand, onDelete
         onReorderDiagnoses=${isCharges ? onReorderDiagnoses : null}
         onAddChargeModifier=${isCharges ? onAddChargeModifier : null}
         onRemoveChargeModifier=${isCharges ? onRemoveChargeModifier : null}
+        onSetChargeComment=${isCharges ? onSetChargeComment : null}
+        onClearChargeComment=${isCharges ? onClearChargeComment : null}
         onRemoveChargeByUuid=${isCharges ? onRemoveChargeByUuid : null}
         readOnly=${readOnly}
         isAmending=${isAmending}
@@ -586,6 +588,7 @@ export function Scribe({ noteId, patientId, staffId, staffName, providerName, pr
         command_uuid: c._localId,
         cpt: c.data.cpt_code,
         description: c.data.description || '',
+        comment: c.data.notes || '',
         modifiers: c.data._modifiers || [],
         pointers: (c.data._pointers || []).filter(u => dxRefs.has(u)),
         // True only when this plugin has written _pointers to the charge. Pre-plugin
@@ -629,6 +632,48 @@ export function Scribe({ noteId, patientId, staffId, staffName, providerName, pr
     matrixRef(chargeUuid)(c)
       ? { ...c, data: { ...c.data, _pointers: c.data._pointers || [], _modifiers: (c.data._modifiers || []).filter(m => m !== code) } }
       : c)), []);
+
+  // Comment handlers write the perform command's native `notes` field, committed
+  // via /insert-commands and rendered by the existing scribe-print template —
+  // no enrichment needed (unlike _modifiers/_pointers on the BLI).
+  //
+  // For a charge NOT yet on the claim (fresh note, or one added during this
+  // amendment) we edit notes in place; the insert path carries it.
+  //
+  // For a charge ALREADY on the signed claim, notes can't be edited in place
+  // (committed perform commands reject .edit(); the only edit path re-originates).
+  // So we mirror the home-app "enter in error + re-enter" gesture: void the old
+  // command (_amend_deleted → /delete-existing-commands) and add a fresh clone
+  // carrying the same CPT/modifiers/pointers with the new comment (→ /insert-
+  // commands). Entering the old command in error leaves its BillingLineItem
+  // ACTIVE (command_id is null on BLIs, so home-app can't auto-void it), so the
+  // sign flow explicitly removes the old charge's BLI after the delete and BEFORE
+  // the clone is inserted — see the "early charge-BLI removal" step in handleInsert.
+  const setChargeComment = (chargeUuid, notes) => setCommands(prev => {
+    const idx = prev.findIndex(c => matrixRef(chargeUuid)(c));
+    if (idx < 0) return prev;
+    const target = prev[idx];
+    // Mirror onRemoveChargeByUuid's gate: only a charge actually on the signed
+    // claim needs the void+re-enter dance. Everything else edits notes in place.
+    if (!(target.already_documented && isAmendingSectionEditable(target, wasFinalized && !approved))) {
+      return prev.map(c => matrixRef(chargeUuid)(c) ? { ...c, data: { ...c.data, notes } } : c);
+    }
+    const { _amend_edited, _template_inserted, ...base } = target;
+    const clone = {
+      ...base,
+      _localId: crypto.randomUUID(),
+      command_uuid: null,
+      already_documented: false,
+      _amend_deleted: false,
+      selected: true,
+      data: { ...target.data, notes },
+    };
+    const next = prev.map((c, i) => i === idx ? { ...c, selected: false, _amend_deleted: true } : c);
+    next.splice(idx + 1, 0, clone);
+    return next;
+  });
+  const onSetChargeComment = useCallback((chargeUuid, text) => setChargeComment(chargeUuid, text), [wasFinalized, approved]);
+  const onClearChargeComment = useCallback((chargeUuid) => setChargeComment(chargeUuid, ''), [wasFinalized, approved]);
 
   const onReorderDiagnoses = useCallback((nextUuids) => setCommands(prev => {
     // The matrix keys rows on _localId (stable, unique), so reorder must too —
@@ -1965,6 +2010,30 @@ export function Scribe({ noteId, patientId, staffId, staffName, providerName, pr
           diagnosis_suggestions: diagnosisSuggestions,
           selected_template_name: selectedTemplate?.name || null, mode,
         });
+        // Early charge-BLI removal. Entering a perform command in error does NOT
+        // void its BillingLineItem (BLIs carry command_id=null, so home-app can't
+        // auto-void them), so a just-deleted charge leaves an orphan ACTIVE BLI.
+        // Remove those orphans NOW — after the EIE hard-commit, before any clone
+        // is inserted — while each CPT still resolves to exactly one ACTIVE BLI,
+        // so enrich's CPT fallback captures the correct BLI id. Without this, a
+        // comment edit's re-entered clone would create a second same-CPT BLI and
+        // wedge the final enrich (ambiguous-CPT → billing_line_item_not_found).
+        // Best-effort: the final enrich retries removed_charges as a backstop, so
+        // a failure here never blocks signing.
+        const earlyRemovedChargeUuids = amendDeletes
+          .filter(c => c.command_type === 'perform' && c.command_uuid)
+          .map(c => c.command_uuid);
+        if (earlyRemovedChargeUuids.length) {
+          try {
+            await fetch(`${API_BASE}/enrich-charges`, {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ note_uuid: noteId, charges: [], removed_charges: earlyRemovedChargeUuids }),
+            });
+          } catch (earlyErr) {
+            console.warn('early charge-BLI removal failed (final enrich retries):', earlyErr);
+          }
+        }
       } catch (err) {
         console.error('Amend deletes failed:', err);
         setError('Failed to apply amendment deletes');
@@ -2332,9 +2401,13 @@ export function Scribe({ noteId, patientId, staffId, staffName, providerName, pr
               return { command_uuid: c.command_uuid, diagnosis_pointers, modifiers: c.data._modifiers || [] };
             })
             .filter(Boolean);
-          const removedCharges = amendDeletes
-            .filter(c => c.command_type === 'perform' && c.command_uuid)
-            .map(c => c.command_uuid);
+          // Charge-BLI removal is handled by the EARLY removal step (after
+          // /delete-existing-commands, before /insert-commands), where each
+          // removed charge's CPT still resolves to exactly one ACTIVE BLI. We
+          // must NOT re-send removed_charges here: a comment edit re-enters a
+          // clone with the SAME CPT, so by now the old uuid's CPT fallback would
+          // resolve to the CLONE's BLI and this loop would delete it. Leave empty.
+          const removedCharges = [];
 
           if (enrichCharges.length || removedCharges.length) {
             // The home-app applies the /insert-commands originate+commit effects
@@ -2977,6 +3050,8 @@ export function Scribe({ noteId, patientId, staffId, staffName, providerName, pr
           onReorderDiagnoses: canEdit ? onReorderDiagnoses : null,
           onAddChargeModifier: canEdit ? onAddChargeModifier : null,
           onRemoveChargeModifier: canEdit ? onRemoveChargeModifier : null,
+          onSetChargeComment: canEdit ? onSetChargeComment : null,
+          onClearChargeComment: canEdit ? onClearChargeComment : null,
           onRemoveChargeByUuid: canEdit ? onRemoveChargeByUuid : null,
           examTemplates: templates,
           onCarryForwardExam: handleCarryForwardExam,

--- a/tests/hyperscribe/scribe/print/test_command_display.py
+++ b/tests/hyperscribe/scribe/print/test_command_display.py
@@ -143,6 +143,23 @@ def test_extract_perform_with_cpt_inline() -> None:
     assert "CPT" not in result["description"]
 
 
+def test_extract_perform_with_comment_notes() -> None:
+    """A charge comment (perform.notes) surfaces as `notes` so the print template
+    renders it beneath the CPT/description."""
+    result = extract_command_display(
+        "perform",
+        {"cpt_code": "96372", "description": "Injection", "notes": "Given in left deltoid per protocol."},
+    )
+    assert result["cpt_code"] == "96372"
+    assert result["notes"] == "Given in left deltoid per protocol."
+    assert "Given in left deltoid per protocol." in result["content"]
+
+
+def test_extract_perform_without_comment_has_empty_notes() -> None:
+    result = extract_command_display("perform", {"cpt_code": "99213", "description": "Office visit"})
+    assert result["notes"] == ""
+
+
 def test_extract_action_command_stop_medication() -> None:
     result = extract_command_display(
         "stopMedication",

--- a/tests/hyperscribe/scribe/print/test_command_display.py
+++ b/tests/hyperscribe/scribe/print/test_command_display.py
@@ -1,3 +1,9 @@
+from pathlib import Path
+
+import hyperscribe
+from django.conf import settings
+from django.template import Context, Engine
+
 from hyperscribe.scribe.print.command_display import (
     SOAP_SECTIONS,
     _decode_b64_html,
@@ -8,6 +14,25 @@ from hyperscribe.scribe.print.command_display import (
     _schema_key_to_label,
     extract_command_display,
 )
+
+
+def _render_print_note(commands: list[dict]) -> str:
+    """Render the real print_scribe_note.html template with the given body commands.
+
+    The SDK's ``render_to_string`` requires plugin context (unavailable in unit
+    tests), so drive Django's template engine directly against the template dir.
+    This exercises the actual template — including the perform/charge branch that
+    prints a charge comment (``perform.notes``).
+    """
+    if not settings.configured:
+        settings.configure(USE_TZ=True)
+        import django
+
+        django.setup()
+    templates_root = str(Path(hyperscribe.__file__).resolve().parent)
+    engine = Engine(dirs=[templates_root])
+    template = engine.get_template("scribe/print/templates/print_scribe_note.html")
+    return template.render(Context({"patient_name": "Test Patient", "commands": commands}))
 
 
 # --- helpers ---
@@ -158,6 +183,33 @@ def test_extract_perform_with_comment_notes() -> None:
 def test_extract_perform_without_comment_has_empty_notes() -> None:
     result = extract_command_display("perform", {"cpt_code": "99213", "description": "Office visit"})
     assert result["notes"] == ""
+
+
+def test_print_template_renders_perform_comment() -> None:
+    """The print template renders a charge comment (perform.notes) under the charge."""
+    html = _render_print_note(
+        [
+            {
+                "schema_key": "perform",
+                "cpt_code": "96372",
+                "description": "Injection",
+                "notes": "Given in left deltoid per protocol.",
+            }
+        ]
+    )
+    assert "Given in left deltoid per protocol." in html
+    # the comment is wrapped in the order-view-details div (CSS rule uses
+    # `.order-view-details {`, so matching `class="..."` targets the rendered div)
+    assert 'class="order-view-details"' in html
+
+
+def test_print_template_omits_empty_perform_comment() -> None:
+    """A charge with no comment renders no comment div."""
+    html = _render_print_note(
+        [{"schema_key": "perform", "cpt_code": "99213", "description": "Office visit", "notes": ""}]
+    )
+    assert "99213" in html
+    assert 'class="order-view-details"' not in html
 
 
 def test_extract_action_command_stop_medication() -> None:


### PR DESCRIPTION
## Summary
Lets providers attach a free-text **comment to each charge** in the charge matrix. The comment lands on the underlying `perform` command's `notes` field and prints in the scribe note via the existing print path — no enrichment or backend changes. Bundled with this are several charge-matrix UX improvements that came out of the same work.

## What changed

**Charge comments (the feature)**
- A `+ Comment` affordance on each charge (mirrors the existing `+ Modifier` picker). Saving writes to `perform.notes`.
- A neutral pill previews a saved comment and opens a popover to **read / edit / remove** it.
- Prints automatically: `perform.notes` already flows through `command_display.py` → `print_scribe_note.html`, so no print-side changes were needed (regression test added).
- **Amendment handling:** a committed `perform` command can't be edited in place (the only edit path re-originates it), so editing a comment on an already-signed charge performs an **enter-in-error + re-enter** of the charge, with explicit BillingLineItem cleanup *before* the replacement is inserted — keeping `/enrich-charges` (which matches BLIs by CPT) unambiguous.

**Charge-matrix UX polish**
- `+ Modifier` and `+ Comment` sit **side by side**; charge column widened to fit; comment add button styled identically to `+ Modifier`.
- CPT code **re-centered** in the header (`×` remove pulled out of layout flow).
- **Empty-state nudge (diagnoses but no charges):** a "ghost" charge column with an `Add charge` CTA and faint checkbox placeholders, in place of the previously-bare table. Advisory only — never blocks signing.
- Modifier and comment chips **unified** into one neutral chip style (shape, color, font).
- Empty-state copy tightened (e.g. "Add a condition above to link this charge").

## Files
`charge-matrix.js`, `summary.js`, `soap-group.js`, `styles.css`, and `tests/.../test_command_display.py` (+ removed a stray temporary mock).

## Testing
- 45 Python tests pass; `ruff` / `mypy` / `format` clean (pre-commit).
- Comments verified end-to-end on the QA instance (initial sign **and** amendment).
- :warning: **No automated JS coverage** — the comment handlers, amendment re-entry/BLI cleanup, and ghost column are verified manually only (repo has no JS test harness). The amendment/BLI logic in `summary.js` is the area most worth a careful review.

## Known limitation
Editing a comment on an already-signed charge during an amendment isn't supported when the **same CPT appears on two charges** — the BLI cleanup can't disambiguate (a pre-existing constraint of CPT-based matching). Suggest a follow-up ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
