### PR TITLE
feat(scribe): generic specialty referrals with validated indication

### DIFF
--- a/hyperscribe/scribe/api/session_view.py
+++ b/hyperscribe/scribe/api/session_view.py
@@ -81,6 +81,7 @@ from hyperscribe.scribe.commands.problem_list_match import (
     prefer_patient_specific_codes,
 )
 from hyperscribe.scribe.recommendations import recommend_commands
+from hyperscribe.scribe.recommendations._referral_diagnosis import link_referral_diagnoses
 from hyperscribe.scribe.recommendations.diagnosis_suggestion import suggest_diagnoses
 from hyperscribe.scribe.recommendations.interactions import (
     check_recommendation_interactions,
@@ -1227,6 +1228,18 @@ class ScribeSessionView(StaffSessionAuthMixin, SimpleAPI):
                 diagnosis_suggestions = suggest_diagnoses(unmatched_headers, api_key)
             except Exception:
                 log.exception("suggest_diagnoses failed (non-critical)")
+
+        # ── Step 4b: Give generic referrals a validated indication ──
+        # Match each referral's condition to a code already in the note (diagnose
+        # commands → diagnosis suggestions → unmatched conditions) so a generic,
+        # provider-less referral is commit-ready. Never fabricates a code.
+        if recommendations_list:
+            try:
+                link_referral_diagnoses(
+                    recommendations_list, commands_list, unmatched_conditions, diagnosis_suggestions
+                )
+            except Exception:
+                log.exception("link_referral_diagnoses failed (non-critical)")
 
         # ── Save to database ──
         # `mode` and `selected_template_name` are owned by the session lifecycle

--- a/hyperscribe/scribe/commands/refer.py
+++ b/hyperscribe/scribe/commands/refer.py
@@ -20,7 +20,15 @@ class ReferParser(CommandParser):
         return None
 
     def validate(self, data: dict[str, Any]) -> list[str]:
+        # A refer command is auto-signed on insert (see post_originate_effects), and
+        # Canvas core requires a recipient, a clinical question, notes, and at least
+        # one indication to sign it. Validate all four here so an incomplete referral
+        # fails loudly at /insert-commands instead of silently rolling back at sign.
         errors: list[str] = []
+        if not data.get("service_provider"):
+            errors.append("Referral recipient is required")
+        if not data.get("clinical_question"):
+            errors.append("Clinical question is required")
         if not data.get("notes_to_specialist"):
             errors.append("Notes to specialist is required")
         if not data.get("diagnosis_codes"):

--- a/hyperscribe/scribe/recommendations/__init__.py
+++ b/hyperscribe/scribe/recommendations/__init__.py
@@ -30,7 +30,9 @@ def _build_recommenders(zip_codes: list[str] | None = None) -> list[BaseRecommen
         MedicationRecommender(),
         AllergyRecommender(),
         PrescriptionRecommender(),
-        ReferRecommender(zip_codes=zip_codes),
+        # zip_codes is intentionally not passed: referrals are recommended
+        # generically (specialty only), without a provider lookup.
+        ReferRecommender(),
         TaskRecommender(),
     ]
 

--- a/hyperscribe/scribe/recommendations/_referral_diagnosis.py
+++ b/hyperscribe/scribe/recommendations/_referral_diagnosis.py
@@ -1,0 +1,124 @@
+"""Attach a validated ICD-10 indication to generic referral recommendations.
+
+Referrals are recommended generically (specialty only, no provider). To be
+commit-ready a ``refer`` command needs at least one indication (diagnosis code)
+— see ``ReferParser.validate``. Rather than generate a new code (and risk an
+LLM-hallucinated ICD-10), this links each referral to a code **already present
+and validated in the note**, matched by the condition the referral addresses.
+
+Sources are consulted in priority order:
+
+1. ``diagnose`` commands that already carry a populated ``icd10_code`` — the
+   note's own coded assessment, the most authoritative source.
+2. ``diagnosis_suggestions`` — science-service-validated codes suggested for the
+   note's still-uncoded problem headers.
+3. ``unmatched_conditions`` — the patient's active problem list codings.
+
+It never fabricates: a referral whose indication matches nothing keeps its
+existing (empty) ``diagnosis_codes`` and remains a non-blocking, provider-review
+item. The function is pure (operates on plain dicts) so it is trivially
+unit-testable.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def _normalize(text: str | None) -> str:
+    """Normalize a condition/problem string for matching (drop trailing colon, casefold)."""
+    return (text or "").strip().rstrip(":").strip().lower()
+
+
+def _match(indication: str, table: dict[str, str]) -> str | None:
+    """Return the code whose condition key matches ``indication`` (exact, then containment)."""
+    if not indication:
+        return None
+    if indication in table:
+        return table[indication]
+    for key, code in table.items():
+        if key and (indication in key or key in indication):
+            return code
+    return None
+
+
+def _codes_from_diagnose_commands(commands: list[dict[str, Any]]) -> dict[str, str]:
+    result: dict[str, str] = {}
+    for command in commands or []:
+        if command.get("command_type") != "diagnose":
+            continue
+        data = command.get("data") or {}
+        code = (data.get("icd10_code") or "").strip()
+        if not code:
+            continue
+        for key in (_normalize(data.get("condition_header")), _normalize(data.get("icd10_display"))):
+            if key:
+                result.setdefault(key, code)
+    return result
+
+
+def _codes_from_suggestions(diagnosis_suggestions: dict[str, Any]) -> dict[str, str]:
+    result: dict[str, str] = {}
+    for header, suggestions in (diagnosis_suggestions or {}).items():
+        if not suggestions:
+            continue
+        first = suggestions[0]
+        code = first.get("formatted_code") or first.get("code")
+        key = _normalize(header)
+        if code and key:
+            result.setdefault(key, code)
+    return result
+
+
+def _codes_from_unmatched_conditions(unmatched_conditions: list[dict[str, Any]]) -> dict[str, str]:
+    result: dict[str, str] = {}
+    for condition in unmatched_conditions or []:
+        code = ""
+        display = ""
+        for entry in condition.get("coding") or []:
+            if entry.get("code"):
+                code = entry["code"]
+                display = entry.get("display") or ""
+                break
+        if not code:
+            continue
+        for key in (_normalize(condition.get("corresponding_note_problem")), _normalize(display)):
+            if key:
+                result.setdefault(key, code)
+    return result
+
+
+def link_referral_diagnoses(
+    recommendations: list[dict[str, Any]],
+    commands: list[dict[str, Any]],
+    unmatched_conditions: list[dict[str, Any]],
+    diagnosis_suggestions: dict[str, Any],
+) -> None:
+    """Attach a validated ICD-10 code to each generic ``refer`` proposal, in place.
+
+    Mutates ``recommendations``: for every ``refer`` proposal that has an
+    ``indication`` but no ``diagnosis_codes`` yet, sets ``data["diagnosis_codes"]``
+    to a single best-matched validated code. Leaves proposals untouched when no
+    match is found (no fabrication).
+    """
+    diagnose_codes = _codes_from_diagnose_commands(commands)
+    suggestion_codes = _codes_from_suggestions(diagnosis_suggestions)
+    unmatched_codes = _codes_from_unmatched_conditions(unmatched_conditions)
+
+    for proposal in recommendations:
+        if proposal.get("command_type") != "refer":
+            continue
+        data = proposal.get("data") or {}
+        if data.get("diagnosis_codes"):
+            continue
+        indication = _normalize(data.get("indication"))
+        if not indication:
+            continue
+        code = (
+            _match(indication, diagnose_codes)
+            or _match(indication, suggestion_codes)
+            or _match(indication, unmatched_codes)
+        )
+        if code:
+            data["diagnosis_codes"] = [code]
+            proposal["data"] = data

--- a/hyperscribe/scribe/recommendations/_referral_diagnosis.py
+++ b/hyperscribe/scribe/recommendations/_referral_diagnosis.py
@@ -30,20 +30,22 @@ def _normalize(text: str | None) -> str:
     return (text or "").strip().rstrip(":").strip().lower()
 
 
-def _match(indication: str, table: dict[str, str]) -> str | None:
-    """Return the code whose condition key matches ``indication`` (exact, then containment)."""
+# Each matchable entry maps a normalized condition key -> (code, display) so the
+# referral can carry both the ICD-10 code and its human-readable name.
+def _match(indication: str, table: dict[str, tuple[str, str]]) -> tuple[str, str] | None:
+    """Return the (code, display) whose condition key matches ``indication`` (exact, then containment)."""
     if not indication:
         return None
     if indication in table:
         return table[indication]
-    for key, code in table.items():
+    for key, value in table.items():
         if key and (indication in key or key in indication):
-            return code
+            return value
     return None
 
 
-def _codes_from_diagnose_commands(commands: list[dict[str, Any]]) -> dict[str, str]:
-    result: dict[str, str] = {}
+def _codes_from_diagnose_commands(commands: list[dict[str, Any]]) -> dict[str, tuple[str, str]]:
+    result: dict[str, tuple[str, str]] = {}
     for command in commands or []:
         if command.get("command_type") != "diagnose":
             continue
@@ -51,27 +53,29 @@ def _codes_from_diagnose_commands(commands: list[dict[str, Any]]) -> dict[str, s
         code = (data.get("icd10_code") or "").strip()
         if not code:
             continue
-        for key in (_normalize(data.get("condition_header")), _normalize(data.get("icd10_display"))):
+        display = (data.get("icd10_display") or "").strip()
+        for key in (_normalize(data.get("condition_header")), _normalize(display)):
             if key:
-                result.setdefault(key, code)
+                result.setdefault(key, (code, display))
     return result
 
 
-def _codes_from_suggestions(diagnosis_suggestions: dict[str, Any]) -> dict[str, str]:
-    result: dict[str, str] = {}
+def _codes_from_suggestions(diagnosis_suggestions: dict[str, Any]) -> dict[str, tuple[str, str]]:
+    result: dict[str, tuple[str, str]] = {}
     for header, suggestions in (diagnosis_suggestions or {}).items():
         if not suggestions:
             continue
         first = suggestions[0]
         code = first.get("formatted_code") or first.get("code")
+        display = (first.get("display") or "").strip()
         key = _normalize(header)
         if code and key:
-            result.setdefault(key, code)
+            result.setdefault(key, (code, display))
     return result
 
 
-def _codes_from_unmatched_conditions(unmatched_conditions: list[dict[str, Any]]) -> dict[str, str]:
-    result: dict[str, str] = {}
+def _codes_from_unmatched_conditions(unmatched_conditions: list[dict[str, Any]]) -> dict[str, tuple[str, str]]:
+    result: dict[str, tuple[str, str]] = {}
     for condition in unmatched_conditions or []:
         code = ""
         display = ""
@@ -84,7 +88,7 @@ def _codes_from_unmatched_conditions(unmatched_conditions: list[dict[str, Any]])
             continue
         for key in (_normalize(condition.get("corresponding_note_problem")), _normalize(display)):
             if key:
-                result.setdefault(key, code)
+                result.setdefault(key, (code, display))
     return result
 
 
@@ -94,11 +98,12 @@ def link_referral_diagnoses(
     unmatched_conditions: list[dict[str, Any]],
     diagnosis_suggestions: dict[str, Any],
 ) -> None:
-    """Attach a validated ICD-10 code to each generic ``refer`` proposal, in place.
+    """Attach a validated ICD-10 indication to each generic ``refer`` proposal, in place.
 
     Mutates ``recommendations``: for every ``refer`` proposal that has an
-    ``indication`` but no ``diagnosis_codes`` yet, sets ``data["diagnosis_codes"]``
-    to a single best-matched validated code. Leaves proposals untouched when no
+    ``indication`` but no ``diagnosis_codes`` yet, sets ``data["diagnosis_codes"]``,
+    ``data["diagnosis_displays"]`` (the ICD-10 name), and ``data["diagnosis_formatted"]``
+    to a single best-matched validated diagnosis. Leaves proposals untouched when no
     match is found (no fabrication).
     """
     diagnose_codes = _codes_from_diagnose_commands(commands)
@@ -114,11 +119,14 @@ def link_referral_diagnoses(
         indication = _normalize(data.get("indication"))
         if not indication:
             continue
-        code = (
+        match = (
             _match(indication, diagnose_codes)
             or _match(indication, suggestion_codes)
             or _match(indication, unmatched_codes)
         )
-        if code:
+        if match:
+            code, display = match
             data["diagnosis_codes"] = [code]
+            data["diagnosis_displays"] = [display or code]
+            data["diagnosis_formatted"] = [code]
             proposal["data"] = data

--- a/hyperscribe/scribe/recommendations/refer.py
+++ b/hyperscribe/scribe/recommendations/refer.py
@@ -13,6 +13,14 @@ from hyperscribe.scribe.recommendations.schemas import ReferRecommendationList
 
 _RELEVANT_KEYS = {"assessment_and_plan", "plan", "history_of_present_illness"}
 
+# A referral is auto-signed on insert (see ReferParser.post_originate_effects), and
+# Canvas core requires a recipient and a clinical question to sign it. Since these
+# are generic referrals (no provider lookup), supply a placeholder recipient and a
+# neutral default clinical question so the command is insert/sign-ready; the provider
+# can replace the recipient and adjust the clinical question in the UI.
+_DEFAULT_CLINICAL_QUESTION = "Assistance with Ongoing Management"
+_PLACEHOLDER_LAST_NAME = "(TBD)"  # non-empty recipient, mirrors the science "(TBD)" convention
+
 _SYSTEM_PROMPT = (
     "You are a clinical data extraction assistant. "
     "Extract only referrals the provider intends to make from the clinical note sections below. "
@@ -73,22 +81,28 @@ class ReferRecommender(BaseRecommender):
             specialty = (ref.specialty or "").strip()
             if not specialty:
                 continue
+            indication = (ref.indication or "").strip() or None
             # Recommend a generic referral to the specialty only — no automatic
-            # science-service provider lookup. The provider can search for and attach
-            # a specific provider in the UI if they want one. The indication is
-            # resolved to a validated diagnosis code downstream
-            # (see _referral_diagnosis.link_referral_diagnoses) so the generic
-            # referral is commit-ready.
+            # science-service provider lookup. A placeholder recipient keeps the
+            # command insert/sign-ready (the provider can replace it in the UI),
+            # and the indication is resolved to a validated diagnosis code
+            # downstream (see _referral_diagnosis.link_referral_diagnoses).
             proposals.append(
                 CommandProposal(
                     command_type="refer",
                     display=specialty,
                     data={
+                        "service_provider": {
+                            "first_name": "",
+                            "last_name": _PLACEHOLDER_LAST_NAME,
+                            "specialty": specialty,
+                            "practice_name": specialty,
+                        },
                         "refer_to_display": specialty,
-                        "indication": (ref.indication or "").strip() or None,
-                        "clinical_question": ref.clinical_question or None,
+                        "indication": indication,
+                        "clinical_question": ref.clinical_question or _DEFAULT_CLINICAL_QUESTION,
                         "priority": ref.priority or "Routine",
-                        "notes_to_specialist": ref.reason or None,
+                        "notes_to_specialist": ref.reason or indication or f"Referral to {specialty}",
                     },
                     section_key="_recommended",
                 )

--- a/hyperscribe/scribe/recommendations/refer.py
+++ b/hyperscribe/scribe/recommendations/refer.py
@@ -34,7 +34,7 @@ _SYSTEM_PROMPT = (
     "Do NOT include follow-up appointments with the same provider — those are not referrals. "
     "For each referral, extract the specialty, the condition/problem the referral addresses "
     "(copy the problem name verbatim from the note's assessment/plan), the clinical question "
-    "category, priority, and reason."
+    "category, and reason."
 )
 
 
@@ -104,7 +104,7 @@ class ReferRecommender(BaseRecommender):
                         "refer_to_display": specialty,
                         "indication": indication,
                         "clinical_question": ref.clinical_question or _DEFAULT_CLINICAL_QUESTION,
-                        "priority": ref.priority or "Routine",
+                        # priority is intentionally left blank for the provider to set in the UI
                         "notes_to_specialist": ref.reason or indication or f"Referral to {specialty}",
                     },
                     section_key="_recommended",

--- a/hyperscribe/scribe/recommendations/refer.py
+++ b/hyperscribe/scribe/recommendations/refer.py
@@ -19,7 +19,10 @@ _RELEVANT_KEYS = {"assessment_and_plan", "plan", "history_of_present_illness"}
 # neutral default clinical question so the command is insert/sign-ready; the provider
 # can replace the recipient and adjust the clinical question in the UI.
 _DEFAULT_CLINICAL_QUESTION = "Assistance with Ongoing Management"
-_PLACEHOLDER_LAST_NAME = "(TBD)"  # non-empty recipient, mirrors the science "(TBD)" convention
+# Canvas core rejects a blank recipient name on ORIGINATE_REFER_COMMAND
+# ("first_name: This field may not be blank."), so the placeholder name fields
+# must be non-empty. "TBD" marks them clearly for the provider to replace.
+_PLACEHOLDER_NAME = "TBD"
 
 _SYSTEM_PROMPT = (
     "You are a clinical data extraction assistant. "
@@ -93,8 +96,8 @@ class ReferRecommender(BaseRecommender):
                     display=specialty,
                     data={
                         "service_provider": {
-                            "first_name": "",
-                            "last_name": _PLACEHOLDER_LAST_NAME,
+                            "first_name": _PLACEHOLDER_NAME,
+                            "last_name": _PLACEHOLDER_NAME,
                             "specialty": specialty,
                             "practice_name": specialty,
                         },

--- a/hyperscribe/scribe/recommendations/refer.py
+++ b/hyperscribe/scribe/recommendations/refer.py
@@ -8,7 +8,6 @@ from logger import log
 from canvas_sdk.clients.llms.libraries import LlmAnthropic
 
 from hyperscribe.scribe.backend.models import ClinicalNote, CommandProposal, NoteSection, Transcript
-from hyperscribe.scribe.contacts import search_refer_providers
 from hyperscribe.scribe.recommendations.base import BaseRecommender
 from hyperscribe.scribe.recommendations.schemas import ReferRecommendationList
 
@@ -22,8 +21,9 @@ _SYSTEM_PROMPT = (
     "Look for phrases like 'refer to', 'referral to', 'consult with', 'send to', "
     "'evaluation by', or mentions of scheduling with a specialist. "
     "Do NOT include follow-up appointments with the same provider — those are not referrals. "
-    "For each referral, extract the specialty, provider/practice name if mentioned, "
-    "clinical question category, priority, and reason."
+    "For each referral, extract the specialty, the condition/problem the referral addresses "
+    "(copy the problem name verbatim from the note's assessment/plan), the clinical question "
+    "category, priority, and reason."
 )
 
 
@@ -35,9 +35,6 @@ def _build_user_prompt(sections: list[NoteSection]) -> str:
 
 
 class ReferRecommender(BaseRecommender):
-    def __init__(self, zip_codes: list[str] | None = None) -> None:
-        self.zip_codes = zip_codes
-
     def recommend(
         self, note: ClinicalNote, client: LlmAnthropic, transcript: Transcript | None = None
     ) -> list[CommandProposal]:
@@ -57,49 +54,43 @@ class ReferRecommender(BaseRecommender):
             return []
 
         if response.code != HTTPStatus.OK:
-            log.info(f"LLM returned {response.code} for refer recommendations: {response.response}")
+            # Do not log response.response: it is derived from the note and may contain PHI.
+            log.info(
+                f"LLM returned {response.code} for refer recommendations "
+                f"(response length: {len(response.response or '')})"
+            )
             return []
 
         try:
             parsed = ReferRecommendationList.model_validate(json.loads(response.response))
         except Exception:
-            log.exception(f"Failed to parse refer LLM response: {response.response}")
+            # Do not log response.response: it is derived from the note and may contain PHI.
+            log.exception(f"Failed to parse refer LLM response (response length: {len(response.response or '')})")
             return []
+
         proposals: list[CommandProposal] = []
         for ref in parsed.referrals:
-            search_term = ref.specialty or ""
-            if not search_term:
+            specialty = (ref.specialty or "").strip()
+            if not specialty:
                 continue
-
-            results = search_refer_providers(search_term, self.zip_codes)
-            if results:
-                match = results[0]
-                display = match["name"]
-                proposals.append(
-                    CommandProposal(
-                        command_type="refer",
-                        display=display or search_term,
-                        data={
-                            "service_provider": match["data"],
-                            "refer_to_display": display or search_term,
-                            "clinical_question": ref.clinical_question or None,
-                            "priority": ref.priority or "Routine",
-                            "notes_to_specialist": ref.reason or None,
-                        },
-                        section_key="_recommended",
-                    )
+            # Recommend a generic referral to the specialty only — no automatic
+            # science-service provider lookup. The provider can search for and attach
+            # a specific provider in the UI if they want one. The indication is
+            # resolved to a validated diagnosis code downstream
+            # (see _referral_diagnosis.link_referral_diagnoses) so the generic
+            # referral is commit-ready.
+            proposals.append(
+                CommandProposal(
+                    command_type="refer",
+                    display=specialty,
+                    data={
+                        "refer_to_display": specialty,
+                        "indication": (ref.indication or "").strip() or None,
+                        "clinical_question": ref.clinical_question or None,
+                        "priority": ref.priority or "Routine",
+                        "notes_to_specialist": ref.reason or None,
+                    },
+                    section_key="_recommended",
                 )
-            else:
-                proposals.append(
-                    CommandProposal(
-                        command_type="refer",
-                        display=search_term,
-                        data={
-                            "clinical_question": ref.clinical_question or None,
-                            "priority": ref.priority or "Routine",
-                            "notes_to_specialist": ref.reason or None,
-                        },
-                        section_key="_recommended",
-                    )
-                )
+            )
         return proposals

--- a/hyperscribe/scribe/recommendations/schemas.py
+++ b/hyperscribe/scribe/recommendations/schemas.py
@@ -70,7 +70,6 @@ class ReferRecommendation(BaseModelLlmJson):
             "'Diagnostic Uncertainty'"
         ),
     )
-    priority: str = Field(default="Routine", description="'Routine' or 'Urgent'")
     reason: str | None = Field(default=None, description="Brief reason or notes for the referral")
 
 

--- a/hyperscribe/scribe/recommendations/schemas.py
+++ b/hyperscribe/scribe/recommendations/schemas.py
@@ -54,6 +54,13 @@ class PrescriptionRecommendationList(BaseModelLlmJson):
 
 class ReferRecommendation(BaseModelLlmJson):
     specialty: str = Field(description="Medical specialty for the referral (e.g. Cardiology, ENT, Dermatology)")
+    indication: str | None = Field(
+        default=None,
+        description=(
+            "The condition or problem this referral addresses, copied verbatim from the note's "
+            "problem/assessment name (e.g. 'Shoulder muscle spasm'); null if the note does not state one"
+        ),
+    )
     clinical_question: str | None = Field(
         default=None,
         description=(

--- a/hyperscribe/scribe/static/order-row.js
+++ b/hyperscribe/scribe/static/order-row.js
@@ -6,6 +6,7 @@ const html = htm.bind(h);
 
 const ICON_X = html`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><line x1="6" y1="6" x2="18" y2="18"/><line x1="6" y1="18" x2="18" y2="6"/></svg>`;
 const ICON_CHECK = html`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="4 12 10 18 20 6"/></svg>`;
+const ICON_SEARCH = html`<svg class="refer-search-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="7"/><path d="M21 21l-4.3-4.3"/></svg>`;
 
 const API_BASE = '/plugin-io/api/hyperscribe/scribe-session';
 const DEBOUNCE_MS = 300;
@@ -629,6 +630,7 @@ export function OrderRow({ command, commandIndex, onEdit, onDelete, readOnly, pa
   const [referPriority, setReferPriority] = useState(command.data.priority || '');
   const [referNotesToSpecialist, setReferNotesToSpecialist] = useState(command.data.notes_to_specialist || '');
   const [referComment, setReferComment] = useState(command.data.comment || '');
+  const [referCommentOpen, setReferCommentOpen] = useState(!!(command.data.comment));
   const referProviderInputRef = useRef(null);
   const referDiagInputRef = useRef(null);
 
@@ -1608,14 +1610,17 @@ export function OrderRow({ command, commandIndex, onEdit, onDelete, readOnly, pa
               <div class="order-form">
                 <div class="history-form-field" style="position: relative;">
                   <label class="history-form-label">Refer To</label>
-                  <input
-                    ref=${referProviderInputRef}
-                    type="text"
-                    class="history-form-input"
-                    value=${referProviderQuery || referProviderDisplay}
-                    onInput=${handleReferProviderInput}
-                    placeholder="Search by name, specialty, or practice..."
-                  />
+                  <div class="refer-search-field">
+                    ${ICON_SEARCH}
+                    <input
+                      ref=${referProviderInputRef}
+                      type="text"
+                      class="history-form-input refer-search-input"
+                      value=${referProviderQuery || referProviderDisplay}
+                      onInput=${handleReferProviderInput}
+                      placeholder="Search providers..."
+                    />
+                  </div>
                   ${referProviderSearching && html`<span class="diag-search-spinner">Searching...</span>`}
                   ${referProviderResults.length > 0 && html`
                     <div class="history-search-dropdown">
@@ -1631,72 +1636,76 @@ export function OrderRow({ command, commandIndex, onEdit, onDelete, readOnly, pa
                     <div class="history-search-dropdown"><div class="history-search-result search-no-results">No providers found</div></div>
                   `}
                 </div>
-                <div class="history-form-field" style="position: relative;">
+                <div class="history-form-field">
                   <label class="history-form-label">Indications</label>
-                  <input
-                    ref=${referDiagInputRef}
-                    class="history-form-input"
-                    type="text"
-                    value=${referDiagQuery}
-                    onInput=${handleReferDiagInput}
-                    onFocus=${() => setReferDiagFocused(true)}
-                    onBlur=${() => setTimeout(() => setReferDiagFocused(false), 150)}
-                    placeholder="Search diagnoses..."
-                  />
-                  ${referDiagSearching && html`<span class="diag-search-spinner">Searching...</span>`}
-                  ${referDiagResults.length > 0 && html`
-                    <div class="history-search-dropdown">
-                      ${referDiagResults.map(d => html`
-                        <div key=${d.code} class="history-search-result" onMouseDown=${(e) => { e.preventDefault(); handleReferDiagSelect(d); }}>${d.formatted_code || d.code} — ${d.display}</div>
-                      `)}
-                    </div>
-                  `}
-                  ${!referDiagSearching && referDiagSearched && referDiagResults.length === 0 && referDiagQuery.length >= 2 && html`
-                    <div class="history-search-dropdown"><div class="history-search-result search-no-results">No diagnoses found</div></div>
-                  `}
-                  ${referDiagFocused && !referDiagQuery && referDiagSuggestions.length > 0 && html`
-                    <div class="history-search-dropdown">
-                      <div class="diag-suggestion-header">Patient conditions</div>
-                      ${referDiagSuggestions.map(d => html`
-                        <div key=${d.code} class="history-search-result" onMouseDown=${(e) => { e.preventDefault(); handleReferDiagSelect(d); }}>${d.formatted_code || d.code} — ${d.display}</div>
-                      `)}
-                    </div>
-                  `}
-                </div>
-                ${referDiagnoses.length > 0 && html`
-                  <div class="lab-selected-tests">
+                  <div class="refer-token-input" style="position: relative;" onClick=${() => referDiagInputRef.current && referDiagInputRef.current.focus()}>
+                    ${ICON_SEARCH}
                     ${referDiagnoses.map(d => html`
-                      <span class="lab-test-chip" key=${d.code}>
+                      <span class="refer-token-chip" key=${d.code}>
                         ${(d.formatted_code || d.code)}${d.display && d.display !== (d.formatted_code || d.code) ? ` — ${d.display}` : ''}
-                        <button type="button" class="lab-test-chip-remove" onClick=${() => handleReferDiagRemove(d.code)}>×</button>
+                        <button type="button" onClick=${(e) => { e.stopPropagation(); handleReferDiagRemove(d.code); }}>×</button>
                       </span>
                     `)}
+                    <input
+                      ref=${referDiagInputRef}
+                      type="text"
+                      value=${referDiagQuery}
+                      onInput=${handleReferDiagInput}
+                      onFocus=${() => setReferDiagFocused(true)}
+                      onBlur=${() => setTimeout(() => setReferDiagFocused(false), 150)}
+                      placeholder=${referDiagnoses.length ? '' : 'Search diagnoses...'}
+                    />
+                    ${referDiagSearching && html`<span class="diag-search-spinner">Searching...</span>`}
+                    ${referDiagResults.length > 0 && html`
+                      <div class="history-search-dropdown">
+                        ${referDiagResults.map(d => html`
+                          <div key=${d.code} class="history-search-result" onMouseDown=${(e) => { e.preventDefault(); handleReferDiagSelect(d); }}>${d.formatted_code || d.code} — ${d.display}</div>
+                        `)}
+                      </div>
+                    `}
+                    ${!referDiagSearching && referDiagSearched && referDiagResults.length === 0 && referDiagQuery.length >= 2 && html`
+                      <div class="history-search-dropdown"><div class="history-search-result search-no-results">No diagnoses found</div></div>
+                    `}
+                    ${referDiagFocused && !referDiagQuery && referDiagSuggestions.length > 0 && html`
+                      <div class="history-search-dropdown">
+                        <div class="diag-suggestion-header">Patient conditions</div>
+                        ${referDiagSuggestions.map(d => html`
+                          <div key=${d.code} class="history-search-result" onMouseDown=${(e) => { e.preventDefault(); handleReferDiagSelect(d); }}>${d.formatted_code || d.code} — ${d.display}</div>
+                        `)}
+                      </div>
+                    `}
                   </div>
-                `}
-                <div class="history-form-field">
-                  <label class="history-form-label">Clinical Question</label>
-                  <select class="history-form-input" value=${referClinicalQuestion} onChange=${(e) => setReferClinicalQuestion(e.target.value)}>
-                    <option value="">Select...</option>
-                    ${CLINICAL_QUESTIONS.map(q => html`
-                      <option key=${q} value=${q}>${q}</option>
-                    `)}
-                  </select>
                 </div>
-                <div class="history-form-field">
-                  <label class="history-form-label">Priority</label>
-                  <div class="allergy-severity">
-                    <button type="button" class="task-quick-btn${referPriority === 'Routine' ? ' active' : ''}" onClick=${() => setReferPriority('Routine')}>Routine</button>
-                    <button type="button" class="task-quick-btn${referPriority === 'Urgent' ? ' active' : ''}" onClick=${() => setReferPriority('Urgent')}>Urgent</button>
+                <div class="refer-grid2">
+                  <div class="history-form-field">
+                    <label class="history-form-label">Clinical Question</label>
+                    <select class="history-form-input" value=${referClinicalQuestion} onChange=${(e) => setReferClinicalQuestion(e.target.value)}>
+                      <option value="">Select...</option>
+                      ${CLINICAL_QUESTIONS.map(q => html`
+                        <option key=${q} value=${q}>${q}</option>
+                      `)}
+                    </select>
+                  </div>
+                  <div class="history-form-field">
+                    <label class="history-form-label">Priority</label>
+                    <div class="refer-priority">
+                      <button type="button" class="refer-pill${referPriority === 'Routine' ? ' active' : ''}" onClick=${() => setReferPriority(referPriority === 'Routine' ? '' : 'Routine')}>Routine</button>
+                      <button type="button" class="refer-pill${referPriority === 'Urgent' ? ' active' : ''}" onClick=${() => setReferPriority(referPriority === 'Urgent' ? '' : 'Urgent')}>Urgent</button>
+                    </div>
                   </div>
                 </div>
                 <div class="history-form-field">
                   <label class="history-form-label">Notes to Specialist</label>
-                  <textarea class="history-form-textarea" rows="3" value=${referNotesToSpecialist} onInput=${(e) => setReferNotesToSpecialist(e.target.value)} placeholder="Required" />
+                  <textarea class="history-form-textarea" rows="2" value=${referNotesToSpecialist} onInput=${(e) => setReferNotesToSpecialist(e.target.value)} placeholder="Required" />
                 </div>
-                <div class="history-form-field">
-                  <label class="history-form-label">Comment</label>
-                  <textarea class="history-form-textarea" rows="3" value=${referComment} onInput=${(e) => setReferComment(e.target.value)} placeholder="Optional" />
-                </div>
+                ${(referCommentOpen || referComment) ? html`
+                  <div class="history-form-field">
+                    <label class="history-form-label">Comment</label>
+                    <textarea class="history-form-textarea" rows="2" value=${referComment} onInput=${(e) => setReferComment(e.target.value)} placeholder="Optional" />
+                  </div>
+                ` : html`
+                  <button type="button" class="refer-add-comment" onClick=${() => setReferCommentOpen(true)}>+ Add comment</button>
+                `}
               </div>
             `}
             <div class="questionnaire-form-actions">
@@ -1780,16 +1789,24 @@ export function OrderRow({ command, commandIndex, onEdit, onDelete, readOnly, pa
 
   if (command.command_type === 'refer') {
     const d = command.data;
-    const detailParts = [];
-    if (d.clinical_question) detailParts.push(d.clinical_question);
-    if (d.priority) detailParts.push(d.priority);
-    if (d.notes_to_specialist) detailParts.push(d.notes_to_specialist);
+    const codes = d.diagnosis_codes || [];
+    const displays = d.diagnosis_displays || [];
+    const formatted = d.diagnosis_formatted || [];
+    const indications = codes.map((code, i) => {
+      const fmt = formatted[i] || code;
+      const name = displays[i] || '';
+      return name && name !== fmt ? `${name} (${fmt})` : fmt;
+    }).filter(Boolean);
+    const metaParts = [];
+    if (indications.length) metaParts.push(indications.join(', '));
+    if (d.notes_to_specialist) metaParts.push(d.notes_to_specialist);
+    const meta = metaParts.join(' · ');
     return html`
       <div class="order-row" onClick=${() => !readOnly && setEditing(true)}>
         <div class="order-view">
           <span class="command-type-label">Refer</span>
           <div class="order-view-name">${command.display || 'Referral'}</div>
-          ${detailParts.length > 0 && html`<div class="order-view-details">${detailParts.join(' · ')}</div>`}
+          ${meta && html`<div class="order-view-meta">${meta}</div>`}
         </div>
       </div>
     `;

--- a/hyperscribe/scribe/static/order-row.js
+++ b/hyperscribe/scribe/static/order-row.js
@@ -1622,6 +1622,7 @@ export function OrderRow({ command, commandIndex, onEdit, onDelete, readOnly, pa
                       class="history-form-input refer-search-input"
                       value=${referProviderQuery || referProviderDisplay}
                       onInput=${handleReferProviderInput}
+                      onBlur=${() => setTimeout(() => { setReferProviderResults([]); setReferProviderSearched(false); }, 150)}
                       placeholder="Search providers..."
                     />
                   </div>
@@ -1645,12 +1646,15 @@ export function OrderRow({ command, commandIndex, onEdit, onDelete, readOnly, pa
                     <label class="history-form-label">Indications</label>
                     <div class="refer-token-input" style="position: relative;" onClick=${() => referDiagInputRef.current && referDiagInputRef.current.focus()}>
                       ${ICON_SEARCH}
-                      ${referDiagnoses.map(d => html`
-                        <span class="refer-token-chip" key=${d.code}>
-                          ${(d.formatted_code || d.code)}${d.display && d.display !== (d.formatted_code || d.code) ? ` — ${d.display}` : ''}
-                          <button type="button" onClick=${(e) => { e.stopPropagation(); handleReferDiagRemove(d.code); }}>×</button>
-                        </span>
-                      `)}
+                      ${referDiagnoses.map(d => {
+                        const label = (d.formatted_code || d.code) + (d.display && d.display !== (d.formatted_code || d.code) ? ` — ${d.display}` : '');
+                        return html`
+                          <span class="refer-token-chip" key=${d.code} title=${label}>
+                            <span class="refer-token-text">${label}</span>
+                            <button type="button" onClick=${(e) => { e.stopPropagation(); handleReferDiagRemove(d.code); }}>×</button>
+                          </span>
+                        `;
+                      })}
                       <input
                         ref=${referDiagInputRef}
                         type="text"

--- a/hyperscribe/scribe/static/order-row.js
+++ b/hyperscribe/scribe/static/order-row.js
@@ -972,6 +972,8 @@ export function OrderRow({ command, commandIndex, onEdit, onDelete, readOnly, pa
   };
 
   const handleReferDiagSelect = (diag) => {
+    // cap indications at 2 so the field stays a single fixed-size line
+    if (referDiagnoses.length >= 2 || referDiagnoses.some(d => d.code === diag.code)) return;
     setReferDiagnoses([...referDiagnoses, diag]);
     setReferDiagQuery('');
     setReferDiagResults([]);
@@ -1655,15 +1657,17 @@ export function OrderRow({ command, commandIndex, onEdit, onDelete, readOnly, pa
                           </span>
                         `;
                       })}
-                      <input
-                        ref=${referDiagInputRef}
-                        type="text"
-                        value=${referDiagQuery}
-                        onInput=${handleReferDiagInput}
-                        onFocus=${() => setReferDiagFocused(true)}
-                        onBlur=${() => setTimeout(() => setReferDiagFocused(false), 150)}
-                        placeholder=${referDiagnoses.length ? '' : 'Search diagnoses...'}
-                      />
+                      ${referDiagnoses.length < 2 && html`
+                        <input
+                          ref=${referDiagInputRef}
+                          type="text"
+                          value=${referDiagQuery}
+                          onInput=${handleReferDiagInput}
+                          onFocus=${() => setReferDiagFocused(true)}
+                          onBlur=${() => setTimeout(() => setReferDiagFocused(false), 150)}
+                          placeholder=${referDiagnoses.length ? '' : 'Search diagnoses...'}
+                        />
+                      `}
                       ${referDiagSearching && html`<span class="diag-search-spinner">Searching...</span>`}
                       ${referDiagResults.length > 0 && html`
                         <div class="history-search-dropdown">

--- a/hyperscribe/scribe/static/order-row.js
+++ b/hyperscribe/scribe/static/order-row.js
@@ -1614,34 +1614,40 @@ export function OrderRow({ command, commandIndex, onEdit, onDelete, readOnly, pa
             `}
             ${activeTab === 'refer' && html`
               <div class="order-form">
-                <div class="history-form-field" style="position: relative;">
+                <div class="history-form-field">
                   <label class="history-form-label">Refer To</label>
-                  <div class="refer-search-field">
+                  <div class="refer-token-input" style="position: relative;" onClick=${() => referProviderInputRef.current && referProviderInputRef.current.focus()}>
                     ${ICON_SEARCH}
-                    <input
-                      ref=${referProviderInputRef}
-                      type="text"
-                      class="history-form-input refer-search-input"
-                      value=${referProviderQuery || referProviderDisplay}
-                      onInput=${handleReferProviderInput}
-                      onBlur=${() => setTimeout(() => { setReferProviderResults([]); setReferProviderSearched(false); }, 150)}
-                      placeholder="Search providers..."
-                    />
+                    ${referProviderDisplay ? html`
+                      <span class="refer-token-chip" title=${referProviderDisplay}>
+                        <span class="refer-token-text">${referProviderDisplay}</span>
+                        <button type="button" onClick=${(e) => { e.stopPropagation(); setReferProvider(null); setReferProviderDisplay(''); setReferProviderQuery(''); }}>×</button>
+                      </span>
+                    ` : html`
+                      <input
+                        ref=${referProviderInputRef}
+                        type="text"
+                        value=${referProviderQuery}
+                        onInput=${handleReferProviderInput}
+                        onBlur=${() => setTimeout(() => { setReferProviderResults([]); setReferProviderSearched(false); }, 150)}
+                        placeholder="Search providers..."
+                      />
+                    `}
+                    ${referProviderSearching && html`<span class="diag-search-spinner">Searching...</span>`}
+                    ${referProviderResults.length > 0 && html`
+                      <div class="history-search-dropdown">
+                        ${referProviderResults.map((r, i) => html`
+                          <div key=${i} class="history-search-result" onMouseDown=${(e) => { e.preventDefault(); handleReferProviderSelect(r); }}>
+                            <div style="font-weight:600">${r.name}</div>
+                            ${r.description && html`<div style="font-size:12px;color:#888">${r.description}</div>`}
+                          </div>
+                        `)}
+                      </div>
+                    `}
+                    ${!referProviderSearching && referProviderSearched && referProviderResults.length === 0 && referProviderQuery.length >= 2 && html`
+                      <div class="history-search-dropdown"><div class="history-search-result search-no-results">No providers found</div></div>
+                    `}
                   </div>
-                  ${referProviderSearching && html`<span class="diag-search-spinner">Searching...</span>`}
-                  ${referProviderResults.length > 0 && html`
-                    <div class="history-search-dropdown">
-                      ${referProviderResults.map((r, i) => html`
-                        <div key=${i} class="history-search-result" onMouseDown=${(e) => { e.preventDefault(); handleReferProviderSelect(r); }}>
-                          <div style="font-weight:600">${r.name}</div>
-                          ${r.description && html`<div style="font-size:12px;color:#888">${r.description}</div>`}
-                        </div>
-                      `)}
-                    </div>
-                  `}
-                  ${!referProviderSearching && referProviderSearched && referProviderResults.length === 0 && referProviderQuery.length >= 2 && html`
-                    <div class="history-search-dropdown"><div class="history-search-result search-no-results">No providers found</div></div>
-                  `}
                 </div>
                 <div class="refer-grid2">
                   <div class="history-form-field">

--- a/hyperscribe/scribe/static/order-row.js
+++ b/hyperscribe/scribe/static/order-row.js
@@ -288,7 +288,7 @@ function InteractionWarningInline({ warning }) {
   `;
 }
 
-export function OrderRow({ command, commandIndex, onEdit, onDelete, readOnly, patientId, noteId, staffId, staffName, isRecommendation, onEditingChange }) {
+export function OrderRow({ command, commandIndex, onEdit, onDelete, readOnly, patientId, noteId, staffId, staffName, noteDiagnoses = [], isRecommendation, onEditingChange }) {
   const isNew = !command.display;
   const [editing, setEditing] = useState(isNew);
   useEffect(() => {
@@ -933,8 +933,6 @@ export function OrderRow({ command, commandIndex, onEdit, onDelete, readOnly, pa
   const handleReferProviderInput = (e) => {
     const val = e.target.value;
     setReferProviderQuery(val);
-    setReferProvider(null);
-    setReferProviderDisplay(val);
     debouncedReferProviderSearch(val);
   };
 
@@ -988,10 +986,32 @@ export function OrderRow({ command, commandIndex, onEdit, onDelete, readOnly, pa
     setReferDiagnoses(referDiagnoses.filter(d => d.code !== code));
   };
 
+  // Tolerant ICD-10 code key so the same diagnosis from different sources
+  // (chart conditions, live search, staged note dx) dedups regardless of dot
+  // formatting or case.
+  const normDiagCode = (c) => (c || '').replace(/[^a-z0-9]/gi, '').toUpperCase();
+
+  // Diagnoses staged in this note's A&P, shown first as the most relevant
+  // indications. Excludes anything already selected as a chip.
+  const noteDiagSuggestions = (() => {
+    if (referDiagQuery || !noteDiagnoses || noteDiagnoses.length === 0) return [];
+    const selected = new Set(referDiagnoses.map(d => normDiagCode(d.code)));
+    const seen = new Set();
+    return noteDiagnoses.filter(d => {
+      const key = normDiagCode(d.code);
+      if (!key || selected.has(key) || seen.has(key)) return false;
+      seen.add(key);
+      return true;
+    });
+  })();
+
   const referDiagSuggestions = (() => {
     if (!referDiagQuery && patientConditions.length > 0) {
-      const alreadySelected = new Set(referDiagnoses.map(d => d.code));
-      return patientConditions.filter(c => !alreadySelected.has(c.code));
+      const alreadySelected = new Set(referDiagnoses.map(d => normDiagCode(d.code)));
+      // Suppress chart conditions already surfaced under "From this note".
+      const noteCodes = new Set(noteDiagSuggestions.map(d => normDiagCode(d.code)));
+      return patientConditions.filter(c =>
+        !alreadySelected.has(normDiagCode(c.code)) && !noteCodes.has(normDiagCode(c.code)));
     }
     return [];
   })();
@@ -1685,12 +1705,20 @@ export function OrderRow({ command, commandIndex, onEdit, onDelete, readOnly, pa
                       ${!referDiagSearching && referDiagSearched && referDiagResults.length === 0 && referDiagQuery.length >= 2 && html`
                         <div class="history-search-dropdown"><div class="history-search-result search-no-results">No diagnoses found</div></div>
                       `}
-                      ${referDiagFocused && !referDiagQuery && referDiagSuggestions.length > 0 && html`
+                      ${referDiagFocused && !referDiagQuery && (noteDiagSuggestions.length > 0 || referDiagSuggestions.length > 0) && html`
                         <div class="history-search-dropdown">
-                          <div class="diag-suggestion-header">Patient conditions</div>
-                          ${referDiagSuggestions.map(d => html`
-                            <div key=${d.code} class="history-search-result" onMouseDown=${(e) => { e.preventDefault(); handleReferDiagSelect(d); }}>${d.formatted_code || d.code} — ${d.display}</div>
-                          `)}
+                          ${noteDiagSuggestions.length > 0 && html`
+                            <div class="diag-suggestion-header">From this note</div>
+                            ${noteDiagSuggestions.map(d => html`
+                              <div key=${`note-${d.code}`} class="history-search-result" onMouseDown=${(e) => { e.preventDefault(); handleReferDiagSelect(d); }}>${d.formatted_code || d.code} — ${d.display}</div>
+                            `)}
+                          `}
+                          ${referDiagSuggestions.length > 0 && html`
+                            <div class="diag-suggestion-header">Patient conditions</div>
+                            ${referDiagSuggestions.map(d => html`
+                              <div key=${`cond-${d.code}`} class="history-search-result" onMouseDown=${(e) => { e.preventDefault(); handleReferDiagSelect(d); }}>${d.formatted_code || d.code} — ${d.display}</div>
+                            `)}
+                          `}
                         </div>
                       `}
                     </div>
@@ -1821,16 +1849,14 @@ export function OrderRow({ command, commandIndex, onEdit, onDelete, readOnly, pa
       const name = displays[i] || '';
       return name && name !== fmt ? `${name} (${fmt})` : fmt;
     }).filter(Boolean);
-    const metaParts = [];
-    if (indications.length) metaParts.push(indications.join(', '));
-    if (d.notes_to_specialist) metaParts.push(d.notes_to_specialist);
-    const meta = metaParts.join(' · ');
+    const indicationsLine = indications.join(', ');
     return html`
       <div class="order-row" onClick=${() => !readOnly && setEditing(true)}>
         <div class="order-view">
           <span class="command-type-label">Refer</span>
           <div class="order-view-name">${command.display || 'Referral'}</div>
-          ${meta && html`<div class="order-view-meta">${meta}</div>`}
+          ${indicationsLine && html`<div class="order-view-meta">${indicationsLine}</div>`}
+          ${d.notes_to_specialist && html`<div class="order-view-meta">${d.notes_to_specialist}</div>`}
         </div>
       </div>
     `;

--- a/hyperscribe/scribe/static/order-row.js
+++ b/hyperscribe/scribe/static/order-row.js
@@ -975,7 +975,10 @@ export function OrderRow({ command, commandIndex, onEdit, onDelete, readOnly, pa
     setReferDiagQuery('');
     setReferDiagResults([]);
     setReferDiagSearched(false);
-    if (referDiagInputRef.current) referDiagInputRef.current.focus({ preventScroll: true });
+    // Close the dropdown after a selection; the provider can click back into
+    // the field to search for another indication.
+    setReferDiagFocused(false);
+    if (referDiagInputRef.current) referDiagInputRef.current.blur();
   };
 
   const handleReferDiagRemove = (code) => {

--- a/hyperscribe/scribe/static/order-row.js
+++ b/hyperscribe/scribe/static/order-row.js
@@ -1667,7 +1667,7 @@ export function OrderRow({ command, commandIndex, onEdit, onDelete, readOnly, pa
                   <div class="lab-selected-tests">
                     ${referDiagnoses.map(d => html`
                       <span class="lab-test-chip" key=${d.code}>
-                        ${d.formatted_code || d.code}
+                        ${(d.formatted_code || d.code)}${d.display && d.display !== (d.formatted_code || d.code) ? ` — ${d.display}` : ''}
                         <button type="button" class="lab-test-chip-remove" onClick=${() => handleReferDiagRemove(d.code)}>×</button>
                       </span>
                     `)}

--- a/hyperscribe/scribe/static/order-row.js
+++ b/hyperscribe/scribe/static/order-row.js
@@ -631,6 +631,7 @@ export function OrderRow({ command, commandIndex, onEdit, onDelete, readOnly, pa
   const [referNotesToSpecialist, setReferNotesToSpecialist] = useState(command.data.notes_to_specialist || '');
   const [referComment, setReferComment] = useState(command.data.comment || '');
   const [referCommentOpen, setReferCommentOpen] = useState(!!(command.data.comment));
+  const [referPriorityOpen, setReferPriorityOpen] = useState(!!(command.data.priority));
   const referProviderInputRef = useRef(null);
   const referDiagInputRef = useRef(null);
 
@@ -1639,47 +1640,47 @@ export function OrderRow({ command, commandIndex, onEdit, onDelete, readOnly, pa
                     <div class="history-search-dropdown"><div class="history-search-result search-no-results">No providers found</div></div>
                   `}
                 </div>
-                <div class="history-form-field">
-                  <label class="history-form-label">Indications</label>
-                  <div class="refer-token-input" style="position: relative;" onClick=${() => referDiagInputRef.current && referDiagInputRef.current.focus()}>
-                    ${ICON_SEARCH}
-                    ${referDiagnoses.map(d => html`
-                      <span class="refer-token-chip" key=${d.code}>
-                        ${(d.formatted_code || d.code)}${d.display && d.display !== (d.formatted_code || d.code) ? ` — ${d.display}` : ''}
-                        <button type="button" onClick=${(e) => { e.stopPropagation(); handleReferDiagRemove(d.code); }}>×</button>
-                      </span>
-                    `)}
-                    <input
-                      ref=${referDiagInputRef}
-                      type="text"
-                      value=${referDiagQuery}
-                      onInput=${handleReferDiagInput}
-                      onFocus=${() => setReferDiagFocused(true)}
-                      onBlur=${() => setTimeout(() => setReferDiagFocused(false), 150)}
-                      placeholder=${referDiagnoses.length ? '' : 'Search diagnoses...'}
-                    />
-                    ${referDiagSearching && html`<span class="diag-search-spinner">Searching...</span>`}
-                    ${referDiagResults.length > 0 && html`
-                      <div class="history-search-dropdown">
-                        ${referDiagResults.map(d => html`
-                          <div key=${d.code} class="history-search-result" onMouseDown=${(e) => { e.preventDefault(); handleReferDiagSelect(d); }}>${d.formatted_code || d.code} — ${d.display}</div>
-                        `)}
-                      </div>
-                    `}
-                    ${!referDiagSearching && referDiagSearched && referDiagResults.length === 0 && referDiagQuery.length >= 2 && html`
-                      <div class="history-search-dropdown"><div class="history-search-result search-no-results">No diagnoses found</div></div>
-                    `}
-                    ${referDiagFocused && !referDiagQuery && referDiagSuggestions.length > 0 && html`
-                      <div class="history-search-dropdown">
-                        <div class="diag-suggestion-header">Patient conditions</div>
-                        ${referDiagSuggestions.map(d => html`
-                          <div key=${d.code} class="history-search-result" onMouseDown=${(e) => { e.preventDefault(); handleReferDiagSelect(d); }}>${d.formatted_code || d.code} — ${d.display}</div>
-                        `)}
-                      </div>
-                    `}
-                  </div>
-                </div>
                 <div class="refer-grid2">
+                  <div class="history-form-field">
+                    <label class="history-form-label">Indications</label>
+                    <div class="refer-token-input" style="position: relative;" onClick=${() => referDiagInputRef.current && referDiagInputRef.current.focus()}>
+                      ${ICON_SEARCH}
+                      ${referDiagnoses.map(d => html`
+                        <span class="refer-token-chip" key=${d.code}>
+                          ${(d.formatted_code || d.code)}${d.display && d.display !== (d.formatted_code || d.code) ? ` — ${d.display}` : ''}
+                          <button type="button" onClick=${(e) => { e.stopPropagation(); handleReferDiagRemove(d.code); }}>×</button>
+                        </span>
+                      `)}
+                      <input
+                        ref=${referDiagInputRef}
+                        type="text"
+                        value=${referDiagQuery}
+                        onInput=${handleReferDiagInput}
+                        onFocus=${() => setReferDiagFocused(true)}
+                        onBlur=${() => setTimeout(() => setReferDiagFocused(false), 150)}
+                        placeholder=${referDiagnoses.length ? '' : 'Search diagnoses...'}
+                      />
+                      ${referDiagSearching && html`<span class="diag-search-spinner">Searching...</span>`}
+                      ${referDiagResults.length > 0 && html`
+                        <div class="history-search-dropdown">
+                          ${referDiagResults.map(d => html`
+                            <div key=${d.code} class="history-search-result" onMouseDown=${(e) => { e.preventDefault(); handleReferDiagSelect(d); }}>${d.formatted_code || d.code} — ${d.display}</div>
+                          `)}
+                        </div>
+                      `}
+                      ${!referDiagSearching && referDiagSearched && referDiagResults.length === 0 && referDiagQuery.length >= 2 && html`
+                        <div class="history-search-dropdown"><div class="history-search-result search-no-results">No diagnoses found</div></div>
+                      `}
+                      ${referDiagFocused && !referDiagQuery && referDiagSuggestions.length > 0 && html`
+                        <div class="history-search-dropdown">
+                          <div class="diag-suggestion-header">Patient conditions</div>
+                          ${referDiagSuggestions.map(d => html`
+                            <div key=${d.code} class="history-search-result" onMouseDown=${(e) => { e.preventDefault(); handleReferDiagSelect(d); }}>${d.formatted_code || d.code} — ${d.display}</div>
+                          `)}
+                        </div>
+                      `}
+                    </div>
+                  </div>
                   <div class="history-form-field">
                     <label class="history-form-label">Clinical Question</label>
                     <select class="history-form-input" value=${referClinicalQuestion} onChange=${(e) => setReferClinicalQuestion(e.target.value)}>
@@ -1689,6 +1690,12 @@ export function OrderRow({ command, commandIndex, onEdit, onDelete, readOnly, pa
                       `)}
                     </select>
                   </div>
+                </div>
+                <div class="history-form-field">
+                  <label class="history-form-label">Notes to Specialist</label>
+                  <textarea class="history-form-textarea" rows="2" value=${referNotesToSpecialist} onInput=${(e) => setReferNotesToSpecialist(e.target.value)} placeholder="Required" />
+                </div>
+                ${(referPriorityOpen || referPriority) && html`
                   <div class="history-form-field">
                     <label class="history-form-label">Priority</label>
                     <div class="refer-priority">
@@ -1696,18 +1703,18 @@ export function OrderRow({ command, commandIndex, onEdit, onDelete, readOnly, pa
                       <button type="button" class="refer-pill${referPriority === 'Urgent' ? ' active' : ''}" onClick=${() => setReferPriority(referPriority === 'Urgent' ? '' : 'Urgent')}>Urgent</button>
                     </div>
                   </div>
-                </div>
-                <div class="history-form-field">
-                  <label class="history-form-label">Notes to Specialist</label>
-                  <textarea class="history-form-textarea" rows="2" value=${referNotesToSpecialist} onInput=${(e) => setReferNotesToSpecialist(e.target.value)} placeholder="Required" />
-                </div>
-                ${(referCommentOpen || referComment) ? html`
+                `}
+                ${(referCommentOpen || referComment) && html`
                   <div class="history-form-field">
                     <label class="history-form-label">Comment</label>
                     <textarea class="history-form-textarea" rows="2" value=${referComment} onInput=${(e) => setReferComment(e.target.value)} placeholder="Optional" />
                   </div>
-                ` : html`
-                  <button type="button" class="refer-add-comment" onClick=${() => setReferCommentOpen(true)}>+ Add comment</button>
+                `}
+                ${(!(referPriorityOpen || referPriority) || !(referCommentOpen || referComment)) && html`
+                  <div class="refer-disclosures">
+                    ${!(referPriorityOpen || referPriority) && html`<button type="button" class="refer-add-pill" onClick=${() => setReferPriorityOpen(true)}>+ Add priority</button>`}
+                    ${!(referCommentOpen || referComment) && html`<button type="button" class="refer-add-pill" onClick=${() => setReferCommentOpen(true)}>+ Add comment</button>`}
+                  </div>
                 `}
               </div>
             `}

--- a/hyperscribe/scribe/static/order-row.js
+++ b/hyperscribe/scribe/static/order-row.js
@@ -232,11 +232,9 @@ function buildDisplay(type, data) {
     return parts.join(' | ') || '';
   }
   if (type === 'refer') {
-    const parts = [];
-    if (data.refer_to_display) parts.push(data.refer_to_display);
-    if (data.clinical_question) parts.push(data.clinical_question);
-    if (data.priority) parts.push(data.priority);
-    return parts.join(' | ') || '';
+    // Headline is the specialty only; clinical_question / priority belong on the
+    // detail line, not the collapsed headline.
+    return data.refer_to_display || '';
   }
   return '';
 }
@@ -628,7 +626,7 @@ export function OrderRow({ command, commandIndex, onEdit, onDelete, readOnly, pa
   const [referDiagSearched, setReferDiagSearched] = useState(false);
   const [referDiagFocused, setReferDiagFocused] = useState(false);
   const [referClinicalQuestion, setReferClinicalQuestion] = useState(command.data.clinical_question || '');
-  const [referPriority, setReferPriority] = useState(command.data.priority || 'Routine');
+  const [referPriority, setReferPriority] = useState(command.data.priority || '');
   const [referNotesToSpecialist, setReferNotesToSpecialist] = useState(command.data.notes_to_specialist || '');
   const [referComment, setReferComment] = useState(command.data.comment || '');
   const referProviderInputRef = useRef(null);
@@ -1126,7 +1124,7 @@ export function OrderRow({ command, commandIndex, onEdit, onDelete, readOnly, pa
         diagnosis_displays: referDiagnoses.map(d => d.display),
         diagnosis_formatted: referDiagnoses.map(d => d.formatted_code || d.code),
         clinical_question: referClinicalQuestion || null,
-        priority: referPriority || 'Routine',
+        priority: referPriority || null,
         notes_to_specialist: referNotesToSpecialist || null,
         comment: referComment || null,
       };

--- a/hyperscribe/scribe/static/soap-group.js
+++ b/hyperscribe/scribe/static/soap-group.js
@@ -647,7 +647,7 @@ function AddConditionSearch({ onAdd, patientId }) {
   `;
 }
 
-export function SoapGroup({ title, groupColor, sections, commandBySectionKey, onEditCommand, onDeleteCommand, adHocCommands, assignees, onAddTask, onAddOrder, onAddPlan, onAddVitals, onAddMedication, onAddAllergy, onAddStopMedication, onAddRemoveAllergy, onAddResolveCondition, onAddHistory, onAddQuestionnaire, onAddCharge, readOnly, isAmending = false, sectionConditions, patientId, noteId, staffId, staffName, recommendations, onEditRecommendation, onDeleteRecommendation, onAcceptRecommendation, onRejectRecommendation, onAddCondition, unmatchedConditions, diagnosisSuggestions, onAddNow, hideRejected, alertFacilityEnabled, onEditingChange, questionnaireScores, chargeMatrixDiagnoses = [], chargeMatrixCharges = [], searchCharges = () => {}, suggestedCharges = [], onToggleChargePointer = () => {}, onReorderDiagnoses = () => {}, onAddChargeModifier = () => {}, onRemoveChargeModifier = () => {}, onSetChargeComment = () => {}, onClearChargeComment = () => {}, onRemoveChargeByUuid = () => {}, examTemplates, onCarryForwardExam }) {
+export function SoapGroup({ title, groupColor, sections, commandBySectionKey, onEditCommand, onDeleteCommand, adHocCommands, assignees, onAddTask, onAddOrder, onAddPlan, onAddVitals, onAddMedication, onAddAllergy, onAddStopMedication, onAddRemoveAllergy, onAddResolveCondition, onAddHistory, onAddQuestionnaire, onAddCharge, readOnly, isAmending = false, sectionConditions, patientId, noteId, staffId, staffName, recommendations, onEditRecommendation, onDeleteRecommendation, onAcceptRecommendation, onRejectRecommendation, onAddCondition, unmatchedConditions, diagnosisSuggestions, noteDiagnoses = [], onAddNow, hideRejected, alertFacilityEnabled, onEditingChange, questionnaireScores, chargeMatrixDiagnoses = [], chargeMatrixCharges = [], searchCharges = () => {}, suggestedCharges = [], onToggleChargePointer = () => {}, onReorderDiagnoses = () => {}, onAddChargeModifier = () => {}, onRemoveChargeModifier = () => {}, onSetChargeComment = () => {}, onClearChargeComment = () => {}, onRemoveChargeByUuid = () => {}, examTemplates, onCarryForwardExam }) {
   const isCharges = title === 'CHARGES';
   const coveredKeys = getCoveredKeys(commandBySectionKey);
 
@@ -1352,6 +1352,7 @@ export function SoapGroup({ title, groupColor, sections, commandBySectionKey, on
                     noteId=${noteId}
                     staffId=${staffId}
                     staffName=${staffName}
+                    noteDiagnoses=${noteDiagnoses}
                     onEditingChange=${onEditingChange}
                   />
                 </div>
@@ -1510,6 +1511,7 @@ export function SoapGroup({ title, groupColor, sections, commandBySectionKey, on
                       noteId=${noteId}
                       staffId=${staffId}
                       staffName=${staffName}
+                      noteDiagnoses=${noteDiagnoses}
                       isRecommendation=${true}
                       onEditingChange=${onEditingChange}
                     />
@@ -1569,6 +1571,7 @@ export function SoapGroup({ title, groupColor, sections, commandBySectionKey, on
                       noteId=${noteId}
                       staffId=${staffId}
                       staffName=${staffName}
+                      noteDiagnoses=${noteDiagnoses}
                       isRecommendation=${true}
                       onEditingChange=${onEditingChange}
                     />

--- a/hyperscribe/scribe/static/styles.css
+++ b/hyperscribe/scribe/static/styles.css
@@ -821,6 +821,30 @@ h2 { margin-bottom: 4px; }
 .lab-test-chip { display: inline-flex; align-items: center; gap: 8px; background: #e8e7f8; color: #3b3a8e; font-size: 14px; padding: 8px 14px; border-radius: 8px; }
 .lab-test-chip-remove { background: none; border: none; color: #3b3a8e; font-size: 18px; cursor: pointer; padding: 0 2px; line-height: 1; }
 .lab-test-chip-remove:active { color: #d32f2f; }
+
+/* ── Referral card (collapsed meta + expanded form) ── */
+.order-view-meta { font-size: 13px; color: #6b7280; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; max-width: 100%; }
+
+.refer-search-field { position: relative; }
+.refer-search-field .refer-search-icon { position: absolute; left: 11px; top: 50%; transform: translateY(-50%); width: 16px; height: 16px; color: #9aa1ad; pointer-events: none; }
+.refer-search-input { padding-left: 34px; }
+
+.refer-token-input { display: flex; flex-wrap: wrap; align-items: center; gap: 6px; width: 100%; min-height: 40px; padding: 5px 8px 5px 30px; border: 1px solid #ddd; border-radius: 6px; background: #fff; box-sizing: border-box; cursor: text; }
+.refer-token-input:focus-within { border-color: #aab2bd; box-shadow: 0 0 0 3px rgba(5, 43, 73, 0.08); }
+.refer-token-input > .refer-search-icon { position: absolute; left: 9px; top: 12px; width: 15px; height: 15px; color: #9aa1ad; pointer-events: none; }
+.refer-token-input input { flex: 1; min-width: 130px; border: none; outline: none; font-family: inherit; font-size: 14px; padding: 4px 2px; background: transparent; color: #333; }
+.refer-token-chip { display: inline-flex; align-items: center; gap: 7px; background: #eef0f4; color: #3a475c; font-size: 12.5px; padding: 4px 6px 4px 10px; border-radius: 6px; }
+.refer-token-chip button { background: none; border: none; color: #98a1ad; font-size: 15px; line-height: 1; cursor: pointer; padding: 0; }
+.refer-token-chip button:active { color: #dc2626; }
+
+.refer-grid2 { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; align-items: start; }
+
+.refer-priority { display: inline-flex; gap: 8px; }
+.refer-pill { border: 1.5px solid #d6dae1; border-radius: 6px; padding: 8px 18px; font-family: inherit; font-size: 13px; font-weight: 600; color: #5b6678; background: #fff; cursor: pointer; transition: all 0.12s; }
+.refer-pill.active { background: #eef0f4; border-color: #aab2bd; color: #1f2733; }
+
+.refer-add-comment { display: inline-flex; align-items: center; gap: 6px; font-family: inherit; font-size: 13px; font-weight: 600; color: #052B49; background: none; border: none; padding: 0; cursor: pointer; align-self: flex-start; }
+
 .diag-search-wrapper { position: relative; flex: 1; min-width: 0; }
 .diag-search-spinner { font-size: 12px; color: #888; font-style: italic; margin-top: 2px; display: block; }
 .diag-search-dropdown { position: absolute; top: 100%; left: 0; right: 0; z-index: 10; background: #fff; border: 1px solid #ddd; border-radius: 4px; box-shadow: 0 4px 12px rgba(0,0,0,0.1); max-height: 200px; overflow-y: auto; margin-top: 2px; }

--- a/hyperscribe/scribe/static/styles.css
+++ b/hyperscribe/scribe/static/styles.css
@@ -843,12 +843,15 @@ select.history-form-input {
 .refer-token-input:focus-within { border-color: #aab2bd; box-shadow: 0 0 0 3px rgba(5, 43, 73, 0.08); }
 .refer-token-input > .refer-search-icon { position: absolute; left: 11px; top: 50%; transform: translateY(-50%); width: 16px; height: 16px; color: #9aa1ad; pointer-events: none; }
 .refer-token-input input { flex: 1; min-width: 60px; border: none; outline: none; font-family: inherit; font-size: 14px; padding: 0; background: transparent; color: #333; }
-.refer-token-chip { display: inline-flex; align-items: center; gap: 6px; min-width: 0; background: #eef0f4; color: #3a475c; font-size: 12.5px; padding: 4px 6px 4px 10px; border-radius: 6px; }
+.refer-token-chip { flex: 0 1 auto; display: inline-flex; align-items: center; gap: 6px; min-width: 0; background: #eef0f4; color: #3a475c; font-size: 12.5px; padding: 4px 6px 4px 10px; border-radius: 6px; }
 .refer-token-text { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0; }
 .refer-token-chip button { flex: none; background: none; border: none; color: #98a1ad; font-size: 15px; line-height: 1; cursor: pointer; padding: 0; }
 .refer-token-chip button:active { color: #dc2626; }
 
 .refer-grid2 { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; align-items: start; }
+/* grid items default to min-width:auto and would expand past their track to fit
+   wide chips — pin them to 0 so the column stays 1fr and the field never grows */
+.refer-grid2 > .history-form-field { min-width: 0; }
 /* normalize the select height so the priority pills can match it exactly */
 .refer-grid2 .history-form-input { box-sizing: border-box; height: 40px; }
 

--- a/hyperscribe/scribe/static/styles.css
+++ b/hyperscribe/scribe/static/styles.css
@@ -850,10 +850,10 @@ select.history-form-input {
 /* normalize the select height so the priority pills can match it exactly */
 .refer-grid2 .history-form-input { box-sizing: border-box; height: 40px; }
 
-.refer-priority { display: flex; gap: 8px; }
-.refer-pill { flex: 1; box-sizing: border-box; height: 40px; display: inline-flex; align-items: center; justify-content: center; border: 1px solid #d6dae1; border-radius: 6px; padding: 0 14px; font-family: inherit; font-size: 13px; font-weight: 600; color: #5b6678; background: #fff; cursor: pointer; transition: all 0.12s; }
-.refer-pill:hover { border-color: #aab2bd; }
-.refer-pill.active { background: #eef0f4; border-color: #aab2bd; color: #1f2733; }
+/* Priority — segmented toggle: connected track, sliding white selection; unset = neither */
+.refer-priority { display: flex; box-sizing: border-box; height: 40px; gap: 2px; padding: 3px; background: #eef0f4; border-radius: 6px; }
+.refer-pill { flex: 1; border: none; background: transparent; border-radius: 4px; font-family: inherit; font-size: 13px; font-weight: 600; color: #6b7280; cursor: pointer; transition: all 0.12s; }
+.refer-pill.active { background: #fff; color: #1f2733; box-shadow: 0 1px 2px rgba(16, 24, 40, 0.18); }
 
 .refer-add-comment { display: inline-flex; align-items: center; gap: 6px; font-family: inherit; font-size: 13px; font-weight: 600; color: #052B49; background: none; border: none; padding: 0; cursor: pointer; align-self: flex-start; }
 

--- a/hyperscribe/scribe/static/styles.css
+++ b/hyperscribe/scribe/static/styles.css
@@ -827,7 +827,16 @@ h2 { margin-bottom: 4px; }
 
 .refer-search-field { position: relative; }
 .refer-search-field .refer-search-icon { position: absolute; left: 11px; top: 50%; transform: translateY(-50%); width: 16px; height: 16px; color: #9aa1ad; pointer-events: none; }
-.refer-search-input { padding-left: 34px; }
+/* higher specificity than .history-form-input so the icon padding isn't reset by its `padding` shorthand */
+.refer-search-field .refer-search-input { padding-left: 36px; }
+
+/* Clean chevron for selects (replaces the default OS caret) */
+select.history-form-input {
+  -webkit-appearance: none; appearance: none;
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis; padding-right: 34px;
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='%236b7280' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'><path d='M6 9l6 6 6-6'/></svg>");
+  background-repeat: no-repeat; background-position: right 12px center;
+}
 
 .refer-token-input { display: flex; flex-wrap: wrap; align-items: center; gap: 6px; width: 100%; min-height: 40px; padding: 5px 8px 5px 30px; border: 1px solid #ddd; border-radius: 6px; background: #fff; box-sizing: border-box; cursor: text; }
 .refer-token-input:focus-within { border-color: #aab2bd; box-shadow: 0 0 0 3px rgba(5, 43, 73, 0.08); }
@@ -838,9 +847,12 @@ h2 { margin-bottom: 4px; }
 .refer-token-chip button:active { color: #dc2626; }
 
 .refer-grid2 { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; align-items: start; }
+/* normalize the select height so the priority pills can match it exactly */
+.refer-grid2 .history-form-input { box-sizing: border-box; height: 40px; }
 
-.refer-priority { display: inline-flex; gap: 8px; }
-.refer-pill { border: 1.5px solid #d6dae1; border-radius: 6px; padding: 8px 18px; font-family: inherit; font-size: 13px; font-weight: 600; color: #5b6678; background: #fff; cursor: pointer; transition: all 0.12s; }
+.refer-priority { display: flex; gap: 8px; }
+.refer-pill { flex: 1; box-sizing: border-box; height: 40px; display: inline-flex; align-items: center; justify-content: center; border: 1px solid #d6dae1; border-radius: 6px; padding: 0 14px; font-family: inherit; font-size: 13px; font-weight: 600; color: #5b6678; background: #fff; cursor: pointer; transition: all 0.12s; }
+.refer-pill:hover { border-color: #aab2bd; }
 .refer-pill.active { background: #eef0f4; border-color: #aab2bd; color: #1f2733; }
 
 .refer-add-comment { display: inline-flex; align-items: center; gap: 6px; font-family: inherit; font-size: 13px; font-weight: 600; color: #052B49; background: none; border: none; padding: 0; cursor: pointer; align-self: flex-start; }

--- a/hyperscribe/scribe/static/styles.css
+++ b/hyperscribe/scribe/static/styles.css
@@ -825,11 +825,6 @@ h2 { margin-bottom: 4px; }
 /* ── Referral card (collapsed meta + expanded form) ── */
 .order-view-meta { font-size: 13px; color: #6b7280; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; max-width: 100%; }
 
-.refer-search-field { position: relative; }
-.refer-search-field .refer-search-icon { position: absolute; left: 11px; top: 50%; transform: translateY(-50%); width: 16px; height: 16px; color: #9aa1ad; pointer-events: none; }
-/* higher specificity than .history-form-input so the icon padding isn't reset by its `padding` shorthand */
-.refer-search-field .refer-search-input { padding-left: 36px; }
-
 /* Clean chevron for selects (replaces the default OS caret) */
 select.history-form-input {
   -webkit-appearance: none; appearance: none;

--- a/hyperscribe/scribe/static/styles.css
+++ b/hyperscribe/scribe/static/styles.css
@@ -851,11 +851,14 @@ select.history-form-input {
 .refer-grid2 .history-form-input { box-sizing: border-box; height: 40px; }
 
 /* Priority — segmented toggle: connected track, sliding white selection; unset = neither */
-.refer-priority { display: flex; box-sizing: border-box; height: 40px; gap: 2px; padding: 3px; background: #eef0f4; border-radius: 6px; }
-.refer-pill { flex: 1; border: none; background: transparent; border-radius: 4px; font-family: inherit; font-size: 13px; font-weight: 600; color: #6b7280; cursor: pointer; transition: all 0.12s; }
+.refer-priority { display: flex; box-sizing: border-box; height: 40px; max-width: 260px; gap: 2px; padding: 3px; background: #eef0f4; border-radius: 6px; }
+.refer-pill { flex: 1; border: none; background: transparent; border-radius: 4px; font-family: inherit; font-size: 13px; font-weight: 600; color: #6b7280; cursor: pointer; transition: all 0.12s; padding: 0 16px; }
 .refer-pill.active { background: #fff; color: #1f2733; box-shadow: 0 1px 2px rgba(16, 24, 40, 0.18); }
 
-.refer-add-comment { display: inline-flex; align-items: center; gap: 6px; font-family: inherit; font-size: 13px; font-weight: 600; color: #052B49; background: none; border: none; padding: 0; cursor: pointer; align-self: flex-start; }
+/* Optional fields (Priority, Comment) revealed via soft-pill disclosures */
+.refer-disclosures { display: flex; flex-wrap: wrap; gap: 12px; align-items: center; }
+.refer-add-pill { display: inline-flex; align-items: center; gap: 6px; font-family: inherit; font-size: 13px; font-weight: 600; color: #41506a; background: #eef0f4; border: none; border-radius: 999px; padding: 7px 14px; cursor: pointer; transition: all 0.12s; }
+.refer-add-pill:hover { background: #e2e6ec; color: #1f2733; }
 
 .diag-search-wrapper { position: relative; flex: 1; min-width: 0; }
 .diag-search-spinner { font-size: 12px; color: #888; font-style: italic; margin-top: 2px; display: block; }

--- a/hyperscribe/scribe/static/styles.css
+++ b/hyperscribe/scribe/static/styles.css
@@ -838,12 +838,14 @@ select.history-form-input {
   background-repeat: no-repeat; background-position: right 12px center;
 }
 
-.refer-token-input { display: flex; flex-wrap: wrap; align-items: center; gap: 6px; width: 100%; min-height: 40px; padding: 5px 8px 5px 30px; border: 1px solid #ddd; border-radius: 6px; background: #fff; box-sizing: border-box; cursor: text; }
+/* single line, fixed height to match the provider search; chips shrink + truncate */
+.refer-token-input { display: flex; flex-wrap: nowrap; align-items: center; gap: 6px; width: 100%; height: 40px; padding: 0 10px 0 34px; border: 1px solid #ddd; border-radius: 6px; background: #fff; box-sizing: border-box; cursor: text; }
 .refer-token-input:focus-within { border-color: #aab2bd; box-shadow: 0 0 0 3px rgba(5, 43, 73, 0.08); }
-.refer-token-input > .refer-search-icon { position: absolute; left: 9px; top: 12px; width: 15px; height: 15px; color: #9aa1ad; pointer-events: none; }
-.refer-token-input input { flex: 1; min-width: 130px; border: none; outline: none; font-family: inherit; font-size: 14px; padding: 4px 2px; background: transparent; color: #333; }
-.refer-token-chip { display: inline-flex; align-items: center; gap: 7px; background: #eef0f4; color: #3a475c; font-size: 12.5px; padding: 4px 6px 4px 10px; border-radius: 6px; }
-.refer-token-chip button { background: none; border: none; color: #98a1ad; font-size: 15px; line-height: 1; cursor: pointer; padding: 0; }
+.refer-token-input > .refer-search-icon { position: absolute; left: 11px; top: 50%; transform: translateY(-50%); width: 16px; height: 16px; color: #9aa1ad; pointer-events: none; }
+.refer-token-input input { flex: 1; min-width: 60px; border: none; outline: none; font-family: inherit; font-size: 14px; padding: 0; background: transparent; color: #333; }
+.refer-token-chip { display: inline-flex; align-items: center; gap: 6px; min-width: 0; background: #eef0f4; color: #3a475c; font-size: 12.5px; padding: 4px 6px 4px 10px; border-radius: 6px; }
+.refer-token-text { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0; }
+.refer-token-chip button { flex: none; background: none; border: none; color: #98a1ad; font-size: 15px; line-height: 1; cursor: pointer; padding: 0; }
 .refer-token-chip button:active { color: #dc2626; }
 
 .refer-grid2 { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; align-items: start; }

--- a/hyperscribe/scribe/static/summary.js
+++ b/hyperscribe/scribe/static/summary.js
@@ -1490,8 +1490,9 @@ export function Scribe({ noteId, patientId, staffId, staffName, providerName, pr
           const parts = [newData.image_display, newData.additional_details, newData.comment, newData.priority].filter(Boolean);
           next = { ...cmd, command_type: type, data: newData, display: parts.join(' | ') };
         } else if (type === 'refer') {
-          const parts = [newData.refer_to_display, newData.clinical_question, newData.priority].filter(Boolean);
-          next = { ...cmd, command_type: type, data: newData, display: parts.join(' | ') || 'Referral' };
+          // Headline is the specialty only (refer_to_display); clinical_question /
+          // priority show on the detail line, not the collapsed headline.
+          next = { ...cmd, command_type: type, data: newData, display: newData.refer_to_display || 'Referral' };
         } else if (type === 'familyHistory') {
           const parts = [newData.condition_display, newData.relative, newData.note].filter(Boolean);
           next = { ...cmd, command_type: type, data: newData, display: parts.join(' — ') || '' };
@@ -1652,8 +1653,7 @@ export function Scribe({ noteId, patientId, staffId, staffName, providerName, pr
         return { ...cmd, command_type: type, data: newData, display: newData.medication_text || '', accepted: true };
       }
       if (type === 'refer') {
-        const parts = [newData.refer_to_display, newData.clinical_question, newData.priority].filter(Boolean);
-        return { ...cmd, command_type: type, data: newData, display: parts.join(' | ') || 'Referral', accepted: true };
+        return { ...cmd, command_type: type, data: newData, display: newData.refer_to_display || 'Referral', accepted: true };
       }
       return { ...cmd, data: newData, accepted: true };
     }));

--- a/hyperscribe/scribe/static/summary.js
+++ b/hyperscribe/scribe/static/summary.js
@@ -348,7 +348,7 @@ function buildCommandBySectionKey(commands) {
   return map;
 }
 
-function renderSoapGroups(sections, commandBySectionKey, onEditCommand, onDeleteCommand, { adHocCommands, objectiveAdHocCommands, historyAdHocCommands, subjectiveAdHocCommands, chargeAdHocCommands, assignees, onAddTask, onAddOrder, onAddPlan, onAddMedication, onAddAllergy, onAddStopMedication, onAddRemoveAllergy, onAddResolveCondition, onAddHistory, onAddQuestionnaire, onAddCharge, onAddTemplateCharge, onRemoveChargeByCpt, templateCharges, readOnly, isAmending, sectionConditions, patientId, noteId, staffId, staffName, recommendations, onEditRecommendation, onDeleteRecommendation, onAcceptRecommendation, onRejectRecommendation, onAddCondition, unmatchedConditions, diagnosisSuggestions, onAddNow, onAddVitals, hideRejected, alertFacilityEnabled, onEditingChange, questionnaireScores, chargeMatrixDiagnoses, chargeMatrixCharges, searchCharges, suggestedCharges, onToggleChargePointer, onReorderDiagnoses, onAddChargeModifier, onRemoveChargeModifier, onSetChargeComment, onClearChargeComment, onRemoveChargeByUuid, examTemplates, onCarryForwardExam } = {}) {
+function renderSoapGroups(sections, commandBySectionKey, onEditCommand, onDeleteCommand, { adHocCommands, objectiveAdHocCommands, historyAdHocCommands, subjectiveAdHocCommands, chargeAdHocCommands, assignees, onAddTask, onAddOrder, onAddPlan, onAddMedication, onAddAllergy, onAddStopMedication, onAddRemoveAllergy, onAddResolveCondition, onAddHistory, onAddQuestionnaire, onAddCharge, onAddTemplateCharge, onRemoveChargeByCpt, templateCharges, readOnly, isAmending, sectionConditions, patientId, noteId, staffId, staffName, recommendations, onEditRecommendation, onDeleteRecommendation, onAcceptRecommendation, onRejectRecommendation, onAddCondition, unmatchedConditions, diagnosisSuggestions, onAddNow, onAddVitals, hideRejected, alertFacilityEnabled, onEditingChange, questionnaireScores, chargeMatrixDiagnoses, chargeMatrixCharges, searchCharges, suggestedCharges, onToggleChargePointer, onReorderDiagnoses, onAddChargeModifier, onRemoveChargeModifier, onSetChargeComment, onClearChargeComment, onRemoveChargeByUuid, examTemplates, onCarryForwardExam, noteDiagnoses } = {}) {
   return SOAP_GROUPS
     .map(group => {
       const matching = sections.filter(s => group.keys.has(s.key.toLowerCase()));
@@ -408,6 +408,7 @@ function renderSoapGroups(sections, commandBySectionKey, onEditCommand, onDelete
         onAddCondition=${isPlan ? onAddCondition : null}
         unmatchedConditions=${isPlan ? unmatchedConditions : null}
         diagnosisSuggestions=${isPlan ? diagnosisSuggestions : null}
+        noteDiagnoses=${noteDiagnoses}
         onAddNow=${(isPlan || isObjective) ? onAddNow : null}
         hideRejected=${hideRejected}
         alertFacilityEnabled=${alertFacilityEnabled}
@@ -556,6 +557,19 @@ export function Scribe({ noteId, patientId, staffId, staffName, providerName, pr
       label: c.data?.icd10_display || c.data?.label || c.display || '',
       locked: Boolean(c.already_documented || c.command_uuid),
     })), [commands]);
+
+  // Accepted A&P diagnoses staged in this note, shaped for the referral
+  // Indications dropdown ({code, formatted_code, display}). Reuses the same
+  // accept filter as chargeMatrixDiagnoses so unreviewed AI suggestions stay
+  // hidden. `code` is normalized (no dot, upper) to dedup against chart
+  // conditions and already-selected chips; formatted_code keeps the dotted form.
+  const noteDiagnoses = useMemo(() => chargeMatrixDiagnoses
+    .filter(d => d.code)
+    .map(d => ({
+      code: d.code.replace(/\./g, '').toUpperCase(),
+      formatted_code: d.code,
+      display: d.label,
+    })), [chargeMatrixDiagnoses]);
 
   // Prune stale diagnosis pointers. When a linked diagnosis is rejected or removed
   // it leaves chargeMatrixDiagnoses, but its _localId lingers in charges' _pointers.
@@ -3045,6 +3059,7 @@ export function Scribe({ noteId, patientId, staffId, staffName, providerName, pr
           onEditingChange: handleEditingChange,
           questionnaireScores: collectQuestionnaireScores(commands),
           chargeMatrixDiagnoses,
+          noteDiagnoses,
           chargeMatrixCharges,
           onToggleChargePointer: canEdit ? onToggleChargePointer : null,
           onReorderDiagnoses: canEdit ? onReorderDiagnoses : null,

--- a/tests/hyperscribe/scribe/commands/test_builder.py
+++ b/tests/hyperscribe/scribe/commands/test_builder.py
@@ -536,9 +536,9 @@ def test_validate_proposals_multiple_failures() -> None:
     # Imaging has 4 errors (ordering provider + indications + details + comment)
     img_errors = next(e for e in errors if e["command_type"] == "imaging_order")
     assert len(img_errors["errors"]) == 4
-    # Refer has 2 errors (notes_to_specialist + indications)
+    # Refer has 4 errors (recipient + clinical_question + notes_to_specialist + indications)
     refer_errors = next(e for e in errors if e["command_type"] == "refer")
-    assert len(refer_errors["errors"]) == 2
+    assert len(refer_errors["errors"]) == 4
 
 
 def test_validate_proposals_unknown_type_skipped() -> None:
@@ -572,8 +572,16 @@ def test_validate_imaging_order_with_required_fields() -> None:
 
 
 def test_validate_refer_missing_notes_and_indications() -> None:
+    # recipient + clinical_question present; only notes and indication are missing
     proposals: list[dict[str, Any]] = [
-        {"command_type": "refer", "data": {"service_provider": {"first_name": "Dr"}}, "display": "Cardiology"},
+        {
+            "command_type": "refer",
+            "data": {
+                "service_provider": {"first_name": "Dr"},
+                "clinical_question": "Assistance with Ongoing Management",
+            },
+            "display": "Cardiology",
+        },
     ]
     errors = validate_proposals(proposals)
     assert len(errors) == 1
@@ -583,11 +591,32 @@ def test_validate_refer_missing_notes_and_indications() -> None:
     assert "indication" in error_text.lower()
 
 
-def test_validate_refer_with_required_fields() -> None:
+def test_validate_refer_missing_recipient_and_clinical_question() -> None:
+    # notes + indication present; recipient and clinical question are missing
     proposals: list[dict[str, Any]] = [
         {
             "command_type": "refer",
             "data": {"notes_to_specialist": "Evaluate murmur", "diagnosis_codes": ["I10"]},
+            "display": "Cardiology",
+        },
+    ]
+    errors = validate_proposals(proposals)
+    assert len(errors) == 1
+    error_text = " ".join(errors[0]["errors"])
+    assert "Referral recipient is required" in error_text
+    assert "Clinical question is required" in error_text
+
+
+def test_validate_refer_with_required_fields() -> None:
+    proposals: list[dict[str, Any]] = [
+        {
+            "command_type": "refer",
+            "data": {
+                "service_provider": {"last_name": "(TBD)", "specialty": "Cardiology"},
+                "clinical_question": "Assistance with Ongoing Management",
+                "notes_to_specialist": "Evaluate murmur",
+                "diagnosis_codes": ["I10"],
+            },
             "display": "Cardiology",
         },
     ]

--- a/tests/hyperscribe/scribe/commands/test_refer.py
+++ b/tests/hyperscribe/scribe/commands/test_refer.py
@@ -8,6 +8,41 @@ def test_extract_returns_none() -> None:
     assert parser.extract("refer to cardiology") is None
 
 
+def _complete_refer_data() -> dict:
+    return {
+        "service_provider": {"last_name": "(TBD)", "specialty": "Cardiology"},
+        "clinical_question": "Assistance with Ongoing Management",
+        "notes_to_specialist": "Please evaluate",
+        "diagnosis_codes": ["I10"],
+    }
+
+
+def test_validate_passes_when_complete() -> None:
+    assert ReferParser().validate(_complete_refer_data()) == []
+
+
+def test_validate_requires_all_four_sign_fields() -> None:
+    errors = ReferParser().validate({})
+    assert "Referral recipient is required" in errors
+    assert "Clinical question is required" in errors
+    assert "Notes to specialist is required" in errors
+    assert "At least one indication is required" in errors
+
+
+def test_validate_flags_missing_recipient() -> None:
+    data = _complete_refer_data()
+    data["service_provider"] = None
+    errors = ReferParser().validate(data)
+    assert errors == ["Referral recipient is required"]
+
+
+def test_validate_flags_missing_indication() -> None:
+    data = _complete_refer_data()
+    data["diagnosis_codes"] = []
+    errors = ReferParser().validate(data)
+    assert errors == ["At least one indication is required"]
+
+
 def test_build_routine_priority() -> None:
     parser = ReferParser()
     data = {"comment": "Follow up", "priority": "Routine"}

--- a/tests/hyperscribe/scribe/recommendations/test_refer.py
+++ b/tests/hyperscribe/scribe/recommendations/test_refer.py
@@ -39,7 +39,7 @@ def test_build_user_prompt() -> None:
     assert "## HPI" in result
 
 
-def test_recommend_is_generic_no_provider() -> None:
+def test_recommend_is_generic_with_placeholder_provider() -> None:
     note = _make_note([NoteSection(key="assessment_and_plan", title="A&P", text="Refer to ENT.")])
     client = _make_client(
         {
@@ -60,26 +60,44 @@ def test_recommend_is_generic_no_provider() -> None:
     assert len(proposals) == 1
     p = proposals[0]
     assert p.command_type == "refer"
-    # generic: display is the specialty, no specific provider attached
+    # generic: display is the specialty; recipient is a placeholder, not a real provider
     assert p.display == "ENT"
-    assert "service_provider" not in p.data
     assert p.data["refer_to_display"] == "ENT"
+    sp = p.data["service_provider"]
+    assert sp["last_name"] == "(TBD)"
+    assert sp["first_name"] == ""
+    assert sp["specialty"] == "ENT"
+    assert sp["practice_name"] == "ENT"
     assert p.data["indication"] == "Chronic sinusitis"
     assert p.data["clinical_question"] == "Specialized intervention"
     assert p.data["priority"] == "Routine"
     assert p.data["notes_to_specialist"] == "Further evaluation needed"
 
 
-def test_recommend_indication_absent_is_none() -> None:
+def test_recommend_defaults_clinical_question_and_notes() -> None:
     note = _make_note([NoteSection(key="plan", title="Plan", text="Refer to cardiology.")])
     client = _make_client({"referrals": [{"specialty": "Cardiology", "priority": "Routine"}]})
 
     proposals = ReferRecommender().recommend(note, client)
 
     assert len(proposals) == 1
-    assert proposals[0].data["indication"] is None
-    assert proposals[0].data["notes_to_specialist"] is None
-    assert proposals[0].data["priority"] == "Routine"
+    data = proposals[0].data
+    assert data["indication"] is None
+    # defaults fill the sign-required fields
+    assert data["clinical_question"] == "Assistance with Ongoing Management"
+    assert data["notes_to_specialist"] == "Referral to Cardiology"
+    assert data["service_provider"]["last_name"] == "(TBD)"
+
+
+def test_recommend_notes_fall_back_to_indication() -> None:
+    note = _make_note([NoteSection(key="plan", title="Plan", text="Refer to ortho.")])
+    client = _make_client(
+        {"referrals": [{"specialty": "Orthopedics", "indication": "Rotator cuff tear", "priority": "Routine"}]}
+    )
+
+    proposals = ReferRecommender().recommend(note, client)
+
+    assert proposals[0].data["notes_to_specialist"] == "Rotator cuff tear"
 
 
 def test_recommend_multiple_referrals_all_generic() -> None:
@@ -97,7 +115,7 @@ def test_recommend_multiple_referrals_all_generic() -> None:
 
     assert len(proposals) == 2
     assert [p.display for p in proposals] == ["ENT", "Dermatology"]
-    assert all("service_provider" not in p.data for p in proposals)
+    assert all(p.data["service_provider"]["last_name"] == "(TBD)" for p in proposals)
     assert proposals[1].data["priority"] == "Urgent"
 
 

--- a/tests/hyperscribe/scribe/recommendations/test_refer.py
+++ b/tests/hyperscribe/scribe/recommendations/test_refer.py
@@ -64,8 +64,9 @@ def test_recommend_is_generic_with_placeholder_provider() -> None:
     assert p.display == "ENT"
     assert p.data["refer_to_display"] == "ENT"
     sp = p.data["service_provider"]
-    assert sp["last_name"] == "(TBD)"
-    assert sp["first_name"] == ""
+    # Canvas core rejects a blank first_name, so placeholder names are non-empty
+    assert sp["first_name"] == "TBD"
+    assert sp["last_name"] == "TBD"
     assert sp["specialty"] == "ENT"
     assert sp["practice_name"] == "ENT"
     assert p.data["indication"] == "Chronic sinusitis"
@@ -86,7 +87,7 @@ def test_recommend_defaults_clinical_question_and_notes() -> None:
     # defaults fill the sign-required fields
     assert data["clinical_question"] == "Assistance with Ongoing Management"
     assert data["notes_to_specialist"] == "Referral to Cardiology"
-    assert data["service_provider"]["last_name"] == "(TBD)"
+    assert data["service_provider"]["last_name"] == "TBD"
 
 
 def test_recommend_notes_fall_back_to_indication() -> None:
@@ -115,7 +116,7 @@ def test_recommend_multiple_referrals_all_generic() -> None:
 
     assert len(proposals) == 2
     assert [p.display for p in proposals] == ["ENT", "Dermatology"]
-    assert all(p.data["service_provider"]["last_name"] == "(TBD)" for p in proposals)
+    assert all(p.data["service_provider"]["last_name"] == "TBD" for p in proposals)
     assert proposals[1].data["priority"] == "Urgent"
 
 

--- a/tests/hyperscribe/scribe/recommendations/test_refer.py
+++ b/tests/hyperscribe/scribe/recommendations/test_refer.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 from http import HTTPStatus
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 from canvas_sdk.clients.llms.structures import LlmResponse, LlmTokens
 
@@ -11,34 +11,6 @@ from hyperscribe.scribe.recommendations.refer import (
     ReferRecommender,
     _build_user_prompt,
 )
-
-_MATCHED_RESULT = {
-    "name": "Jane Smith (ENT Clinic), Otolaryngology",
-    "description": "Phone: 555-1234",
-    "data": {
-        "first_name": "Jane",
-        "last_name": "Smith",
-        "specialty": "Otolaryngology",
-        "practice_name": "ENT Clinic",
-        "business_fax": "",
-        "business_phone": "555-1234",
-        "business_address": "123 Main St",
-    },
-}
-
-_DERM_RESULT = {
-    "name": "Bob Brown (Skin Clinic), Dermatology",
-    "description": "",
-    "data": {
-        "first_name": "Bob",
-        "last_name": "Brown",
-        "specialty": "Dermatology",
-        "practice_name": "Skin Clinic",
-        "business_fax": "",
-        "business_phone": "",
-        "business_address": "",
-    },
-}
 
 
 def _make_note(sections: list[NoteSection] | None = None) -> ClinicalNote:
@@ -67,16 +39,14 @@ def test_build_user_prompt() -> None:
     assert "## HPI" in result
 
 
-@patch("hyperscribe.scribe.recommendations.refer.search_refer_providers")
-def test_recommend_with_matching_provider(mock_search: MagicMock) -> None:
-    mock_search.return_value = [_MATCHED_RESULT]
-
+def test_recommend_is_generic_no_provider() -> None:
     note = _make_note([NoteSection(key="assessment_and_plan", title="A&P", text="Refer to ENT.")])
     client = _make_client(
         {
             "referrals": [
                 {
                     "specialty": "ENT",
+                    "indication": "Chronic sinusitis",
                     "clinicalQuestion": "Specialized intervention",
                     "priority": "Routine",
                     "reason": "Further evaluation needed",
@@ -88,46 +58,37 @@ def test_recommend_with_matching_provider(mock_search: MagicMock) -> None:
     proposals = ReferRecommender().recommend(note, client)
 
     assert len(proposals) == 1
-    assert proposals[0].command_type == "refer"
-    assert proposals[0].data["service_provider"]["first_name"] == "Jane"
-    assert proposals[0].data["refer_to_display"] == "Jane Smith (ENT Clinic), Otolaryngology"
-    assert proposals[0].data["clinical_question"] == "Specialized intervention"
-    assert proposals[0].data["notes_to_specialist"] == "Further evaluation needed"
-    mock_search.assert_called_once_with("ENT", None)
+    p = proposals[0]
+    assert p.command_type == "refer"
+    # generic: display is the specialty, no specific provider attached
+    assert p.display == "ENT"
+    assert "service_provider" not in p.data
+    assert p.data["refer_to_display"] == "ENT"
+    assert p.data["indication"] == "Chronic sinusitis"
+    assert p.data["clinical_question"] == "Specialized intervention"
+    assert p.data["priority"] == "Routine"
+    assert p.data["notes_to_specialist"] == "Further evaluation needed"
 
 
-@patch("hyperscribe.scribe.recommendations.refer.search_refer_providers")
-def test_recommend_incomplete_when_no_provider_found(mock_search: MagicMock) -> None:
-    mock_search.return_value = []
-
-    note = _make_note([NoteSection(key="assessment_and_plan", title="A&P", text="Refer to ENT.")])
-    client = _make_client({"referrals": [{"specialty": "ENT", "priority": "Routine", "reason": "Evaluation needed"}]})
+def test_recommend_indication_absent_is_none() -> None:
+    note = _make_note([NoteSection(key="plan", title="Plan", text="Refer to cardiology.")])
+    client = _make_client({"referrals": [{"specialty": "Cardiology", "priority": "Routine"}]})
 
     proposals = ReferRecommender().recommend(note, client)
 
     assert len(proposals) == 1
-    assert proposals[0].command_type == "refer"
-    assert proposals[0].display == "ENT"
-    assert proposals[0].data.get("service_provider") is None
-    assert proposals[0].data.get("refer_to_display") is None
+    assert proposals[0].data["indication"] is None
+    assert proposals[0].data["notes_to_specialist"] is None
     assert proposals[0].data["priority"] == "Routine"
-    assert proposals[0].data["notes_to_specialist"] == "Evaluation needed"
-    mock_search.assert_called_once_with("ENT", None)
 
 
-@patch("hyperscribe.scribe.recommendations.refer.search_refer_providers")
-def test_recommend_multiple_mixed_matches(mock_search: MagicMock) -> None:
-    mock_search.side_effect = [
-        [],  # ENT not found → incomplete
-        [_DERM_RESULT],
-    ]
-
+def test_recommend_multiple_referrals_all_generic() -> None:
     note = _make_note([NoteSection(key="plan", title="Plan", text="Refer to ENT and Dermatology.")])
     client = _make_client(
         {
             "referrals": [
-                {"specialty": "ENT", "priority": "Routine"},
-                {"specialty": "Dermatology", "priority": "Routine"},
+                {"specialty": "ENT", "indication": "Sinusitis", "priority": "Routine"},
+                {"specialty": "Dermatology", "indication": "Rash", "priority": "Urgent"},
             ]
         }
     )
@@ -135,9 +96,16 @@ def test_recommend_multiple_mixed_matches(mock_search: MagicMock) -> None:
     proposals = ReferRecommender().recommend(note, client)
 
     assert len(proposals) == 2
-    assert proposals[0].data.get("service_provider") is None
-    assert proposals[0].data.get("refer_to_display") is None
-    assert proposals[1].data["service_provider"]["specialty"] == "Dermatology"
+    assert [p.display for p in proposals] == ["ENT", "Dermatology"]
+    assert all("service_provider" not in p.data for p in proposals)
+    assert proposals[1].data["priority"] == "Urgent"
+
+
+def test_recommend_skips_blank_specialty() -> None:
+    note = _make_note([NoteSection(key="plan", title="Plan", text="Refer out.")])
+    client = _make_client({"referrals": [{"specialty": "  ", "priority": "Routine"}]})
+
+    assert ReferRecommender().recommend(note, client) == []
 
 
 def test_recommend_empty_note() -> None:
@@ -182,10 +150,8 @@ def test_recommend_malformed_response() -> None:
     assert ReferRecommender().recommend(note, client) == []
 
 
-@patch("hyperscribe.scribe.recommendations.refer.search_refer_providers")
-def test_recommend_no_referrals_found(mock_search: MagicMock) -> None:
+def test_recommend_no_referrals_found() -> None:
     note = _make_note([NoteSection(key="assessment_and_plan", title="A&P", text="Continue meds.")])
     client = _make_client({"referrals": []})
 
     assert ReferRecommender().recommend(note, client) == []
-    mock_search.assert_not_called()

--- a/tests/hyperscribe/scribe/recommendations/test_refer.py
+++ b/tests/hyperscribe/scribe/recommendations/test_refer.py
@@ -48,7 +48,6 @@ def test_recommend_is_generic_with_placeholder_provider() -> None:
                     "specialty": "ENT",
                     "indication": "Chronic sinusitis",
                     "clinicalQuestion": "Specialized intervention",
-                    "priority": "Routine",
                     "reason": "Further evaluation needed",
                 },
             ]
@@ -71,13 +70,14 @@ def test_recommend_is_generic_with_placeholder_provider() -> None:
     assert sp["practice_name"] == "ENT"
     assert p.data["indication"] == "Chronic sinusitis"
     assert p.data["clinical_question"] == "Specialized intervention"
-    assert p.data["priority"] == "Routine"
+    # priority is left blank for the provider to set
+    assert "priority" not in p.data
     assert p.data["notes_to_specialist"] == "Further evaluation needed"
 
 
 def test_recommend_defaults_clinical_question_and_notes() -> None:
     note = _make_note([NoteSection(key="plan", title="Plan", text="Refer to cardiology.")])
-    client = _make_client({"referrals": [{"specialty": "Cardiology", "priority": "Routine"}]})
+    client = _make_client({"referrals": [{"specialty": "Cardiology"}]})
 
     proposals = ReferRecommender().recommend(note, client)
 
@@ -93,7 +93,7 @@ def test_recommend_defaults_clinical_question_and_notes() -> None:
 def test_recommend_notes_fall_back_to_indication() -> None:
     note = _make_note([NoteSection(key="plan", title="Plan", text="Refer to ortho.")])
     client = _make_client(
-        {"referrals": [{"specialty": "Orthopedics", "indication": "Rotator cuff tear", "priority": "Routine"}]}
+        {"referrals": [{"specialty": "Orthopedics", "indication": "Rotator cuff tear"}]}
     )
 
     proposals = ReferRecommender().recommend(note, client)
@@ -106,8 +106,8 @@ def test_recommend_multiple_referrals_all_generic() -> None:
     client = _make_client(
         {
             "referrals": [
-                {"specialty": "ENT", "indication": "Sinusitis", "priority": "Routine"},
-                {"specialty": "Dermatology", "indication": "Rash", "priority": "Urgent"},
+                {"specialty": "ENT", "indication": "Sinusitis"},
+                {"specialty": "Dermatology", "indication": "Rash"},
             ]
         }
     )
@@ -117,12 +117,12 @@ def test_recommend_multiple_referrals_all_generic() -> None:
     assert len(proposals) == 2
     assert [p.display for p in proposals] == ["ENT", "Dermatology"]
     assert all(p.data["service_provider"]["last_name"] == "TBD" for p in proposals)
-    assert proposals[1].data["priority"] == "Urgent"
+    assert all("priority" not in p.data for p in proposals)
 
 
 def test_recommend_skips_blank_specialty() -> None:
     note = _make_note([NoteSection(key="plan", title="Plan", text="Refer out.")])
-    client = _make_client({"referrals": [{"specialty": "  ", "priority": "Routine"}]})
+    client = _make_client({"referrals": [{"specialty": "  "}]})
 
     assert ReferRecommender().recommend(note, client) == []
 

--- a/tests/hyperscribe/scribe/recommendations/test_referral_diagnosis.py
+++ b/tests/hyperscribe/scribe/recommendations/test_referral_diagnosis.py
@@ -24,6 +24,9 @@ def test_links_code_from_diagnose_command() -> None:
     commands = [_diagnose("Shoulder muscle spasm:", "M62.838", "Other muscle spasm")]
     link_referral_diagnoses(recs, commands, [], {})
     assert recs[0]["data"]["diagnosis_codes"] == ["M62.838"]
+    # the ICD-10 name is attached for display alongside the code
+    assert recs[0]["data"]["diagnosis_displays"] == ["Other muscle spasm"]
+    assert recs[0]["data"]["diagnosis_formatted"] == ["M62.838"]
 
 
 def test_diagnose_command_takes_priority_over_suggestions() -> None:
@@ -38,9 +41,12 @@ def test_falls_back_to_suggestions_when_diagnose_uncoded() -> None:
     recs = [_refer("Shoulder muscle spasm")]
     # diagnose command exists but has no code yet
     commands = [_diagnose("Shoulder muscle spasm:", None)]
-    suggestions = {"Shoulder muscle spasm:": [{"code": "M6281", "formatted_code": "M62.81"}]}
+    suggestions = {
+        "Shoulder muscle spasm:": [{"code": "M6281", "formatted_code": "M62.81", "display": "Muscle weakness"}]
+    }
     link_referral_diagnoses(recs, commands, [], suggestions)
     assert recs[0]["data"]["diagnosis_codes"] == ["M62.81"]
+    assert recs[0]["data"]["diagnosis_displays"] == ["Muscle weakness"]
 
 
 def test_falls_back_to_unmatched_conditions() -> None:
@@ -53,6 +59,7 @@ def test_falls_back_to_unmatched_conditions() -> None:
     ]
     link_referral_diagnoses(recs, commands=[], unmatched_conditions=unmatched, diagnosis_suggestions={})
     assert recs[0]["data"]["diagnosis_codes"] == ["J45.909"]
+    assert recs[0]["data"]["diagnosis_displays"] == ["Unspecified asthma, uncomplicated"]
 
 
 def test_containment_match() -> None:

--- a/tests/hyperscribe/scribe/recommendations/test_referral_diagnosis.py
+++ b/tests/hyperscribe/scribe/recommendations/test_referral_diagnosis.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+from typing import Any
+
+from hyperscribe.scribe.recommendations._referral_diagnosis import link_referral_diagnoses
+
+
+def _refer(indication: str | None, diagnosis_codes: list[str] | None = None) -> dict[str, Any]:
+    data: dict[str, Any] = {"refer_to_display": "Cardiology", "indication": indication}
+    if diagnosis_codes is not None:
+        data["diagnosis_codes"] = diagnosis_codes
+    return {"command_type": "refer", "display": "Cardiology", "data": data}
+
+
+def _diagnose(header: str, code: str | None, display: str = "") -> dict[str, Any]:
+    return {
+        "command_type": "diagnose",
+        "data": {"condition_header": header, "icd10_code": code, "icd10_display": display},
+    }
+
+
+def test_links_code_from_diagnose_command() -> None:
+    recs = [_refer("Shoulder muscle spasm")]
+    commands = [_diagnose("Shoulder muscle spasm:", "M62.838", "Other muscle spasm")]
+    link_referral_diagnoses(recs, commands, [], {})
+    assert recs[0]["data"]["diagnosis_codes"] == ["M62.838"]
+
+
+def test_diagnose_command_takes_priority_over_suggestions() -> None:
+    recs = [_refer("Hypertension")]
+    commands = [_diagnose("Hypertension:", "I10")]
+    suggestions = {"Hypertension:": [{"code": "I150", "formatted_code": "I15.0"}]}
+    link_referral_diagnoses(recs, commands, [], suggestions)
+    assert recs[0]["data"]["diagnosis_codes"] == ["I10"]
+
+
+def test_falls_back_to_suggestions_when_diagnose_uncoded() -> None:
+    recs = [_refer("Shoulder muscle spasm")]
+    # diagnose command exists but has no code yet
+    commands = [_diagnose("Shoulder muscle spasm:", None)]
+    suggestions = {"Shoulder muscle spasm:": [{"code": "M6281", "formatted_code": "M62.81"}]}
+    link_referral_diagnoses(recs, commands, [], suggestions)
+    assert recs[0]["data"]["diagnosis_codes"] == ["M62.81"]
+
+
+def test_falls_back_to_unmatched_conditions() -> None:
+    recs = [_refer("Asthma")]
+    unmatched = [
+        {
+            "coding": [{"system": "icd10", "code": "J45.909", "display": "Unspecified asthma, uncomplicated"}],
+            "corresponding_note_problem": "Asthma",
+        }
+    ]
+    link_referral_diagnoses(recs, commands=[], unmatched_conditions=unmatched, diagnosis_suggestions={})
+    assert recs[0]["data"]["diagnosis_codes"] == ["J45.909"]
+
+
+def test_containment_match() -> None:
+    # indication is a substring of the note's problem header (minor wording drift)
+    recs = [_refer("muscle spasm")]
+    commands = [_diagnose("Shoulder muscle spasm:", "M62.838")]
+    link_referral_diagnoses(recs, commands, [], {})
+    assert recs[0]["data"]["diagnosis_codes"] == ["M62.838"]
+
+
+def test_partial_word_overlap_does_not_match() -> None:
+    # conservative: "shoulder spasm" is NOT a substring of "shoulder muscle spasm",
+    # so no code is linked (avoids guessing a wrong indication)
+    recs = [_refer("shoulder spasm")]
+    commands = [_diagnose("Shoulder muscle spasm:", "M62.838")]
+    link_referral_diagnoses(recs, commands, [], {})
+    assert "diagnosis_codes" not in recs[0]["data"]
+
+
+def test_no_match_leaves_codes_absent() -> None:
+    recs = [_refer("Cardiology consult")]
+    commands = [_diagnose("Diabetes:", "E11.9")]
+    link_referral_diagnoses(recs, commands, [], {})
+    assert "diagnosis_codes" not in recs[0]["data"]
+
+
+def test_no_indication_is_skipped() -> None:
+    recs = [_refer(None)]
+    commands = [_diagnose("Hypertension:", "I10")]
+    link_referral_diagnoses(recs, commands, [], {})
+    assert "diagnosis_codes" not in recs[0]["data"]
+
+
+def test_existing_codes_preserved() -> None:
+    recs = [_refer("Hypertension", diagnosis_codes=["I11.9"])]
+    commands = [_diagnose("Hypertension:", "I10")]
+    link_referral_diagnoses(recs, commands, [], {})
+    # not overwritten
+    assert recs[0]["data"]["diagnosis_codes"] == ["I11.9"]
+
+
+def test_non_refer_proposals_untouched() -> None:
+    med = {"command_type": "medication_statement", "data": {"indication": "Hypertension"}}
+    recs = [med]
+    commands = [_diagnose("Hypertension:", "I10")]
+    link_referral_diagnoses(recs, commands, [], {})
+    assert "diagnosis_codes" not in med["data"]


### PR DESCRIPTION
## Summary
Makes scribe **referral** recommendations generic to the specialty and commit-ready, in the nabla/scribe path (`hyperscribe/scribe/`). Legacy `hyperscribe/commands/` is untouched.

## Changes
1. **Generic referrals only.** `ReferRecommender` no longer runs the science-service provider lookup; every referral is recommended to the specialty (no specific provider). The manual provider-search endpoint (`search_refer_providers`) is unchanged and still available in the UI.
2. **Validated indication (diagnosis code).** The LLM also extracts the condition the referral addresses (`indication`), and a new pure helper `link_referral_diagnoses` attaches an ICD-10 code **already present in the note** — diagnose commands → science-validated diagnosis suggestions → unmatched conditions. Never fabricates: no match leaves `diagnosis_codes` empty.
3. **Insert/sign-ready.** A refer command auto-signs on insert and Canvas core requires a recipient + clinical question + notes + indication. So generic referrals now carry: a placeholder recipient (non-blank `first_name`/`last_name` = "TBD", `practice_name` = specialty — Canvas core rejects a blank `first_name`), a default `clinical_question` ("Assistance with Ongoing Management"), and `notes_to_specialist` (reason → indication → "Referral to {specialty}").
4. **`ReferParser.validate` tightened** to require all four sign fields, so an incomplete referral fails loudly at `/insert-commands` instead of silently rolling back at sign (same guard `_rx_validation` provides for prescribe).
5. **Priority dropped** from the referral pipeline (schema + prompt + data) — left blank for the provider to set.
6. PHI-safe logging in the refer recommender (no raw LLM response on error/parse paths).

## Tests / checks
- Rewrote `test_refer.py` for generic-only + placeholder + defaults; added `test_referral_diagnosis.py` (match priority, conservative matching, no-fabrication); added `ReferParser.validate` tests; updated `test_builder.py` to the 4-field contract.
- Full scribe suite green (1,229), ruff + mypy clean.

## Verified live
Confirmed in a real instance that generic referrals now originate + sign into the note body (the blank-`first_name` ORIGINATE failure is resolved).

## Notes / out of scope
- The standalone `/recommend-commands` endpoint returns generic referrals without linked diagnosis codes (no diagnosis context there); linking runs in the generate-summary flow.
- `clinical_question` default is a neutral guess when the AI doesn't infer one — provider can adjust.
- Diagnosis matching is conservative (exact/substring) to avoid mis-linking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)