### PR TITLE
feat(scribe): Manual Mode Only setting + visit-type selector polish

### DIFF
--- a/hyperscribe/CANVAS_MANIFEST.json
+++ b/hyperscribe/CANVAS_MANIFEST.json
@@ -1,6 +1,6 @@
 {
   "sdk_version": "0.155.0",
-  "plugin_version": "2026-06-24 v0.3.12",
+  "plugin_version": "2026-06-24 v0.3.13",
   "name": "hyperscribe",
   "description": "Create commands based on the content of an audio discussion between a patient and a provider.",
   "url_permissions": [

--- a/hyperscribe/CANVAS_MANIFEST.json
+++ b/hyperscribe/CANVAS_MANIFEST.json
@@ -1,6 +1,6 @@
 {
   "sdk_version": "0.155.0",
-  "plugin_version": "2026-06-24 v0.3.11",
+  "plugin_version": "2026-06-24 v0.3.12",
   "name": "hyperscribe",
   "description": "Create commands based on the content of an audio discussion between a patient and a provider.",
   "url_permissions": [

--- a/hyperscribe/CANVAS_MANIFEST.json
+++ b/hyperscribe/CANVAS_MANIFEST.json
@@ -1,6 +1,6 @@
 {
   "sdk_version": "0.155.0",
-  "plugin_version": "2026-06-10 v0.3.10 (feat-physical-exam-improvements)",
+  "plugin_version": "2026-06-24 v0.3.11",
   "name": "hyperscribe",
   "description": "Create commands based on the content of an audio discussion between a patient and a provider.",
   "url_permissions": [
@@ -282,6 +282,7 @@
     "NotionFeedbackDatabaseId",
     "ScribeBackend",
     "ScribeDebugStaffers",
+    "ScribeManualModeOnly",
     "ScribeNoteTypes",
     "ScribePilotStaffers",
     "ScribeTabName",

--- a/hyperscribe/scribe/api/scribe_view.py
+++ b/hyperscribe/scribe/api/scribe_view.py
@@ -88,6 +88,7 @@ class ScribeView(StaffSessionAuthMixin, SimpleAPI):
                 "note_editable": "true" if note_editable else "",
                 "is_author": "true" if is_author else "",
                 "alert_facility_enabled": "true" if self.secrets.get("AlertFacilityEnabled") else "",
+                "manual_mode_only": "true" if self.secrets.get("ScribeManualModeOnly") else "",
                 "initial_data": _safe_json(initial_data),
             },
         )

--- a/hyperscribe/scribe/static/app.js
+++ b/hyperscribe/scribe/static/app.js
@@ -6,7 +6,7 @@ import { Audit } from '/plugin-io/api/hyperscribe/scribe/static/audit.js';
 
 const html = htm.bind(h);
 
-export function App({ noteId, view, providerName, providerPhotoUrl, patientName, patientBirthDate, patientGender, patientId, staffId, staffName, debugMode, noteEditable, isAuthor, alertFacilityEnabled, initialData }) {
+export function App({ noteId, view, providerName, providerPhotoUrl, patientName, patientBirthDate, patientGender, patientId, staffId, staffName, debugMode, noteEditable, isAuthor, alertFacilityEnabled, manualModeOnly, initialData }) {
   if (view === 'audit') {
     return html`<${Audit} noteId=${noteId} />`;
   }
@@ -30,6 +30,7 @@ export function App({ noteId, view, providerName, providerPhotoUrl, patientName,
       noteEditable=${noteEditable}
       isAuthor=${isAuthor}
       alertFacilityEnabled=${alertFacilityEnabled}
+      manualModeOnly=${manualModeOnly}
       initialData=${initialData}
     />`;
   }

--- a/hyperscribe/scribe/static/index.html
+++ b/hyperscribe/scribe/static/index.html
@@ -69,6 +69,7 @@
       noteEditable: '{{ note_editable }}' === 'true',
       isAuthor: '{{ is_author }}' === 'true',
       alertFacilityEnabled: '{{ alert_facility_enabled }}' === 'true',
+      manualModeOnly: '{{ manual_mode_only }}' === 'true',
       initialData: initialData,
     };
     render(h(App, config), document.getElementById('app'));

--- a/hyperscribe/scribe/static/soap-group.js
+++ b/hyperscribe/scribe/static/soap-group.js
@@ -1191,6 +1191,11 @@ export function SoapGroup({ title, groupColor, sections, commandBySectionKey, on
             ? visibleAdHoc.filter(e => e.command.command_type === historyType)
             : [];
           const showHistoryText = s.text && !isCoveredHistory;
+          // social_history has no manual input affordance (not in NARRATIVE_SECTIONS,
+          // no SECTION_TO_HISTORY_TYPE entry), so an empty Social History section is a
+          // dead, un-fillable header. Hide it whenever it has nothing to show; the AI
+          // path still renders it once it supplies history_review content.
+          if (key === 'social_history' && !showHistoryText && historyEntries.length === 0 && !cmds) return null;
           if (readOnly && !showHistoryText && !cmds && historyEntries.length === 0) return null;
           if (!showHistoryText && historyEntries.length === 0 && !onAddHistory && !cmds) return null;
           return html`

--- a/hyperscribe/scribe/static/soap-group.js
+++ b/hyperscribe/scribe/static/soap-group.js
@@ -1197,7 +1197,12 @@ export function SoapGroup({ title, groupColor, sections, commandBySectionKey, on
           // path still renders it once it supplies history_review content.
           if (key === 'social_history' && !showHistoryText && historyEntries.length === 0 && !cmds) return null;
           if (readOnly && !showHistoryText && !cmds && historyEntries.length === 0) return null;
-          if (!showHistoryText && historyEntries.length === 0 && !onAddHistory && !cmds) return null;
+          // Plan sections render their Add/Resolve Condition buttons (and any ad-hoc
+          // resolves) from the fall-through branch below, even with no narrative command.
+          // Without this exemption an empty A&P (e.g. manual mode, where no empty plan
+          // card is pre-seeded) would be dropped here, taking those buttons with it.
+          const planAddable = PLAN_SECTIONS.has(key) && (onAddCondition || onAddResolveCondition);
+          if (!showHistoryText && historyEntries.length === 0 && !onAddHistory && !cmds && !planAddable) return null;
           return html`
             <div class="subsection" key=${s.key}>
               <div class="subsection-title">${s.title}</div>

--- a/hyperscribe/scribe/static/styles.css
+++ b/hyperscribe/scribe/static/styles.css
@@ -1391,18 +1391,30 @@ select.history-form-input {
 }
 
 .template-select {
-  padding: 8px 12px;
+  appearance: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  /* extra right padding leaves room for the custom chevron so the label never collides with it */
+  padding: 8px 38px 8px 14px;
   font-family: inherit;
   font-size: 13px;
+  line-height: 1.2;
   font-weight: 500;
   border: 1px solid #ddd;
   border-radius: 6px;
-  background: #fff;
+  /* custom chevron, comfortably inset from the right edge (replaces the cramped OS default arrow) */
+  background-color: #fff;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='%236b7280' stroke-width='2.2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='6 9 12 15 18 9'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 12px center;
+  background-size: 16px;
   color: #333;
   cursor: pointer;
   min-width: 170px;
+  transition: border-color .15s ease, box-shadow .15s ease;
 }
-.template-select:focus { outline: none; border-color: #052B49; }
+.template-select:hover { border-color: #c4c9cf; }
+.template-select:focus { outline: none; border-color: #052B49; box-shadow: 0 0 0 3px rgba(5, 43, 73, 0.12); }
 .template-select:disabled { opacity: 0.5; cursor: not-allowed; }
 
 .start-ai-btn {
@@ -1416,6 +1428,7 @@ select.history-form-input {
   color: #fff;
   font-family: inherit;
   font-size: 13px;
+  line-height: 1.2;
   font-weight: 600;
   cursor: pointer;
   transition: background 0.15s;
@@ -1435,6 +1448,7 @@ select.history-form-input {
   color: #052B49;
   font-family: inherit;
   font-size: 13px;
+  line-height: 1.2;
   font-weight: 600;
   cursor: pointer;
   transition: all 0.15s;

--- a/hyperscribe/scribe/static/summary.js
+++ b/hyperscribe/scribe/static/summary.js
@@ -421,7 +421,7 @@ function renderSoapGroups(sections, commandBySectionKey, onEditCommand, onDelete
     .filter(Boolean);
 }
 
-export function Scribe({ noteId, patientId, staffId, staffName, providerName, providerPhotoUrl, patientName, patientBirthDate, patientGender, debugMode, noteEditable = true, isAuthor = false, alertFacilityEnabled = false, initialData = null }) {
+export function Scribe({ noteId, patientId, staffId, staffName, providerName, providerPhotoUrl, patientName, patientBirthDate, patientGender, debugMode, noteEditable = true, isAuthor = false, alertFacilityEnabled = false, manualModeOnly = false, initialData = null }) {
   const initSummary = initialData?.summary ?? null;
   const [noteData, setNoteData] = useState(initSummary?.note ?? null);
   const [generating, setGenerating] = useState(false);
@@ -2874,10 +2874,12 @@ export function Scribe({ noteId, patientId, staffId, staffName, providerName, pr
             </select>
           `}
           ${showTopControls && html`
-            <button class="start-ai-btn" onClick=${handleStartAI} disabled=${!selectedTemplate}>
-              <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><circle cx="12" cy="12" r="8" /></svg>
-              Start AI Scribe
-            </button>
+            ${!manualModeOnly && html`
+              <button class="start-ai-btn" onClick=${handleStartAI} disabled=${!selectedTemplate}>
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><circle cx="12" cy="12" r="8" /></svg>
+                Start AI Scribe
+              </button>
+            `}
             <button class="start-manual-btn" onClick=${handleStartManual} disabled=${!selectedTemplate}>
               Manual
             </button>

--- a/hyperscribe/scribe/static/summary.js
+++ b/hyperscribe/scribe/static/summary.js
@@ -1375,7 +1375,8 @@ export function Scribe({ noteId, patientId, staffId, staffName, providerName, pr
       { command_type: 'hpi', display: '', data: { narrative: '' }, selected: true, section_key: 'history_of_present_illness', already_documented: false },
       // Vitals is intentionally NOT pre-populated: an empty vitals card auto-opens its editor and blocks
       // commit until saved/cancelled (KOALA-5802). It's added on demand via the "+ Vitals" button instead.
-      { command_type: 'plan', display: '', data: { narrative: '' }, selected: true, section_key: 'assessment_and_plan', already_documented: false },
+      // Plan is intentionally NOT pre-populated either: providers add it on demand via the "+ Plan" button
+      // so Assessment & Plan starts empty rather than showing a blank Plan card.
     ];
     // Add PE from template if available.
     if (selectedTemplate?.pe_sections?.length > 0) {


### PR DESCRIPTION
## Summary

Adds a new plugin setting to restrict Scribe to manual documentation, plus a few related manual-mode and UI refinements.

- **`ScribeManualModeOnly` setting** — when the secret is truthy, the **Start AI Scribe** button is hidden so only **Manual** can be selected. Default off → behavior unchanged. Threaded through the existing `alertFacilityEnabled` feature-flag path (manifest secret → `scribe_view` context → `index.html` config → `App` → `Scribe`), so no new plumbing concepts.
- **Tidy empty manual-mode sections** — stop pre-seeding an empty Plan card under Assessment & Plan (added on demand via **+ Plan**, mirroring the existing Vitals exclusion); hide the **Social History** section when empty (it has no manual input affordance).
- **Fix: restore Add/Resolve Condition in an empty A&P** — removing the pre-seeded Plan card left `assessment_and_plan` with no commands, which tripped a `!cmds` render guard and dropped the section's Add/Resolve Condition buttons. Plan sections with condition-add affordances are now exempt from that guard, so the buttons render without re-introducing the empty card.
- **Visit-type selector polish** — replace the cramped OS default `<select>` arrow with a custom inset chevron (`appearance:none` + inline SVG), add a hover border and navy focus ring, and align the selector's corner radius (6px) and height with the Start AI Scribe / Manual buttons.

## Plugin version
`2026-06-24 v0.3.13`

## Testing
- Python suite: **2,623 passed**.
- Caveat: all changes here are frontend (the flag plumbing, `soap-group.js`/`summary.js` logic, `styles.css`) and the repo has no JS test harness, so the green Python suite confirms nothing else regressed but does **not** cover these changes. Recommend a manual QA pass of the manual-mode A&P flow (add condition, resolve condition, add plan, finalize) and the selector appearance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)