### PR TITLE
feat(scribe): auto-link new charge to first 4 matrix diagnoses

### DIFF
--- a/hyperscribe/scribe/static/summary.js
+++ b/hyperscribe/scribe/static/summary.js
@@ -1825,6 +1825,13 @@ export function Scribe({ noteId, patientId, staffId, staffName, providerName, pr
   const handleAddTemplateCharge = useCallback((cptCode, description) => {
     logEvent('ADD_TEMPLATE_CHARGE', { cptCode, description });
     if (!canEdit) return;
+    // Auto-associate a freshly added charge with the first MAX_POINTERS (4)
+    // diagnoses currently listed in the matrix, in rank order. command_uuid here
+    // is the diagnosis command's _localId — the same identity stored in _pointers
+    // and toggled by onToggleChargePointer. One-time seed at selection time:
+    // diagnoses added later are NOT retroactively linked, and re-selecting an
+    // existing charge (below) preserves its prior pointers.
+    const defaultPointers = chargeMatrixDiagnoses.slice(0, MAX_POINTERS).map(d => d.command_uuid);
     setCommands(prev => {
       // Re-select if already exists but deselected. KOALA-5485: if this was
       // an amend-mode delete that the user just toggled back on, also clear
@@ -1847,14 +1854,14 @@ export function Scribe({ noteId, patientId, staffId, staffName, providerName, pr
       return [...prev, {
         command_type: 'perform',
         display: `${cptCode} — ${description}`,
-        data: { cpt_code: cptCode, description, notes: '', _modifiers: [], _pointers: [] },
+        data: { cpt_code: cptCode, description, notes: '', _modifiers: [], _pointers: defaultPointers },
         selected: true,
         section_key: '_charges_ad_hoc',
         already_documented: false,
         _localId: crypto.randomUUID(),
       }];
     });
-  }, [canEdit]);
+  }, [canEdit, chargeMatrixDiagnoses]);
 
   const handleRemoveChargeByCpt = useCallback((cptCode) => {
     logEvent('REMOVE_CHARGE', { cptCode });


### PR DESCRIPTION
## What

When a provider adds a charge in the charge matrix — whether picked from the visit template's **Suggested** list or via **CPT/HCPCS free-text search** — the new charge column is now automatically linked to the **first up-to-4 diagnoses currently listed in the matrix**, in their displayed rank order at the moment of selection.

## Why

Providers were manually checking the same diagnosis boxes for nearly every charge. Seeding the first four (the per-charge `MAX_POINTERS` cap) removes that repetitive step while leaving full manual control intact.

## How

Single change in `hyperscribe/scribe/static/summary.js` → `handleAddTemplateCharge` (the one handler both `onAddCharge` and `onAddTemplateCharge` route to):

- Compute `defaultPointers = chargeMatrixDiagnoses.slice(0, MAX_POINTERS).map(d => d.command_uuid)` at click time. `command_uuid` here is the diagnosis command's `_localId` — the exact identity already stored in `_pointers` and toggled by `onToggleChargePointer`.
- Seed the new charge's `data._pointers` with it (was `[]`).
- Add `chargeMatrixDiagnoses` to the `useCallback` deps so the seed reflects current matrix state.

### Behavior decisions
- **One-time seed at selection time.** Diagnoses added *after* a charge is created are **not** retroactively linked.
- **Re-select preserves prior pointers.** Re-adding a previously removed/deselected charge keeps its existing pointers (the re-select branch is untouched) — no clobbering of manual edits.
- **Zero diagnoses** → `_pointers: []`, identical to prior behavior.

### Why it's safe
- Cap respected (seeds ≤ `MAX_POINTERS`); footer pill and sign-gate stay valid.
- Prune-safe: every seeded pointer is backed by a live matrix diagnosis.
- No server/SDK change — `/enrich-charges` already consumes `_pointers`.

## Testing

- `uv run pytest tests/` → **2697 passed** (no Python touched; confirms no regressions).
- Lint/format/mypy clean (pre-commit).
- Manual UI check: adding a charge with diagnoses present pre-checks the first 4 boxes (footer `n/4`); 0 diagnoses → none; reorder-then-add links to the new top 4; re-selecting a removed charge keeps its pointers.

> Note: repo has no JS test harness, so the front-end logic is covered by manual verification; the end-to-end sign-through (`/enrich-charges` writing pointers onto the BLI) is the remaining confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)