### PR TITLE
fix(scribe): always surface Physical Exam in the summary tab

### DIFF
--- a/hyperscribe/scribe/static/sections-exam-row.js
+++ b/hyperscribe/scribe/static/sections-exam-row.js
@@ -146,7 +146,7 @@ export function ExamSectionsRow({
     return html`
       <div class=${`exam-rows${readOnly ? '' : ' exam-clickable'}`} onClick=${enterEdit}>
         ${sections.length === 0
-          ? html`<div class="exam-empty">No ${LABEL[sectionKind]} documented.${readOnly ? '' : ' Click to add.'}</div>`
+          ? html`<div class="exam-empty">No ${LABEL[sectionKind]} documented.</div>`
           : sections.map((s, i) => html`
             <div class="exam-row" key=${s.key || i}>
               <div class="exam-sys">${s.title}</div>

--- a/hyperscribe/scribe/static/soap-group.js
+++ b/hyperscribe/scribe/static/soap-group.js
@@ -648,7 +648,7 @@ function AddConditionSearch({ onAdd, patientId }) {
   `;
 }
 
-export function SoapGroup({ title, groupColor, sections, commandBySectionKey, onEditCommand, onDeleteCommand, adHocCommands, assignees, onAddTask, onAddOrder, onAddPlan, onAddVitals, onAddMedication, onAddAllergy, onAddStopMedication, onAddRemoveAllergy, onAddResolveCondition, onAddHistory, onAddQuestionnaire, onAddCharge, readOnly, isAmending = false, sectionConditions, patientId, noteId, staffId, staffName, recommendations, onEditRecommendation, onDeleteRecommendation, onAcceptRecommendation, onRejectRecommendation, onAddCondition, unmatchedConditions, diagnosisSuggestions, noteDiagnoses = [], onAddNow, hideRejected, alertFacilityEnabled, onEditingChange, questionnaireScores, chargeMatrixDiagnoses = [], chargeMatrixCharges = [], searchCharges = () => {}, suggestedCharges = [], onToggleChargePointer = () => {}, onReorderDiagnoses = () => {}, onAddChargeModifier = () => {}, onRemoveChargeModifier = () => {}, onSetChargeComment = () => {}, onClearChargeComment = () => {}, onRemoveChargeByUuid = () => {}, examTemplates, onCarryForwardExam, isPsychiatry = false }) {
+export function SoapGroup({ title, groupColor, sections, commandBySectionKey, onEditCommand, onDeleteCommand, adHocCommands, assignees, onAddTask, onAddOrder, onAddPlan, onAddVitals, onAddPhysicalExam, onAddMentalStatusExam, onAddMedication, onAddAllergy, onAddStopMedication, onAddRemoveAllergy, onAddResolveCondition, onAddHistory, onAddQuestionnaire, onAddCharge, readOnly, isAmending = false, sectionConditions, patientId, noteId, staffId, staffName, recommendations, onEditRecommendation, onDeleteRecommendation, onAcceptRecommendation, onRejectRecommendation, onAddCondition, unmatchedConditions, diagnosisSuggestions, noteDiagnoses = [], onAddNow, hideRejected, alertFacilityEnabled, onEditingChange, questionnaireScores, chargeMatrixDiagnoses = [], chargeMatrixCharges = [], searchCharges = () => {}, suggestedCharges = [], onToggleChargePointer = () => {}, onReorderDiagnoses = () => {}, onAddChargeModifier = () => {}, onRemoveChargeModifier = () => {}, onSetChargeComment = () => {}, onClearChargeComment = () => {}, onRemoveChargeByUuid = () => {}, examTemplates, onCarryForwardExam, isPsychiatry = false }) {
   const isCharges = title === 'CHARGES';
   const coveredKeys = getCoveredKeys(commandBySectionKey);
 
@@ -925,19 +925,50 @@ export function SoapGroup({ title, groupColor, sections, commandBySectionKey, on
           // mental_status_exam before physical_exam). Gated on isPsychiatry so a
           // stray command on a non-psych visit never surfaces the card.
           if (key === 'mental_status_exam') {
-            if (!isPsychiatry || !cmds) return null;
-            const entry = cmds[0];
-            const mseRowReadOnly = rowLocked(entry.command, readOnly, isAmending);
+            // Psychiatry-only: the section is never surfaced on non-psych
+            // visits. On a psychiatry visit it is always surfaced, even when
+            // Nabla omitted the mental_health_exam section — mirroring the
+            // Physical Exam card. When no MSE command exists, render the empty
+            // "Click to add" editor against a synthetic placeholder; the first
+            // Save routes through onAddMentalStatusExam, which promotes the
+            // draft into a real, index-addressable command. The empty
+            // placeholder never reaches the chart — the `insertable` filter
+            // drops MSE commands with no sections.
+            if (!isPsychiatry) return null;
+            if (cmds) {
+              const entry = cmds[0];
+              const mseRowReadOnly = rowLocked(entry.command, readOnly, isAmending);
+              return html`
+                <div class="subsection" key=${s.key}>
+                  <div class="subsection-title">${s.title}</div>
+                  <div class=${`content-block rec-narrative${mseRowReadOnly && entry.command.already_documented ? ' command-locked' : ''}`}>
+                    ${mseRowReadOnly && entry.command.already_documented && ICON_LOCK}
+                    <${ExamSectionsRow}
+                      command=${entry.command}
+                      commandIndex=${entry.index}
+                      onEdit=${onEditCommand}
+                      readOnly=${mseRowReadOnly}
+                      onEditingChange=${onEditingChange}
+                      sectionKind="mental_status_exam"
+                      templates=${examTemplates}
+                      onCarryForward=${onCarryForwardExam}
+                    />
+                  </div>
+                </div>
+              `;
+            }
+            // No MSE command yet. Only offer the empty editor when editable.
+            if (readOnly || !onAddMentalStatusExam) return null;
+            const msePlaceholder = { command_type: 'mental_status_exam', section_key: 'mental_status_exam', display: '', selected: true, already_documented: false, data: { sections: [] } };
             return html`
               <div class="subsection" key=${s.key}>
                 <div class="subsection-title">${s.title}</div>
-                <div class=${`content-block rec-narrative${mseRowReadOnly && entry.command.already_documented ? ' command-locked' : ''}`}>
-                  ${mseRowReadOnly && entry.command.already_documented && ICON_LOCK}
+                <div class="content-block rec-narrative">
                   <${ExamSectionsRow}
-                    command=${entry.command}
-                    commandIndex=${entry.index}
-                    onEdit=${onEditCommand}
-                    readOnly=${mseRowReadOnly}
+                    command=${msePlaceholder}
+                    commandIndex="mental_status_exam_placeholder"
+                    onEdit=${(_, data) => onAddMentalStatusExam(data)}
+                    readOnly=${false}
                     onEditingChange=${onEditingChange}
                     sectionKind="mental_status_exam"
                     templates=${examTemplates}
@@ -948,19 +979,50 @@ export function SoapGroup({ title, groupColor, sections, commandBySectionKey, on
             `;
           }
 
-          if (cmds && key === 'physical_exam') {
-            const entry = cmds[0];
-            const peRowReadOnly = rowLocked(entry.command, readOnly, isAmending);
+          if (key === 'physical_exam') {
+            // Physical Exam is a standard section on EVERY visit type (psychiatry
+            // included): ENSURE_KEYS forces it in even when Nabla omits it. Render
+            // the documented card when a command exists, otherwise the empty
+            // "Click to add" editor whose first Save routes through
+            // onAddPhysicalExam to create the command. No visit-type branching.
+            if (cmds) {
+              const entry = cmds[0];
+              const peRowReadOnly = rowLocked(entry.command, readOnly, isAmending);
+              return html`
+                <div class="subsection" key=${s.key}>
+                  <div class="subsection-title">${s.title}</div>
+                  <div class=${`content-block rec-narrative${peRowReadOnly && entry.command.already_documented ? ' command-locked' : ''}`}>
+                    ${peRowReadOnly && entry.command.already_documented && ICON_LOCK}
+                    <${ExamSectionsRow}
+                      command=${entry.command}
+                      commandIndex=${entry.index}
+                      onEdit=${onEditCommand}
+                      readOnly=${peRowReadOnly}
+                      onEditingChange=${onEditingChange}
+                      sectionKind="physical_exam"
+                      templates=${examTemplates}
+                      onCarryForward=${onCarryForwardExam}
+                    />
+                  </div>
+                </div>
+              `;
+            }
+            // No PE command yet: render the always-on empty "Click to add" editor
+            // against a synthetic placeholder; the provider's first Save routes
+            // through onAddPhysicalExam, which promotes the draft into a real,
+            // index-addressable command. The empty placeholder never reaches the
+            // chart — the `insertable` filter drops PE commands with no sections.
+            if (readOnly || !onAddPhysicalExam) return null;
+            const pePlaceholder = { command_type: 'physical_exam', section_key: 'physical_exam', display: '', selected: true, already_documented: false, data: { sections: [] } };
             return html`
               <div class="subsection" key=${s.key}>
                 <div class="subsection-title">${s.title}</div>
-                <div class=${`content-block rec-narrative${peRowReadOnly && entry.command.already_documented ? ' command-locked' : ''}`}>
-                  ${peRowReadOnly && entry.command.already_documented && ICON_LOCK}
+                <div class="content-block rec-narrative">
                   <${ExamSectionsRow}
-                    command=${entry.command}
-                    commandIndex=${entry.index}
-                    onEdit=${onEditCommand}
-                    readOnly=${peRowReadOnly}
+                    command=${pePlaceholder}
+                    commandIndex="physical_exam_placeholder"
+                    onEdit=${(_, data) => onAddPhysicalExam(data)}
+                    readOnly=${false}
                     onEditingChange=${onEditingChange}
                     sectionKind="physical_exam"
                     templates=${examTemplates}

--- a/hyperscribe/scribe/static/summary.js
+++ b/hyperscribe/scribe/static/summary.js
@@ -350,7 +350,7 @@ function buildCommandBySectionKey(commands) {
   return map;
 }
 
-function renderSoapGroups(sections, commandBySectionKey, onEditCommand, onDeleteCommand, { adHocCommands, objectiveAdHocCommands, historyAdHocCommands, subjectiveAdHocCommands, chargeAdHocCommands, assignees, onAddTask, onAddOrder, onAddPlan, onAddMedication, onAddAllergy, onAddStopMedication, onAddRemoveAllergy, onAddResolveCondition, onAddHistory, onAddQuestionnaire, onAddCharge, onAddTemplateCharge, onRemoveChargeByCpt, templateCharges, readOnly, isAmending, sectionConditions, patientId, noteId, staffId, staffName, recommendations, onEditRecommendation, onDeleteRecommendation, onAcceptRecommendation, onRejectRecommendation, onAddCondition, unmatchedConditions, diagnosisSuggestions, onAddNow, onAddVitals, hideRejected, alertFacilityEnabled, onEditingChange, questionnaireScores, chargeMatrixDiagnoses, chargeMatrixCharges, searchCharges, suggestedCharges, onToggleChargePointer, onReorderDiagnoses, onAddChargeModifier, onRemoveChargeModifier, onSetChargeComment, onClearChargeComment, onRemoveChargeByUuid, examTemplates, onCarryForwardExam, noteDiagnoses, isPsychiatry } = {}) {
+function renderSoapGroups(sections, commandBySectionKey, onEditCommand, onDeleteCommand, { adHocCommands, objectiveAdHocCommands, historyAdHocCommands, subjectiveAdHocCommands, chargeAdHocCommands, assignees, onAddTask, onAddOrder, onAddPlan, onAddMedication, onAddAllergy, onAddStopMedication, onAddRemoveAllergy, onAddResolveCondition, onAddHistory, onAddQuestionnaire, onAddCharge, onAddTemplateCharge, onRemoveChargeByCpt, templateCharges, readOnly, isAmending, sectionConditions, patientId, noteId, staffId, staffName, recommendations, onEditRecommendation, onDeleteRecommendation, onAcceptRecommendation, onRejectRecommendation, onAddCondition, unmatchedConditions, diagnosisSuggestions, onAddNow, onAddVitals, onAddPhysicalExam, onAddMentalStatusExam, hideRejected, alertFacilityEnabled, onEditingChange, questionnaireScores, chargeMatrixDiagnoses, chargeMatrixCharges, searchCharges, suggestedCharges, onToggleChargePointer, onReorderDiagnoses, onAddChargeModifier, onRemoveChargeModifier, onSetChargeComment, onClearChargeComment, onRemoveChargeByUuid, examTemplates, onCarryForwardExam, noteDiagnoses, isPsychiatry } = {}) {
   return SOAP_GROUPS
     .map(group => {
       const matching = sections.filter(s => group.keys.has(s.key.toLowerCase()));
@@ -373,6 +373,8 @@ function renderSoapGroups(sections, commandBySectionKey, onEditCommand, onDelete
         onAddOrder=${isPlan ? onAddOrder : null}
         onAddPlan=${isPlan ? onAddPlan : null}
         onAddVitals=${isObjective ? onAddVitals : null}
+        onAddPhysicalExam=${isObjective ? onAddPhysicalExam : null}
+        onAddMentalStatusExam=${isObjective ? onAddMentalStatusExam : null}
         onAddMedication=${isObjective ? onAddMedication : null}
         onAddAllergy=${isObjective ? onAddAllergy : null}
         onAddStopMedication=${isObjective ? onAddStopMedication : null}
@@ -1676,6 +1678,56 @@ export function Scribe({ noteId, patientId, staffId, staffName, providerName, pr
     }]);
   }, [canEdit]);
 
+  // Physical Exam is always surfaced (via ENSURE_KEYS) even when Nabla omits the
+  // section. When no PE command exists yet, the Objective group renders an empty
+  // ExamSectionsRow against a synthetic placeholder; its first Save lands here and
+  // promotes that draft into a real, index-addressable command so subsequent edits
+  // flow through the normal handleEdit path. Keyed on `physical_exam` (not an
+  // _objective_ad_hoc bucket) so it renders in the PE card and participates in the
+  // amend routing. An empty exam is dropped by the `insertable` filter, so this
+  // never writes a blank Physical Exam to the chart.
+  const handleAddPhysicalExam = useCallback((newData) => {
+    if (!canEdit) return;
+    const sections = (newData && newData.sections) || [];
+    logEvent('ADD_PHYSICAL_EXAM', { systemCount: sections.length });
+    setCommands(prev => {
+      // Defensive: if a PE command already exists (e.g. a template was applied
+      // between render and save), don't append a second one — the existing
+      // card owns the section.
+      if (prev.some(c => c.command_type === 'physical_exam')) return prev;
+      return [...prev, {
+        command_type: 'physical_exam',
+        display: sections.map(s => s.title).join(' | '),
+        data: { sections },
+        selected: true,
+        section_key: 'physical_exam',
+        already_documented: false,
+      }];
+    });
+  }, [canEdit]);
+
+  // Mental Status Exam mirrors handleAddPhysicalExam, but only fires on
+  // psychiatry visits (the Objective group gates the empty card on isPsychiatry).
+  // Promotes the first Save of the empty ExamSectionsRow into a real,
+  // index-addressable command. An empty MSE is dropped by the `insertable`
+  // filter, so this never writes a blank Mental Status Exam to the chart.
+  const handleAddMentalStatusExam = useCallback((newData) => {
+    if (!canEdit) return;
+    const sections = (newData && newData.sections) || [];
+    logEvent('ADD_MENTAL_STATUS_EXAM', { systemCount: sections.length });
+    setCommands(prev => {
+      if (prev.some(c => c.command_type === 'mental_status_exam')) return prev;
+      return [...prev, {
+        command_type: 'mental_status_exam',
+        display: sections.map(s => s.title).join(' | '),
+        data: { sections },
+        selected: true,
+        section_key: 'mental_status_exam',
+        already_documented: false,
+      }];
+    });
+  }, [canEdit]);
+
   const handleEditRecommendation = useCallback((index, newData, newType) => {
     if (!canEdit) return;
     logEvent('EDIT_REC', { index, commandType: newType, data: newData });
@@ -2824,13 +2876,17 @@ export function Scribe({ noteId, patientId, staffId, staffName, providerName, pr
     ['family_history', { key: 'family_history', title: 'Family History', text: '' }],
     ['lab_results', { key: 'lab_results', title: 'Lab Results', text: '' }],
     ['imaging_results', { key: 'imaging_results', title: 'Imaging Results', text: '' }],
-    ['physical_exam', { key: 'physical_exam', title: 'Physical Exam', text: '' }],
   ]);
   // Mental Status Exam is psychiatry-only — only force its (possibly empty)
-  // section when the selected visit template is the psychiatry one.
+  // section when the selected visit template is the psychiatry one. Ensured
+  // before Physical Exam to match SKELETON_SECTIONS order.
   if (isPsychiatry) {
     ENSURE_KEYS.set('mental_status_exam', { key: 'mental_status_exam', title: 'Mental Status Exam', text: '' });
   }
+  // Physical Exam is a standard section on every visit type — always ensured so
+  // the soap-group PE branch is reached and renders the documented card or the
+  // empty "Click to add" editor, even when Nabla omits the section.
+  ENSURE_KEYS.set('physical_exam', { key: 'physical_exam', title: 'Physical Exam', text: '' });
   const effectiveSections = (() => {
     const base = noteData ? noteData.sections : SKELETON_SECTIONS;
     const existing = new Set(base.map(s => s.key.toLowerCase()));
@@ -3067,6 +3123,8 @@ export function Scribe({ noteId, patientId, staffId, staffName, providerName, pr
           onAddOrder: canEdit ? handleAddOrder : null,
           onAddPlan: canEdit ? handleAddPlan : null,
           onAddVitals: canEdit ? handleAddVitals : null,
+          onAddPhysicalExam: canEdit ? handleAddPhysicalExam : null,
+          onAddMentalStatusExam: canEdit ? handleAddMentalStatusExam : null,
           onAddMedication: canEdit ? handleAddMedication : null,
           onAddAllergy: canEdit ? handleAddAllergy : null,
           onAddStopMedication: canEdit ? handleAddStopMedication : null,


### PR DESCRIPTION
## Problem

When the Nabla payload contained no `physical_exam` content, the Scribe Summary tab dropped the **Physical Exam section entirely** — the render branch (`soap-group.js`) only drew the card when a command already existed. There was no way to document a physical exam that Nabla didn't capture.

## Fix

Render the Physical Exam on **every visit type**, even when Nabla omits it:
- **Documented card** when a PE command exists.
- **Empty "click to add" editor** otherwise; the provider's first Save routes through `handleAddPhysicalExam`, which promotes the draft into a real, index-addressable command.
- An **untouched empty exam is dropped by the existing `insertable` filter**, so nothing blank is ever written to the chart.

`ENSURE_KEYS` now always ensures the `physical_exam` section so the render branch is reached even when Nabla returns nothing.

The psychiatry-only **Mental Status Exam** gets the same always-present treatment (empty editor when omitted), and the empty-state copy is simplified to `No <section> documented.`

## Scope / behavior

| | Non-psych | Psychiatry |
|---|---|---|
| Physical Exam | Always present (card or empty editor) | Same |
| Mental Status Exam | Not shown | Always present (card or empty editor) |

Physical Exam behaves **identically across all visit types** — no template-specific add/remove logic.

Files (frontend only):
- `summary.js` — `handleAddPhysicalExam`/`handleAddMentalStatusExam`, `ENSURE_KEYS`, section order
- `soap-group.js` — PE/MSE render branches
- `sections-exam-row.js` — empty-state copy

## Notes for reviewers

- These are Preact/htm view components; the repo has **no JS test harness**, so this rests on manual verification. The full Python `pytest` suite still passes (pre-commit), and no Python touched.
- The copy change (" Click to add." removed) is in the shared `ExamSectionsRow`, so it also affects the **ROS** and **Mental Status Exam** empty states — intentional and consistent.

## Verification

Manually verified against a psych transcript with no physical-exam content: PE renders as an empty editor that can be documented, and an untouched empty exam is not written to the chart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)