### PR TITLE
PLUGIN-333: Grounded ICD-10 recommendation pipeline (provider always picks) + Wrap Up

### DIFF
--- a/hyperscribe/CANVAS_MANIFEST.json
+++ b/hyperscribe/CANVAS_MANIFEST.json
@@ -1,6 +1,6 @@
 {
   "sdk_version": "0.155.0",
-  "plugin_version": "2026-07-02 v0.4.25",
+  "plugin_version": "2026-07-02 v0.4.26",
   "name": "hyperscribe",
   "description": "Create commands based on the content of an audio discussion between a patient and a provider.",
   "url_permissions": [

--- a/hyperscribe/CANVAS_MANIFEST.json
+++ b/hyperscribe/CANVAS_MANIFEST.json
@@ -1,6 +1,6 @@
 {
   "sdk_version": "0.155.0",
-  "plugin_version": "2026-07-02 v0.4.15",
+  "plugin_version": "2026-07-02 v0.4.16",
   "name": "hyperscribe",
   "description": "Create commands based on the content of an audio discussion between a patient and a provider.",
   "url_permissions": [

--- a/hyperscribe/CANVAS_MANIFEST.json
+++ b/hyperscribe/CANVAS_MANIFEST.json
@@ -1,6 +1,6 @@
 {
   "sdk_version": "0.155.0",
-  "plugin_version": "2026-07-07 v0.4.38",
+  "plugin_version": "2026-07-07 v0.4.40",
   "name": "hyperscribe",
   "description": "Create commands based on the content of an audio discussion between a patient and a provider.",
   "url_permissions": [

--- a/hyperscribe/CANVAS_MANIFEST.json
+++ b/hyperscribe/CANVAS_MANIFEST.json
@@ -1,6 +1,6 @@
 {
   "sdk_version": "0.155.0",
-  "plugin_version": "2026-06-30 v0.4.3",
+  "plugin_version": "2026-06-30 v0.4.4",
   "name": "hyperscribe",
   "description": "Create commands based on the content of an audio discussion between a patient and a provider.",
   "url_permissions": [

--- a/hyperscribe/CANVAS_MANIFEST.json
+++ b/hyperscribe/CANVAS_MANIFEST.json
@@ -1,6 +1,6 @@
 {
   "sdk_version": "0.155.0",
-  "plugin_version": "2026-07-02 v0.4.14",
+  "plugin_version": "2026-07-02 v0.4.15",
   "name": "hyperscribe",
   "description": "Create commands based on the content of an audio discussion between a patient and a provider.",
   "url_permissions": [

--- a/hyperscribe/CANVAS_MANIFEST.json
+++ b/hyperscribe/CANVAS_MANIFEST.json
@@ -1,6 +1,6 @@
 {
   "sdk_version": "0.155.0",
-  "plugin_version": "2026-07-01 v0.4.13",
+  "plugin_version": "2026-07-02 v0.4.14",
   "name": "hyperscribe",
   "description": "Create commands based on the content of an audio discussion between a patient and a provider.",
   "url_permissions": [

--- a/hyperscribe/CANVAS_MANIFEST.json
+++ b/hyperscribe/CANVAS_MANIFEST.json
@@ -1,6 +1,6 @@
 {
   "sdk_version": "0.155.0",
-  "plugin_version": "2026-07-06 v0.4.32",
+  "plugin_version": "2026-07-07 v0.4.33",
   "name": "hyperscribe",
   "description": "Create commands based on the content of an audio discussion between a patient and a provider.",
   "url_permissions": [

--- a/hyperscribe/CANVAS_MANIFEST.json
+++ b/hyperscribe/CANVAS_MANIFEST.json
@@ -1,6 +1,6 @@
 {
   "sdk_version": "0.155.0",
-  "plugin_version": "2026-07-02 v0.4.26",
+  "plugin_version": "2026-07-02 v0.4.27",
   "name": "hyperscribe",
   "description": "Create commands based on the content of an audio discussion between a patient and a provider.",
   "url_permissions": [

--- a/hyperscribe/CANVAS_MANIFEST.json
+++ b/hyperscribe/CANVAS_MANIFEST.json
@@ -1,6 +1,6 @@
 {
   "sdk_version": "0.155.0",
-  "plugin_version": "2026-06-30 v0.4.6",
+  "plugin_version": "2026-07-01 v0.4.7",
   "name": "hyperscribe",
   "description": "Create commands based on the content of an audio discussion between a patient and a provider.",
   "url_permissions": [

--- a/hyperscribe/CANVAS_MANIFEST.json
+++ b/hyperscribe/CANVAS_MANIFEST.json
@@ -1,6 +1,6 @@
 {
   "sdk_version": "0.155.0",
-  "plugin_version": "2026-07-01 v0.4.8",
+  "plugin_version": "2026-07-01 v0.4.9",
   "name": "hyperscribe",
   "description": "Create commands based on the content of an audio discussion between a patient and a provider.",
   "url_permissions": [

--- a/hyperscribe/CANVAS_MANIFEST.json
+++ b/hyperscribe/CANVAS_MANIFEST.json
@@ -1,6 +1,6 @@
 {
   "sdk_version": "0.155.0",
-  "plugin_version": "2026-07-06 v0.4.31",
+  "plugin_version": "2026-07-06 v0.4.32",
   "name": "hyperscribe",
   "description": "Create commands based on the content of an audio discussion between a patient and a provider.",
   "url_permissions": [

--- a/hyperscribe/CANVAS_MANIFEST.json
+++ b/hyperscribe/CANVAS_MANIFEST.json
@@ -1,6 +1,6 @@
 {
   "sdk_version": "0.155.0",
-  "plugin_version": "2026-07-07 v0.4.34",
+  "plugin_version": "2026-07-07 v0.4.35",
   "name": "hyperscribe",
   "description": "Create commands based on the content of an audio discussion between a patient and a provider.",
   "url_permissions": [

--- a/hyperscribe/CANVAS_MANIFEST.json
+++ b/hyperscribe/CANVAS_MANIFEST.json
@@ -1,6 +1,6 @@
 {
   "sdk_version": "0.155.0",
-  "plugin_version": "2026-07-07 v0.4.36",
+  "plugin_version": "2026-07-07 v0.4.37",
   "name": "hyperscribe",
   "description": "Create commands based on the content of an audio discussion between a patient and a provider.",
   "url_permissions": [

--- a/hyperscribe/CANVAS_MANIFEST.json
+++ b/hyperscribe/CANVAS_MANIFEST.json
@@ -1,6 +1,6 @@
 {
   "sdk_version": "0.155.0",
-  "plugin_version": "2026-07-02 v0.4.27",
+  "plugin_version": "2026-07-02 v0.4.28",
   "name": "hyperscribe",
   "description": "Create commands based on the content of an audio discussion between a patient and a provider.",
   "url_permissions": [

--- a/hyperscribe/CANVAS_MANIFEST.json
+++ b/hyperscribe/CANVAS_MANIFEST.json
@@ -1,6 +1,6 @@
 {
   "sdk_version": "0.155.0",
-  "plugin_version": "2026-06-30 v0.4.2",
+  "plugin_version": "2026-06-30 v0.4.3",
   "name": "hyperscribe",
   "description": "Create commands based on the content of an audio discussion between a patient and a provider.",
   "url_permissions": [

--- a/hyperscribe/CANVAS_MANIFEST.json
+++ b/hyperscribe/CANVAS_MANIFEST.json
@@ -1,6 +1,6 @@
 {
   "sdk_version": "0.155.0",
-  "plugin_version": "2026-07-02 v0.4.29",
+  "plugin_version": "2026-07-02 v0.4.30",
   "name": "hyperscribe",
   "description": "Create commands based on the content of an audio discussion between a patient and a provider.",
   "url_permissions": [

--- a/hyperscribe/CANVAS_MANIFEST.json
+++ b/hyperscribe/CANVAS_MANIFEST.json
@@ -1,6 +1,6 @@
 {
   "sdk_version": "0.155.0",
-  "plugin_version": "2026-07-02 v0.4.18",
+  "plugin_version": "2026-07-02 v0.4.19",
   "name": "hyperscribe",
   "description": "Create commands based on the content of an audio discussion between a patient and a provider.",
   "url_permissions": [

--- a/hyperscribe/CANVAS_MANIFEST.json
+++ b/hyperscribe/CANVAS_MANIFEST.json
@@ -1,6 +1,6 @@
 {
   "sdk_version": "0.155.0",
-  "plugin_version": "2026-06-24 v0.3.13",
+  "plugin_version": "2026-06-30 v0.4.0",
   "name": "hyperscribe",
   "description": "Create commands based on the content of an audio discussion between a patient and a provider.",
   "url_permissions": [

--- a/hyperscribe/CANVAS_MANIFEST.json
+++ b/hyperscribe/CANVAS_MANIFEST.json
@@ -1,6 +1,6 @@
 {
   "sdk_version": "0.155.0",
-  "plugin_version": "2026-07-02 v0.4.16",
+  "plugin_version": "2026-07-02 v0.4.17",
   "name": "hyperscribe",
   "description": "Create commands based on the content of an audio discussion between a patient and a provider.",
   "url_permissions": [

--- a/hyperscribe/CANVAS_MANIFEST.json
+++ b/hyperscribe/CANVAS_MANIFEST.json
@@ -1,6 +1,6 @@
 {
   "sdk_version": "0.155.0",
-  "plugin_version": "2026-07-02 v0.4.20",
+  "plugin_version": "2026-07-02 v0.4.21",
   "name": "hyperscribe",
   "description": "Create commands based on the content of an audio discussion between a patient and a provider.",
   "url_permissions": [

--- a/hyperscribe/CANVAS_MANIFEST.json
+++ b/hyperscribe/CANVAS_MANIFEST.json
@@ -1,6 +1,6 @@
 {
   "sdk_version": "0.155.0",
-  "plugin_version": "2026-07-02 v0.4.21",
+  "plugin_version": "2026-07-02 v0.4.22",
   "name": "hyperscribe",
   "description": "Create commands based on the content of an audio discussion between a patient and a provider.",
   "url_permissions": [

--- a/hyperscribe/CANVAS_MANIFEST.json
+++ b/hyperscribe/CANVAS_MANIFEST.json
@@ -1,6 +1,6 @@
 {
   "sdk_version": "0.155.0",
-  "plugin_version": "2026-06-30 v0.4.1",
+  "plugin_version": "2026-06-30 v0.4.2",
   "name": "hyperscribe",
   "description": "Create commands based on the content of an audio discussion between a patient and a provider.",
   "url_permissions": [

--- a/hyperscribe/CANVAS_MANIFEST.json
+++ b/hyperscribe/CANVAS_MANIFEST.json
@@ -1,6 +1,6 @@
 {
   "sdk_version": "0.155.0",
-  "plugin_version": "2026-06-30 v0.4.5",
+  "plugin_version": "2026-06-30 v0.4.6",
   "name": "hyperscribe",
   "description": "Create commands based on the content of an audio discussion between a patient and a provider.",
   "url_permissions": [

--- a/hyperscribe/CANVAS_MANIFEST.json
+++ b/hyperscribe/CANVAS_MANIFEST.json
@@ -1,6 +1,6 @@
 {
   "sdk_version": "0.155.0",
-  "plugin_version": "2026-07-02 v0.4.19",
+  "plugin_version": "2026-07-02 v0.4.20",
   "name": "hyperscribe",
   "description": "Create commands based on the content of an audio discussion between a patient and a provider.",
   "url_permissions": [

--- a/hyperscribe/CANVAS_MANIFEST.json
+++ b/hyperscribe/CANVAS_MANIFEST.json
@@ -1,6 +1,6 @@
 {
   "sdk_version": "0.155.0",
-  "plugin_version": "2026-07-01 v0.4.10",
+  "plugin_version": "2026-07-01 v0.4.11",
   "name": "hyperscribe",
   "description": "Create commands based on the content of an audio discussion between a patient and a provider.",
   "url_permissions": [

--- a/hyperscribe/CANVAS_MANIFEST.json
+++ b/hyperscribe/CANVAS_MANIFEST.json
@@ -1,6 +1,6 @@
 {
   "sdk_version": "0.155.0",
-  "plugin_version": "2026-07-01 v0.4.7",
+  "plugin_version": "2026-07-01 v0.4.8",
   "name": "hyperscribe",
   "description": "Create commands based on the content of an audio discussion between a patient and a provider.",
   "url_permissions": [

--- a/hyperscribe/CANVAS_MANIFEST.json
+++ b/hyperscribe/CANVAS_MANIFEST.json
@@ -1,6 +1,6 @@
 {
   "sdk_version": "0.155.0",
-  "plugin_version": "2026-07-02 v0.4.23",
+  "plugin_version": "2026-07-02 v0.4.24",
   "name": "hyperscribe",
   "description": "Create commands based on the content of an audio discussion between a patient and a provider.",
   "url_permissions": [

--- a/hyperscribe/CANVAS_MANIFEST.json
+++ b/hyperscribe/CANVAS_MANIFEST.json
@@ -1,6 +1,6 @@
 {
   "sdk_version": "0.155.0",
-  "plugin_version": "2026-07-02 v0.4.28",
+  "plugin_version": "2026-07-02 v0.4.29",
   "name": "hyperscribe",
   "description": "Create commands based on the content of an audio discussion between a patient and a provider.",
   "url_permissions": [

--- a/hyperscribe/CANVAS_MANIFEST.json
+++ b/hyperscribe/CANVAS_MANIFEST.json
@@ -1,6 +1,6 @@
 {
   "sdk_version": "0.155.0",
-  "plugin_version": "2026-06-30 v0.4.0",
+  "plugin_version": "2026-06-30 v0.4.1",
   "name": "hyperscribe",
   "description": "Create commands based on the content of an audio discussion between a patient and a provider.",
   "url_permissions": [

--- a/hyperscribe/CANVAS_MANIFEST.json
+++ b/hyperscribe/CANVAS_MANIFEST.json
@@ -1,6 +1,6 @@
 {
   "sdk_version": "0.155.0",
-  "plugin_version": "2026-07-02 v0.4.22",
+  "plugin_version": "2026-07-02 v0.4.23",
   "name": "hyperscribe",
   "description": "Create commands based on the content of an audio discussion between a patient and a provider.",
   "url_permissions": [

--- a/hyperscribe/CANVAS_MANIFEST.json
+++ b/hyperscribe/CANVAS_MANIFEST.json
@@ -1,6 +1,6 @@
 {
   "sdk_version": "0.155.0",
-  "plugin_version": "2026-07-01 v0.4.12",
+  "plugin_version": "2026-07-01 v0.4.13",
   "name": "hyperscribe",
   "description": "Create commands based on the content of an audio discussion between a patient and a provider.",
   "url_permissions": [

--- a/hyperscribe/CANVAS_MANIFEST.json
+++ b/hyperscribe/CANVAS_MANIFEST.json
@@ -1,6 +1,6 @@
 {
   "sdk_version": "0.155.0",
-  "plugin_version": "2026-07-01 v0.4.9",
+  "plugin_version": "2026-07-01 v0.4.10",
   "name": "hyperscribe",
   "description": "Create commands based on the content of an audio discussion between a patient and a provider.",
   "url_permissions": [

--- a/hyperscribe/CANVAS_MANIFEST.json
+++ b/hyperscribe/CANVAS_MANIFEST.json
@@ -1,6 +1,6 @@
 {
   "sdk_version": "0.155.0",
-  "plugin_version": "2026-07-01 v0.4.11",
+  "plugin_version": "2026-07-01 v0.4.12",
   "name": "hyperscribe",
   "description": "Create commands based on the content of an audio discussion between a patient and a provider.",
   "url_permissions": [

--- a/hyperscribe/CANVAS_MANIFEST.json
+++ b/hyperscribe/CANVAS_MANIFEST.json
@@ -1,6 +1,6 @@
 {
   "sdk_version": "0.155.0",
-  "plugin_version": "2026-07-02 v0.4.17",
+  "plugin_version": "2026-07-02 v0.4.18",
   "name": "hyperscribe",
   "description": "Create commands based on the content of an audio discussion between a patient and a provider.",
   "url_permissions": [

--- a/hyperscribe/CANVAS_MANIFEST.json
+++ b/hyperscribe/CANVAS_MANIFEST.json
@@ -1,6 +1,6 @@
 {
   "sdk_version": "0.155.0",
-  "plugin_version": "2026-06-30 v0.4.4",
+  "plugin_version": "2026-06-30 v0.4.5",
   "name": "hyperscribe",
   "description": "Create commands based on the content of an audio discussion between a patient and a provider.",
   "url_permissions": [

--- a/hyperscribe/CANVAS_MANIFEST.json
+++ b/hyperscribe/CANVAS_MANIFEST.json
@@ -1,6 +1,6 @@
 {
   "sdk_version": "0.155.0",
-  "plugin_version": "2026-07-07 v0.4.33",
+  "plugin_version": "2026-07-07 v0.4.34",
   "name": "hyperscribe",
   "description": "Create commands based on the content of an audio discussion between a patient and a provider.",
   "url_permissions": [

--- a/hyperscribe/CANVAS_MANIFEST.json
+++ b/hyperscribe/CANVAS_MANIFEST.json
@@ -1,6 +1,6 @@
 {
   "sdk_version": "0.155.0",
-  "plugin_version": "2026-07-02 v0.4.30",
+  "plugin_version": "2026-07-06 v0.4.31",
   "name": "hyperscribe",
   "description": "Create commands based on the content of an audio discussion between a patient and a provider.",
   "url_permissions": [

--- a/hyperscribe/CANVAS_MANIFEST.json
+++ b/hyperscribe/CANVAS_MANIFEST.json
@@ -1,6 +1,6 @@
 {
   "sdk_version": "0.155.0",
-  "plugin_version": "2026-07-02 v0.4.24",
+  "plugin_version": "2026-07-02 v0.4.25",
   "name": "hyperscribe",
   "description": "Create commands based on the content of an audio discussion between a patient and a provider.",
   "url_permissions": [

--- a/hyperscribe/models/scribe.py
+++ b/hyperscribe/models/scribe.py
@@ -43,6 +43,11 @@ class ScribeSummary(CustomModel):
     selected_template_name: Any = TextField(default="")
     mode: Any = TextField(default="")
     raw_response: Any = JSONField(default=dict)
+    # Raw Nabla /generate-normalized-data response, stored for analysis,
+    # evaluations, and debugging of the ICD-10 ranking pipeline. Same PHI
+    # class as raw_response (the raw note-generation response) — never log
+    # its contents.
+    raw_normalized_response: Any = JSONField(default=dict)
     updated_at: Any = DateTimeField(auto_now=True)
 
 

--- a/hyperscribe/scribe/api/session_view.py
+++ b/hyperscribe/scribe/api/session_view.py
@@ -1369,14 +1369,15 @@ class ScribeSessionView(StaffSessionAuthMixin, SimpleAPI):
         }
 
         # ── Step 4b: Give generic referrals a validated indication ──
-        # Match each referral's condition to a code already in the note (diagnose
-        # commands → diagnosis suggestions → unmatched conditions) so a generic,
-        # provider-less referral is commit-ready. Never fabricates a code.
+        # Match each referral's condition to a code already in the note — a coded
+        # diagnose command or an active-chart (unmatched) condition — so a generic,
+        # provider-less referral is commit-ready. Never fabricates a code, and never
+        # links from a still-uncoded block's ranked suggestions (that would stamp a
+        # guess the provider may not pick); those are linked to the provider's final
+        # code at reconciliation time by the frontend live-linker.
         if recommendations_list:
             try:
-                link_referral_diagnoses(
-                    recommendations_list, commands_list, unmatched_conditions, diagnosis_suggestions
-                )
+                link_referral_diagnoses(recommendations_list, commands_list, unmatched_conditions)
             except Exception:
                 log.exception("link_referral_diagnoses failed (non-critical)")
 

--- a/hyperscribe/scribe/api/session_view.py
+++ b/hyperscribe/scribe/api/session_view.py
@@ -55,6 +55,7 @@ from hyperscribe.scribe.backend import (
     get_backend_from_secrets,
 )
 from hyperscribe.scribe.commands.ap_split import split_plan_into_diagnoses
+from hyperscribe.scribe.commands.diagnosis_candidates import PatientConditionSnapshot
 from hyperscribe.scribe.commands.builder import (
     DIRECT_EDIT_SECTIONS,
     EDITABLE_AMEND_SECTIONS,
@@ -416,6 +417,54 @@ def _load_active_patient_conditions(patient_id: str) -> list[ActivePatientCondit
     return results
 
 
+def _load_patient_condition_history(patient_id: str) -> list[PatientConditionSnapshot]:
+    """Return the patient's committed conditions — active AND inactive (resolved,
+    remission, relapse, investigative) — narrowed to what the ICD-10 ranker needs.
+
+    Distinct from :func:`_load_active_patient_conditions` (which is ``.active()``
+    only and feeds the legacy rewrite/belt): the ranker uses prior conditions as a
+    selection signal and to show provenance ("Resolved 2021"), so this drops the
+    ``.active()`` filter and carries ``clinical_status`` / ``onset_date`` /
+    ``resolution_date``.
+
+    Best-effort: any ORM error returns ``[]`` so ``/generate-summary`` never dies
+    on a condition lookup (mirrors the contract documented in
+    ``ap_split._build_active_condition_icd10_index``). PHI: log only counts —
+    never codes, displays, or patient identifiers.
+    """
+    if not patient_id:
+        return []
+    try:
+        conditions = (
+            ConditionModel.objects.committed()
+            .for_patient(patient_id)
+            .prefetch_related("codings")
+            .order_by("-onset_date")
+        )
+        results: list[PatientConditionSnapshot] = []
+        for condition in conditions:
+            codings = list(condition.codings.all())
+            if not codings:
+                continue
+            icd10 = next((coding for coding in codings if "icd" in (coding.system or "").lower()), None)
+            chosen = icd10 or codings[0]
+            results.append(
+                PatientConditionSnapshot(
+                    condition_id=str(condition.id),
+                    code=chosen.code or "",
+                    display=chosen.display or "",
+                    system=chosen.system or "",
+                    clinical_status=condition.clinical_status or "",
+                    onset_date=condition.onset_date.isoformat() if condition.onset_date else "",
+                    resolution_date=condition.resolution_date.isoformat() if condition.resolution_date else "",
+                )
+            )
+        return results
+    except Exception:
+        log.exception("patient condition history lookup failed for note generation")
+        return []
+
+
 def _match_conditions_to_sections(
     note: ClinicalNote,
     conditions: list[Condition],
@@ -485,6 +534,8 @@ def _save_summary(note_id: str, payload: dict[str, Any]) -> None:
         defaults["mode"] = payload["mode"] or ""
     if "raw_response" in payload:
         defaults["raw_response"] = payload["raw_response"]
+    if "raw_normalized_response" in payload:
+        defaults["raw_normalized_response"] = payload["raw_normalized_response"]
     ScribeSummary.objects.update_or_create(note_id=note_dbid, defaults=defaults)
 
 
@@ -859,6 +910,7 @@ class ScribeSessionView(StaffSessionAuthMixin, SimpleAPI):
                 "selected_template_name",
                 "mode",
                 "raw_response",
+                "raw_normalized_response",
                 "updated_at",
             )
             .first()
@@ -1237,8 +1289,17 @@ class ScribeSessionView(StaffSessionAuthMixin, SimpleAPI):
                     note_for_split = Note.objects.select_related("patient").get(id=note_uuid)
                 except Note.DoesNotExist:
                     note_for_split = None
+        # Feed the grounded ranker the patient's full condition history (active +
+        # inactive) for selection/provenance, and the science service for the
+        # fallback/unspecified-refinement lookups. ``note`` still drives the
+        # active-only condition_id stamping (diagnose→assess flip eligibility).
+        chart_conditions = _load_patient_condition_history(str(data.get("patient_id", "")))
         commands_list, unmatched_conditions = split_plan_into_diagnoses(
-            commands_list, section_conditions, note=note_for_split
+            commands_list,
+            section_conditions,
+            note=note_for_split,
+            chart_conditions=chart_conditions,
+            science_search=CanvasScience.search_conditions,
         )
         prefill_diagnose_backgrounds(commands_list, note_uuid)
 
@@ -1292,20 +1353,20 @@ class ScribeSessionView(StaffSessionAuthMixin, SimpleAPI):
             except Exception:
                 log.exception("interaction check failed (non-critical)")
 
-        # ── Step 4: Suggest diagnoses for unmatched blocks ──
+        # ── Step 4: Collect grounded suggestions for uncoded blocks ──
+        # The A&P belt already stamped ranked, science/chart-grounded
+        # ``candidate_suggestions`` on each uncoded diagnose proposal (no LLM, no
+        # invented codes). Surface them as a ``block_id -> options`` map — the
+        # stable association key, replacing the old mutable-header keying.
         _save_progress(note_id, 4, total, SUMMARY_STEPS[4])
-        diagnosis_suggestions: dict[str, Any] = {}
-        unmatched_headers = [
-            c["data"].get("condition_header", "")
+        diagnosis_suggestions: dict[str, Any] = {
+            c["data"]["block_id"]: c["data"]["candidate_suggestions"]
             for c in commands_list
-            if c.get("command_type") == "diagnose" and not c.get("data", {}).get("icd10_code")
-        ]
-        unmatched_headers = [h for h in unmatched_headers if h]
-        if unmatched_headers and api_key:
-            try:
-                diagnosis_suggestions = suggest_diagnoses(unmatched_headers, api_key)
-            except Exception:
-                log.exception("suggest_diagnoses failed (non-critical)")
+            if c.get("command_type") == "diagnose"
+            and not c.get("data", {}).get("icd10_code")
+            and c.get("data", {}).get("block_id")
+            and c.get("data", {}).get("candidate_suggestions")
+        }
 
         # ── Step 4b: Give generic referrals a validated indication ──
         # Match each referral's condition to a code already in the note (diagnose
@@ -1339,6 +1400,9 @@ class ScribeSessionView(StaffSessionAuthMixin, SimpleAPI):
             summary_payload["selected_template_name"] = data["selected_template_name"]
         if raw_response is not None:
             summary_payload["raw_response"] = raw_response
+        raw_normalized_response = getattr(backend, "_last_raw_normalized_response", None)
+        if raw_normalized_response is not None:
+            summary_payload["raw_normalized_response"] = raw_normalized_response
         _save_summary(note_id, summary_payload)
 
         return [
@@ -1548,16 +1612,9 @@ class ScribeSessionView(StaffSessionAuthMixin, SimpleAPI):
         conditions = data.get("conditions", [])
         if not conditions or not isinstance(conditions, list):
             return [JSONResponse({"suggestions": {}}, status_code=HTTPStatus.OK)]
-        api_key = self.secrets.get("AnthropicAPIKey", "")
-        if not api_key:
-            return [
-                JSONResponse(
-                    {"error": "AnthropicAPIKey secret is not configured"},
-                    status_code=HTTPStatus.BAD_REQUEST,
-                )
-            ]
         try:
-            suggestions = suggest_diagnoses(conditions, api_key)
+            # Grounded in the science service only — no LLM, no invented codes.
+            suggestions = suggest_diagnoses(conditions)
         except Exception:
             log.exception("suggest_diagnoses failed")
             return [

--- a/hyperscribe/scribe/api/session_view.py
+++ b/hyperscribe/scribe/api/session_view.py
@@ -1394,13 +1394,9 @@ class ScribeSessionView(StaffSessionAuthMixin, SimpleAPI):
                         command = by_block.get(block_id)
                         if command is None:
                             continue
-                        if resolution.chosen is not None:
-                            code, display = resolution.chosen
-                            command["data"]["icd10_code"] = code
-                            command["data"]["icd10_display"] = display
-                            # Auto-applied: no longer uncoded, drop the picker options.
-                            command["data"].pop("candidate_suggestions", None)
-                        elif resolution.suggestions:
+                        # Never auto-apply — only surface the resolver's grounded suggestions;
+                        # the provider picks the code in the picker.
+                        if resolution.suggestions:
                             command["data"]["candidate_suggestions"] = resolution.suggestions
                 except Exception:
                     log.exception("diagnosis LLM resolver failed (non-critical)")

--- a/hyperscribe/scribe/api/session_view.py
+++ b/hyperscribe/scribe/api/session_view.py
@@ -82,8 +82,12 @@ from hyperscribe.scribe.commands.problem_list_match import (
     ActivePatientCondition,
     prefer_patient_specific_codes,
 )
-from hyperscribe.scribe.recommendations import prescription_dispense_enabled, recommend_commands
+from hyperscribe.scribe.recommendations import make_llm_client, prescription_dispense_enabled, recommend_commands
 from hyperscribe.scribe.recommendations._referral_diagnosis import link_referral_diagnoses
+from hyperscribe.scribe.recommendations.diagnosis_llm_resolver import (
+    BlockContext as DiagnosisBlockContext,
+    resolve_uncoded_blocks,
+)
 from hyperscribe.scribe.recommendations.diagnosis_suggestion import suggest_diagnoses
 from hyperscribe.scribe.recommendations.interactions import (
     check_recommendation_interactions,
@@ -1359,6 +1363,52 @@ class ScribeSessionView(StaffSessionAuthMixin, SimpleAPI):
         # invented codes). Surface them as a ``block_id -> options`` map — the
         # stable association key, replacing the old mutable-header keying.
         _save_progress(note_id, 4, total, SUMMARY_STEPS[4])
+        # Grounded-LLM resolver: for the blocks the deterministic belt could not code,
+        # retrieve real ICD-10 codes and let the LLM select the best (auto-apply on high
+        # confidence) or curate a grounded picker. Best-effort — never invents a code,
+        # never overrides a code the belt already applied, never crashes generation.
+        if api_key:
+            uncoded_blocks = [
+                DiagnosisBlockContext(
+                    block_id=c["data"]["block_id"],
+                    header=c["data"].get("condition_header", ""),
+                    body=c["data"].get("today_assessment", ""),
+                    candidates=c["data"].get("candidate_suggestions") or [],
+                )
+                for c in commands_list
+                if c.get("command_type") == "diagnose"
+                and not c.get("data", {}).get("icd10_code")
+                and c.get("data", {}).get("block_id")
+            ]
+            if uncoded_blocks:
+                try:
+                    resolutions = resolve_uncoded_blocks(
+                        uncoded_blocks,
+                        lambda: make_llm_client(api_key),
+                        CanvasScience.search_conditions,
+                    )
+                    by_block = {
+                        c["data"].get("block_id"): c for c in commands_list if c.get("command_type") == "diagnose"
+                    }
+                    for block_id, resolution in resolutions.items():
+                        command = by_block.get(block_id)
+                        if command is None:
+                            continue
+                        if resolution.chosen is not None:
+                            code, display = resolution.chosen
+                            command["data"]["icd10_code"] = code
+                            command["data"]["icd10_display"] = display
+                            # Auto-applied: no longer uncoded, drop the picker options.
+                            command["data"].pop("candidate_suggestions", None)
+                        elif resolution.suggestions:
+                            command["data"]["candidate_suggestions"] = resolution.suggestions
+                except Exception:
+                    log.exception("diagnosis LLM resolver failed (non-critical)")
+
+        # The belt + resolver have stamped ranked, science/chart-grounded
+        # ``candidate_suggestions`` on each still-uncoded diagnose proposal (no invented
+        # codes). Surface them as a ``block_id -> options`` map — the stable association
+        # key, replacing the old mutable-header keying.
         diagnosis_suggestions: dict[str, Any] = {
             c["data"]["block_id"]: c["data"]["candidate_suggestions"]
             for c in commands_list

--- a/hyperscribe/scribe/clients/nabla/backend.py
+++ b/hyperscribe/scribe/clients/nabla/backend.py
@@ -174,6 +174,10 @@ class NablaBackend(ScribeBackend):
             "include_corresponding_note_problems": True,
         }
         raw = self._rest_client.generate_normalized_data(payload)
+        # Stash the raw normalized-data response (mirrors _last_raw_note_response)
+        # so /generate-summary can persist it for analysis/regression of the
+        # ICD-10 ranking pipeline.
+        self._last_raw_normalized_response = raw
         return self._parse_normalized_data(raw)
 
     # Remap section titles from Nabla to user-facing labels.

--- a/hyperscribe/scribe/commands/ap_split.py
+++ b/hyperscribe/scribe/commands/ap_split.py
@@ -359,10 +359,18 @@ def split_plan_into_diagnoses(
         # pointless one-option picker).
         unspecified_options: list = []
         if chosen is not None and is_unspecified_code(chosen.code, chosen.display):
-            children = expand_unspecified(chosen, science_search)
+            # Rank both the unspecified code and its refinements by how well each matches
+            # the documented note text (header + assessment), so a specificity the note
+            # actually states (e.g. "moderate" -> F32.1) leads and the unspecified only
+            # leads when the note is genuinely vague.
+            context_text = f"{header}\n" + "\n".join(block.body)
+            children = expand_unspecified(chosen, science_search, context_text=context_text)
             if children:
-                # Offer the unspecified code first, then the more-specific siblings.
-                unspecified_options = [chosen, *children]
+                unspecified_options = sorted(
+                    [chosen, *children],
+                    key=lambda candidate: word_overlap(context_text, candidate.display),
+                    reverse=True,
+                )
                 chosen = None  # defer to a provider pick
 
         data: dict[str, Any] = {

--- a/hyperscribe/scribe/commands/ap_split.py
+++ b/hyperscribe/scribe/commands/ap_split.py
@@ -9,6 +9,14 @@ from logger import log
 if TYPE_CHECKING:
     from canvas_sdk.v1.data.note import Note
 
+    # Annotation-only imports (``from __future__ import annotations`` keeps these
+    # as strings at runtime, so there is no import cycle even though
+    # ``diagnosis_candidates`` imports text helpers from this module).
+    from hyperscribe.scribe.commands.diagnosis_candidates import (
+        PatientConditionSnapshot,
+        ScienceSearch,
+    )
+
 
 _STOP_WORDS = frozenset(
     {
@@ -244,24 +252,38 @@ def split_plan_into_diagnoses(
     commands: list[dict[str, Any]],
     section_conditions: dict[str, list[dict[str, Any]]],
     note: Note | None = None,
+    *,
+    chart_conditions: list[PatientConditionSnapshot] | None = None,
+    science_search: ScienceSearch | None = None,
 ) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
     """Replace the plan/assessment_and_plan command with per-condition diagnose commands.
 
     Returns ``(updated_commands, unmatched_conditions)`` where *unmatched_conditions*
-    are conditions from normalized data that did not match any A&P block header.
+    are conditions from normalized data that no A&P block claimed.
 
-    KOALA_5635_STAMP_CONDITION_ID — when ``note`` is supplied, each produced
-    diagnose proposal whose ``icd10_code`` matches an active condition on the
-    note's patient gets ``data["condition_id"]`` stamped with the SDK
-    ``condition.id``. That makes the proposal eligible for the per-(patient,
-    condition) background carry-forward (the frontend later flips
-    ``command_type`` from ``diagnose`` → ``assess`` at insert time when the
-    same ICD-match holds; see ``handleInsert`` in summary.js).
+    Code selection is delegated to the grounded ranker in ``diagnosis_candidates``:
+    for each block, ALL codings of the associated Nabla condition(s) — plus the
+    patient's chart codes (``chart_conditions``) and, as a last resort, a grounded
+    science search (``science_search``) — enter a clinically-ranked candidate set.
+    A single confident match is auto-applied; otherwise the block is left UNCODED
+    and ``data["candidate_suggestions"]`` carries the ranked options for the
+    provider to pick. This replaces the old first-match-wins ``next(...)`` pick,
+    which let an incidental symptom code (e.g. R45.851) win over the real
+    diagnosis (e.g. F33.1) and orphaned the rest.
 
-    Why ``note`` is optional: ``split_plan_into_diagnoses`` was pure (no DB
-    access) prior to KOALA-5635 and existing callers in tests still rely on
-    that contract. Callers that have a ``note`` opt-in to the stamping by
-    passing it; callers that don't get the original behavior.
+    Each proposal is stamped with a stable ``data["block_id"]`` (``apblock-{i}``),
+    the association key used downstream instead of the mutable condition header.
+
+    KOALA_5635_STAMP_CONDITION_ID — a proposal whose chosen code matches an ACTIVE
+    condition on the patient gets ``data["condition_id"]`` stamped (from the
+    ``note``-derived active index and/or the chosen chart candidate), keeping it
+    eligible for the diagnose→assess flip. Resolved/inactive matches never carry a
+    condition_id (the SDK has no reactivation command).
+
+    Why the keyword args are optional: the pure (no DB / no network) contract is
+    preserved for existing callers — when ``chart_conditions``/``science_search``
+    are omitted, ranking runs on the Nabla codings alone (which already fixes the
+    symptom-over-diagnosis defect).
     """
     ap_idx = -1
     for i, c in enumerate(commands):
@@ -278,14 +300,26 @@ def split_plan_into_diagnoses(
     if not blocks:
         return commands, []
 
+    # Lazy import to avoid an import cycle: ``diagnosis_candidates`` imports the
+    # text helpers (``word_overlap`` / ``significant_words``) from this module at
+    # load time, so this module must not import it at module scope.
+    from hyperscribe.scribe.commands.diagnosis_candidates import (
+        build_block_candidates,
+        expand_unspecified,
+        is_unspecified_code,
+        serialize_candidate,
+    )
+
     diagnose_commands: list[dict[str, Any]] = []
-    matched_set: set[int] = set()
+    claimed: set[int] = set()
     # KOALA_5635_STAMP_CONDITION_ID — build the active-condition ICD-10 index
     # once per call (not per block) so we don't N+1 patient_conditions per
     # diagnose proposal. ``{}`` when ``note`` is None or the lookup fails.
     active_icd10_index = _build_active_condition_icd10_index(note) if note is not None else {}
+    chart = chart_conditions or []
 
-    for block in blocks:
+    for i, block in enumerate(blocks):
+        block_id = f"apblock-{i}"
         # Strip a trailing colon from the header. split_by_problem templates emit
         # problem headers as "Diagnosis:" (followed by bulleted plan), and the
         # colon breaks the exact match against Nabla's colon-less
@@ -295,48 +329,57 @@ def split_plan_into_diagnoses(
         header = block.header.strip()
         if header.endswith(":"):
             header = header[:-1].strip()
-        # Prefer exact match via Nabla's corresponding_note_problem field.
-        matched = next(
-            (
-                c
-                for c in codes
-                if c.get("corresponding_note_problem")
-                and c["corresponding_note_problem"].strip().lower() == header.lower()
-            ),
-            None,
-        )
-        if not matched:
-            matched = match_condition(header, codes)
-        icd: dict[str, Any] | None = None
-        if matched:
-            icd = next((cd for cd in (matched.get("coding") or []) if cd.get("code")), None)
-            matched_set.add(id(matched))
-        if icd and matched:
-            display = icd.get("display") or matched.get("display") or header
-            icd10_code: str | None = icd["code"]
-            icd10_display = icd.get("display") or matched.get("display") or ""
-        else:
-            display = header
-            icd10_code = None
-            icd10_display = ""
-        # KOALA_5635_STAMP_CONDITION_ID — when this proposal's icd10_code
-        # matches an active condition on the note's patient, stamp the SDK
-        # condition_id so the dict-shaped carry-forward prefill at the call
-        # site can scope the background lookup to (patient, condition).
-        # Additive only: we do NOT flip command_type to "assess" here — the
-        # frontend handleInsert flip (KOALA-5634 territory) still owns the
-        # diagnose→assess decision at insert time.
+
+        # Associate Nabla condition(s) with this block. Exact
+        # ``corresponding_note_problem`` matches first — note there may be SEVERAL
+        # (Nabla attaches the same note problem to a definitive code AND incidental
+        # symptom codes), and we keep ALL of them so the ranker, not list order,
+        # decides. Falls back to a single fuzzy header match.
+        nabla_for_block = [
+            c
+            for c in codes
+            if c.get("corresponding_note_problem") and c["corresponding_note_problem"].strip().lower() == header.lower()
+        ]
+        if not nabla_for_block:
+            fuzzy = match_condition(header, codes)
+            if fuzzy is not None:
+                nabla_for_block = [fuzzy]
+        for condition in nabla_for_block:
+            claimed.add(id(condition))
+
+        block_candidates = build_block_candidates(block_id, header, nabla_for_block, chart, science_search)
+        chosen = block_candidates.chosen
+
         data: dict[str, Any] = {
-            "icd10_code": icd10_code,
-            "icd10_display": icd10_display,
+            "icd10_code": chosen.raw_code if chosen else None,
+            "icd10_display": chosen.display if chosen else "",
             "condition_header": header,
             "today_assessment": "\n".join(block.body),
             "accepted": False,
+            "block_id": block_id,
         }
-        if icd10_code and active_icd10_index:
-            stamped_id = active_icd10_index.get(_normalize_icd10(icd10_code))
+        display = (chosen.display if chosen else "") or header
+
+        if chosen is not None:
+            # condition_id: the ``note``-derived active index (existing path) OR the
+            # chosen chart candidate's id. Both are ACTIVE-only — a resolved/inactive
+            # match never carries a condition_id, so the diagnose→assess flip can't
+            # attach an assessment to a resolved record (no SDK reactivation).
+            stamped_id = active_icd10_index.get(_normalize_icd10(chosen.raw_code)) or chosen.condition_id
             if stamped_id:
                 data["condition_id"] = stamped_id
+            # Unspecified nudge: the working code stays applied, but surface grounded
+            # more-specific siblings (from the science service) for one-click refine.
+            if is_unspecified_code(chosen.code, chosen.display):
+                children = expand_unspecified(chosen, science_search)
+                if children:
+                    data["unspecified"] = True
+                    data["candidate_suggestions"] = [serialize_candidate(child) for child in children]
+        elif block_candidates.ambiguous:
+            # Leave the card UNCODED and surface the ranked options (with provenance)
+            # for the provider to choose. Never auto-stamp an ambiguous code.
+            data["candidate_suggestions"] = [serialize_candidate(c) for c in block_candidates.candidates[:5]]
+
         diagnose_commands.append(
             _serialize_proposal(
                 command_type="diagnose",
@@ -346,6 +389,6 @@ def split_plan_into_diagnoses(
             )
         )
 
-    unmatched = [c for c in codes if id(c) not in matched_set]
+    unmatched = [c for c in codes if id(c) not in claimed]
     updated = [*commands[:ap_idx], *diagnose_commands, *commands[ap_idx + 1 :]]
     return updated, unmatched

--- a/hyperscribe/scribe/commands/ap_split.py
+++ b/hyperscribe/scribe/commands/ap_split.py
@@ -377,11 +377,18 @@ def split_plan_into_diagnoses(
                 )
                 chosen = None  # defer to a provider pick
 
+        # Lead the assessment text with the original Nabla A&P headline so it persists
+        # for reference — inside the editable Today's assessment content itself (not a
+        # separate UI element), present from generation, and carried onto the assess
+        # narrative when a diagnosis flips to assess (summary.js seeds narrative from
+        # today_assessment). The provider can edit or remove it like any other text.
+        body_text = "\n".join(block.body)
+        assessment_text = f"{header}\n{body_text}" if header and body_text else (header or body_text)
         data: dict[str, Any] = {
             "icd10_code": chosen.raw_code if chosen else None,
             "icd10_display": chosen.display if chosen else "",
             "condition_header": header,
-            "today_assessment": "\n".join(block.body),
+            "today_assessment": assessment_text,
             "accepted": False,
             "block_id": block_id,
         }

--- a/hyperscribe/scribe/commands/ap_split.py
+++ b/hyperscribe/scribe/commands/ap_split.py
@@ -313,10 +313,6 @@ def split_plan_into_diagnoses(
 
     diagnose_commands: list[dict[str, Any]] = []
     claimed: set[int] = set()
-    # KOALA_5635_STAMP_CONDITION_ID — build the active-condition ICD-10 index
-    # once per call (not per block) so we don't N+1 patient_conditions per
-    # diagnose proposal. ``{}`` when ``note`` is None or the lookup fails.
-    active_icd10_index = _build_active_condition_icd10_index(note) if note is not None else {}
     chart = chart_conditions or []
 
     for i, block in enumerate(blocks):
@@ -355,64 +351,42 @@ def split_plan_into_diagnoses(
         block_candidates = build_block_candidates(
             block_id, header, nabla_for_block, chart, science_search, context_text=context_text
         )
-        chosen = block_candidates.chosen
-
-        # An unspecified code is NOT auto-applied when grounded more-specific options
-        # exist: the block is left UNCODED and the picker offers the unspecified code
-        # FIRST, then the more-specific siblings — so the provider picks (one click to
-        # keep the unspecified, or refine). When no more-specific option exists there's
-        # nothing to choose between, so the unspecified code is applied as-is (avoids a
-        # pointless one-option picker).
-        unspecified_options: list = []
-        if chosen is not None and is_unspecified_code(chosen.code, chosen.display):
-            # Rank both the unspecified code and its refinements by how well each matches
-            # the documented note text, so a specificity the note actually states (e.g.
-            # "moderate" -> F32.1) leads and the unspecified only leads when it's vague.
-            children = expand_unspecified(chosen, science_search, context_text=context_text)
+        # Never auto-apply a code: surface the ranked candidates and let the provider pick
+        # every diagnosis. The most-recommended code leads. An active-problem match is just
+        # the top suggestion here — picking it flips to `assess` at insert time (summary.js
+        # matches the chosen code to the active problem list), preserving continuity of care
+        # without silently coding anything.
+        surfaced: list = list(block_candidates.candidates)
+        # If the top candidate is an unspecified/parent code, fold in grounded more-specific
+        # options so the provider can refine, ranked by how well each matches the note text.
+        if surfaced and is_unspecified_code(surfaced[0].code, surfaced[0].display):
+            children = expand_unspecified(surfaced[0], science_search, context_text=context_text)
             if children:
-                unspecified_options = sorted(
-                    [chosen, *children],
+                merged: dict[str, Any] = {}
+                for candidate in [*surfaced, *children]:
+                    merged.setdefault(candidate.code, candidate)
+                surfaced = sorted(
+                    merged.values(),
                     key=lambda candidate: word_overlap(context_text, candidate.display),
                     reverse=True,
                 )
-                chosen = None  # defer to a provider pick
 
-        # Lead the assessment text with the original Nabla A&P headline so it persists
-        # for reference — inside the editable Today's assessment content itself (not a
-        # separate UI element), present from generation, and carried onto the assess
-        # narrative when a diagnosis flips to assess (summary.js seeds narrative from
-        # today_assessment). The provider can edit or remove it like any other text.
+        # Lead the assessment text with the original Nabla A&P headline so it persists for
+        # reference inside the editable Today's assessment content (and carries onto the
+        # assess narrative when a diagnosis flips to assess at insert).
         body_text = "\n".join(block.body)
         assessment_text = f"{header}\n{body_text}" if header and body_text else (header or body_text)
         data: dict[str, Any] = {
-            "icd10_code": chosen.raw_code if chosen else None,
-            "icd10_display": chosen.display if chosen else "",
+            "icd10_code": None,
+            "icd10_display": "",
             "condition_header": header,
             "today_assessment": assessment_text,
             "accepted": False,
             "block_id": block_id,
         }
-        display = (chosen.display if chosen else "") or header
-
-        if chosen is not None:
-            # condition_id: the ``note``-derived active index (existing path) OR the
-            # chosen chart candidate's id. Both are ACTIVE-only — a resolved/inactive
-            # match never carries a condition_id, so the diagnose→assess flip can't
-            # attach an assessment to a resolved record (no SDK reactivation).
-            stamped_id = active_icd10_index.get(_normalize_icd10(chosen.raw_code)) or chosen.condition_id
-            if stamped_id:
-                data["condition_id"] = stamped_id
-        elif unspecified_options:
-            # Uncoded: keep-as-unspecified (first) or refine to a more-specific code.
-            data["candidate_suggestions"] = [serialize_candidate(c) for c in surface_candidates(unspecified_options)]
-        elif block_candidates.ambiguous:
-            # Leave the card UNCODED and surface the ranked options (with provenance) for
-            # the provider to choose. surface_candidates drops incidental symptom/context
-            # codes (e.g. R45.851 "Suicidal ideations" under a depression problem) when a
-            # definitive option exists, and caps the list. Never auto-stamp.
-            data["candidate_suggestions"] = [
-                serialize_candidate(c) for c in surface_candidates(block_candidates.candidates)
-            ]
+        if surfaced:
+            data["candidate_suggestions"] = [serialize_candidate(c) for c in surface_candidates(surfaced)]
+        display = header
 
         diagnose_commands.append(
             _serialize_proposal(

--- a/hyperscribe/scribe/commands/ap_split.py
+++ b/hyperscribe/scribe/commands/ap_split.py
@@ -350,6 +350,19 @@ def split_plan_into_diagnoses(
         block_candidates = build_block_candidates(block_id, header, nabla_for_block, chart, science_search)
         chosen = block_candidates.chosen
 
+        # An unspecified code is NOT auto-applied when grounded more-specific options
+        # exist: the block is left UNCODED and the picker offers the unspecified code
+        # FIRST, then the more-specific siblings — so the provider picks (one click to
+        # keep the unspecified, or refine). When no more-specific option exists there's
+        # nothing to choose between, so the unspecified code is applied as-is (avoids a
+        # pointless one-option picker).
+        unspecified_options: list[dict[str, str]] = []
+        if chosen is not None and is_unspecified_code(chosen.code, chosen.display):
+            children = expand_unspecified(chosen, science_search)
+            if children:
+                unspecified_options = [serialize_candidate(chosen), *(serialize_candidate(c) for c in children)]
+                chosen = None  # defer to a provider pick
+
         data: dict[str, Any] = {
             "icd10_code": chosen.raw_code if chosen else None,
             "icd10_display": chosen.display if chosen else "",
@@ -368,13 +381,9 @@ def split_plan_into_diagnoses(
             stamped_id = active_icd10_index.get(_normalize_icd10(chosen.raw_code)) or chosen.condition_id
             if stamped_id:
                 data["condition_id"] = stamped_id
-            # Unspecified nudge: the working code stays applied, but surface grounded
-            # more-specific siblings (from the science service) for one-click refine.
-            if is_unspecified_code(chosen.code, chosen.display):
-                children = expand_unspecified(chosen, science_search)
-                if children:
-                    data["unspecified"] = True
-                    data["candidate_suggestions"] = [serialize_candidate(child) for child in children]
+        elif unspecified_options:
+            # Uncoded: keep-as-unspecified (first) or refine to a more-specific code.
+            data["candidate_suggestions"] = unspecified_options
         elif block_candidates.ambiguous:
             # Leave the card UNCODED and surface the ranked options (with provenance)
             # for the provider to choose. Never auto-stamp an ambiguous code.

--- a/hyperscribe/scribe/commands/ap_split.py
+++ b/hyperscribe/scribe/commands/ap_split.py
@@ -348,7 +348,13 @@ def split_plan_into_diagnoses(
         for condition in nabla_for_block:
             claimed.add(id(condition))
 
-        block_candidates = build_block_candidates(block_id, header, nabla_for_block, chart, science_search)
+        # Full note text for this block (header + assessment). Used to (a) let the
+        # science fallback recover a code via a body synonym the header lacks, and
+        # (b) rank unspecified refinements by documented specificity.
+        context_text = f"{header}\n" + "\n".join(block.body)
+        block_candidates = build_block_candidates(
+            block_id, header, nabla_for_block, chart, science_search, context_text=context_text
+        )
         chosen = block_candidates.chosen
 
         # An unspecified code is NOT auto-applied when grounded more-specific options
@@ -360,10 +366,8 @@ def split_plan_into_diagnoses(
         unspecified_options: list = []
         if chosen is not None and is_unspecified_code(chosen.code, chosen.display):
             # Rank both the unspecified code and its refinements by how well each matches
-            # the documented note text (header + assessment), so a specificity the note
-            # actually states (e.g. "moderate" -> F32.1) leads and the unspecified only
-            # leads when the note is genuinely vague.
-            context_text = f"{header}\n" + "\n".join(block.body)
+            # the documented note text, so a specificity the note actually states (e.g.
+            # "moderate" -> F32.1) leads and the unspecified only leads when it's vague.
             children = expand_unspecified(chosen, science_search, context_text=context_text)
             if children:
                 unspecified_options = sorted(

--- a/hyperscribe/scribe/commands/ap_split.py
+++ b/hyperscribe/scribe/commands/ap_split.py
@@ -308,6 +308,7 @@ def split_plan_into_diagnoses(
         expand_unspecified,
         is_unspecified_code,
         serialize_candidate,
+        surface_candidates,
     )
 
     diagnose_commands: list[dict[str, Any]] = []
@@ -356,11 +357,12 @@ def split_plan_into_diagnoses(
         # keep the unspecified, or refine). When no more-specific option exists there's
         # nothing to choose between, so the unspecified code is applied as-is (avoids a
         # pointless one-option picker).
-        unspecified_options: list[dict[str, str]] = []
+        unspecified_options: list = []
         if chosen is not None and is_unspecified_code(chosen.code, chosen.display):
             children = expand_unspecified(chosen, science_search)
             if children:
-                unspecified_options = [serialize_candidate(chosen), *(serialize_candidate(c) for c in children)]
+                # Offer the unspecified code first, then the more-specific siblings.
+                unspecified_options = [chosen, *children]
                 chosen = None  # defer to a provider pick
 
         data: dict[str, Any] = {
@@ -383,11 +385,15 @@ def split_plan_into_diagnoses(
                 data["condition_id"] = stamped_id
         elif unspecified_options:
             # Uncoded: keep-as-unspecified (first) or refine to a more-specific code.
-            data["candidate_suggestions"] = unspecified_options
+            data["candidate_suggestions"] = [serialize_candidate(c) for c in surface_candidates(unspecified_options)]
         elif block_candidates.ambiguous:
-            # Leave the card UNCODED and surface the ranked options (with provenance)
-            # for the provider to choose. Never auto-stamp an ambiguous code.
-            data["candidate_suggestions"] = [serialize_candidate(c) for c in block_candidates.candidates[:5]]
+            # Leave the card UNCODED and surface the ranked options (with provenance) for
+            # the provider to choose. surface_candidates drops incidental symptom/context
+            # codes (e.g. R45.851 "Suicidal ideations" under a depression problem) when a
+            # definitive option exists, and caps the list. Never auto-stamp.
+            data["candidate_suggestions"] = [
+                serialize_candidate(c) for c in surface_candidates(block_candidates.candidates)
+            ]
 
         diagnose_commands.append(
             _serialize_proposal(

--- a/hyperscribe/scribe/commands/diagnose.py
+++ b/hyperscribe/scribe/commands/diagnose.py
@@ -19,6 +19,13 @@ class DiagnoseParser(CommandParser):
 
     def validate(self, data: dict[str, Any]) -> list[str]:
         errors: list[str] = []
+        # Hard block (server-side guard): a diagnose command must carry an ICD-10
+        # code. The frontend blocks approval of an uncoded diagnosis; this mirrors
+        # that on the insert path so the requirement can't be bypassed via the API.
+        # (A diagnosis that matched an active problem flips to ``assess`` upstream
+        # and is built by a different parser, so it never reaches here uncoded.)
+        if not (data.get("icd10_code") or "").strip():
+            errors.append("Diagnosis is missing an ICD-10 code")
         if len(data.get("today_assessment") or "") > 2048:
             errors.append("Assessment text exceeds 2048 characters")
         return errors

--- a/hyperscribe/scribe/commands/diagnosis_candidates.py
+++ b/hyperscribe/scribe/commands/diagnosis_candidates.py
@@ -137,23 +137,20 @@ def format_icd10(code: str) -> str:
 def is_unspecified_code(code: str, display: str = "") -> bool:
     """Return True if ``code`` is an unspecified/parent ICD-10 code.
 
-    "Unspecified" is identified primarily from the display text (the reliable
-    signal — e.g. ``G47.00`` "Insomnia, **unspecified**", whose numeric tail
-    ``00`` is not otherwise distinguishable), with a numeric backstop matching the
-    parent shapes used by ``icd10_is_unspecified_parent_of``: a bare 3-char root,
-    a root followed by ``9``, or a root followed by ``9`` + one digit.
+    "Unspecified" is identified from two signals: (a) the display text contains
+    "unspecified" (the reliable one — ``G47.00`` "Insomnia, **unspecified**",
+    ``F32.9`` "…, unspecified", ``E78.5`` "Hyperlipidemia, unspecified"); or (b) a
+    bare 3-char rubric (``G43``), which is never independently billable.
+
+    We deliberately do NOT treat every ``.9`` code as unspecified: ``E11.9``
+    "…without complications" and ``K21.9`` "…without esophagitis" are the standard,
+    billable default codes and their displays don't say "unspecified" — flagging
+    them would force needless refinement picks and nudge toward over-coding.
     """
     if display and "unspecified" in display.lower():
         return True
     norm = icd10_normalize(code)
-    if not norm:
-        return False
-    if len(norm) == 3:
-        return True
-    tail = norm[3:]
-    if tail == "9":
-        return True
-    return len(tail) == 2 and tail[0] == "9" and tail[1].isdigit()
+    return len(norm) == 3
 
 
 def _is_symptom_or_context(code: str) -> bool:
@@ -254,6 +251,7 @@ def assemble_block_candidates(
     nabla_for_block: list[dict[str, Any]],
     chart: list[PatientConditionSnapshot],
     science_search: ScienceSearch | None = None,
+    context_text: str = "",
 ) -> list[DiagnosisCandidate]:
     """Build the (de-duplicated, unranked) candidate set for one A&P block.
 
@@ -264,6 +262,10 @@ def assemble_block_candidates(
     :param chart: the patient's condition snapshots (active and inactive).
     :param science_search: optional grounded lookup, used only as a fallback when
         there is no chart/Nabla support for the block.
+    :param context_text: header + assessment body. When Nabla omits a code, the
+        science fallback also searches the body so a synonym present only there
+        (e.g. "impingement" for a "rotator cuff tendinitis" header) can surface the
+        right code.
     """
     candidates: list[DiagnosisCandidate] = []
 
@@ -321,12 +323,22 @@ def assemble_block_candidates(
         )
         has_chart_match = True
 
-    # (d) Science-search fallback — only when nothing grounded the block yet.
+    # (d) Science-search fallback — only when nothing grounded the block yet. Search
+    # both the header keywords AND the assessment-body keywords, so a code whose ICD
+    # display matches a synonym present only in the body (e.g. "impingement" for a
+    # "rotator cuff tendinitis" header -> M75.4x) can still surface.
     if science_search is not None and not has_nabla and not has_chart_match:
-        expression = " ".join(significant_words(header)) or header.strip()
-        if expression:
+        expressions: list[str] = []
+        header_expr = " ".join(significant_words(header)) or header.strip()
+        if header_expr:
+            expressions.append(header_expr)
+        if context_text:
+            body_expr = " ".join(significant_words(context_text))
+            if body_expr and body_expr != header_expr:
+                expressions.append(body_expr)
+        if expressions:
             try:
-                for hit in science_search([expression]) or []:
+                for hit in science_search(expressions) or []:
                     code = icd10_normalize(getattr(hit, "code", ""))
                     if not code:
                         continue
@@ -407,10 +419,18 @@ def build_block_candidates(
     nabla_for_block: list[dict[str, Any]],
     chart: list[PatientConditionSnapshot],
     science_search: ScienceSearch | None = None,
+    context_text: str = "",
 ) -> BlockCandidates:
     """Assemble → rank → resolve for one block, in one call (the belt's entry point)."""
-    ranked = rank_candidates(header, assemble_block_candidates(header, nabla_for_block, chart, science_search))
-    chosen, ambiguous = resolve_choice(header, ranked)
+    candidates = assemble_block_candidates(header, nabla_for_block, chart, science_search, context_text)
+    # When the block is grounded by Nabla/chart, rank on the header (stable). When it
+    # fell through to a science-only fallback, rank on the full note context so a code
+    # matched via a body synonym (not in the header) can lead. Header-based ranking is
+    # unchanged for the common case (no blast radius).
+    grounded = any(c.source != CandidateSource.SCIENCE_SEARCH for c in candidates)
+    match_text = header if (grounded or not context_text) else context_text
+    ranked = rank_candidates(match_text, candidates)
+    chosen, ambiguous = resolve_choice(match_text, ranked)
     return BlockCandidates(block_id=block_id, header=header, candidates=ranked, chosen=chosen, ambiguous=ambiguous)
 
 
@@ -465,6 +485,17 @@ def expand_unspecified(
                 source=CandidateSource.MORE_SPECIFIC,
             )
         )
+    # Drop non-billable category parents: a code that is a strict prefix of another
+    # returned child (e.g. ``E784`` is a prefix of ``E7841``/``E7849``). The family
+    # search returns the leaves, so the prefix rule reliably removes non-leaf parents.
+    all_codes = {c.code for c in children}
+    children = [c for c in children if not any(other != c.code and other.startswith(c.code) for other in all_codes)]
+    # Dedup identical displays (a parent and a child can share a label).
+    by_display: dict[str, DiagnosisCandidate] = {}
+    for candidate in children:
+        key = " ".join((candidate.display or "").lower().split())
+        by_display.setdefault(key, candidate)
+    children = list(by_display.values())
     if context_text:
         children.sort(key=lambda candidate: word_overlap(context_text, candidate.display), reverse=True)
     return children

--- a/hyperscribe/scribe/commands/diagnosis_candidates.py
+++ b/hyperscribe/scribe/commands/diagnosis_candidates.py
@@ -1,0 +1,435 @@
+"""Grounded, ranked ICD-10 candidate selection for A&P diagnosis blocks.
+
+This module replaces the old "first-match-wins" code pick in
+``split_plan_into_diagnoses`` (``ap_split.py``) with a retrieval-grounded,
+clinically-ranked candidate model. It NEVER invents a code: every candidate is
+sourced from the patient's chart (active or inactive conditions), Nabla's
+normalized codings for the block, or a grounded science-service search. The LLM
+is not involved here.
+
+Why this exists (see KOALA / the ICD-10 redesign plan): Nabla frequently returns
+several codings for a single A&P problem — a definitive diagnosis plus incidental
+symptom/sign codes pulled from the plan narrative (e.g. for a depression block it
+emits both ``F33.1`` *and* ``R45.851`` "Suicidal ideations"). The old belt took
+whichever appeared first and discarded the rest, so a Chapter-18 symptom code
+could silently replace the real diagnosis. Here, all codings enter a ranked set
+and clinical priority decides — with the patient's own chart code preferred over
+Nabla's (Nabla skews toward unspecified), and symptom/context codes deprioritized
+when a definitive code is available.
+
+Purity / sandbox notes: all containers are ``typing.NamedTuple`` (the plugin
+sandbox can't evaluate ``@dataclass`` at module-load — see ``problem_list_match``).
+The module has no DB or network imports; ``science_search`` is injected by the
+caller (defaulting to ``CanvasScience.search_conditions`` at the call site), which
+keeps the engine pure and trivially unit-testable.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable, NamedTuple
+
+# Reused text/code helpers. These imports are one-directional: ``ap_split`` and
+# ``problem_list_match`` do NOT import this module at module-load time
+# (``ap_split`` imports it lazily inside ``split_plan_into_diagnoses``), so there
+# is no import cycle.
+from hyperscribe.scribe.commands.ap_split import significant_words, word_overlap
+from hyperscribe.scribe.commands.problem_list_match import (
+    _icd10_family_root,
+    icd10_normalize,
+)
+
+# A callable that takes a list of search expressions and returns objects exposing
+# ``.code`` and ``.label`` (e.g. ``CanvasScience.search_conditions`` →
+# ``list[Icd10Condition]``). Injected so the engine stays pure.
+ScienceSearch = Callable[[list[str]], list[Any]]
+
+
+class CandidateSource:
+    """Provenance buckets for a diagnosis candidate, ordered by trust.
+
+    ``ACTIVE_PROBLEM`` (the patient's active problem list) is the most
+    authoritative, then ``PRIOR_CONDITION`` (the patient's resolved/inactive
+    history), then ``NABLA`` (codings the scribe detected for this block), then
+    ``SCIENCE_SEARCH`` (a grounded ontology lookup used only as a fallback).
+    ``MORE_SPECIFIC`` is not a primary source — it tags the more-specific
+    children surfaced when an unspecified code is auto-applied.
+    """
+
+    ACTIVE_PROBLEM = "active_problem"
+    PRIOR_CONDITION = "prior_condition"
+    NABLA = "nabla"
+    SCIENCE_SEARCH = "science_search"
+    MORE_SPECIFIC = "more_specific"
+
+
+# Trust ranking used for de-duplication (higher wins when two sources carry the
+# same normalized code).
+_SOURCE_TRUST = {
+    CandidateSource.ACTIVE_PROBLEM: 3,
+    CandidateSource.PRIOR_CONDITION: 2,
+    CandidateSource.NABLA: 1,
+    CandidateSource.SCIENCE_SEARCH: 0,
+    CandidateSource.MORE_SPECIFIC: 0,
+}
+
+
+class DiagnosisCandidate(NamedTuple):
+    """One ranked ICD-10 candidate for an A&P block.
+
+    :param code: normalized dotless canonical code (``F331``) — the comparison key.
+    :param raw_code: code as sourced (dotted or not); preserved for display/storage.
+    :param display: human-readable label for the code.
+    :param source: one of ``CandidateSource.*``.
+    :param condition_id: SDK condition id — populated ONLY for ``ACTIVE_PROBLEM``
+        candidates, so a confident match can flip diagnose→assess against the live
+        problem-list entry. Never set for ``PRIOR_CONDITION``: the SDK has no
+        reactivation command, so a recurrence must be a fresh ``Diagnose``.
+    :param clinical_status: chart clinical status (active/resolved/...); "" otherwise.
+    :param onset_date / resolution_date: ISO strings for provenance; "" when unknown.
+    :param nabla_order: original index within Nabla's coding list (final tiebreak).
+    """
+
+    code: str
+    raw_code: str
+    display: str
+    source: str
+    condition_id: str = ""
+    clinical_status: str = ""
+    onset_date: str = ""
+    resolution_date: str = ""
+    nabla_order: int = 999
+
+
+class PatientConditionSnapshot(NamedTuple):
+    """A patient chart condition narrowed to what candidate assembly needs."""
+
+    condition_id: str
+    code: str
+    display: str
+    system: str
+    clinical_status: str
+    onset_date: str
+    resolution_date: str
+
+
+class BlockCandidates(NamedTuple):
+    """The ranked outcome for a single A&P block.
+
+    ``chosen`` is set only when one candidate is confident enough to auto-apply;
+    otherwise ``ambiguous`` is True and the caller surfaces ``candidates`` (top N)
+    for the provider to pick from. Both may be falsy when there are no candidates
+    at all (the block stays uncoded and the provider searches manually).
+    """
+
+    block_id: str
+    header: str
+    candidates: list[DiagnosisCandidate]
+    chosen: DiagnosisCandidate | None
+    ambiguous: bool
+
+
+def format_icd10(code: str) -> str:
+    """Return the dotted display form of an ICD-10 code (``F331`` -> ``F33.1``)."""
+    clean = (code or "").replace(".", "").upper().strip()
+    return clean[:3] + "." + clean[3:] if len(clean) > 3 else clean
+
+
+def is_unspecified_code(code: str, display: str = "") -> bool:
+    """Return True if ``code`` is an unspecified/parent ICD-10 code.
+
+    "Unspecified" is identified primarily from the display text (the reliable
+    signal — e.g. ``G47.00`` "Insomnia, **unspecified**", whose numeric tail
+    ``00`` is not otherwise distinguishable), with a numeric backstop matching the
+    parent shapes used by ``icd10_is_unspecified_parent_of``: a bare 3-char root,
+    a root followed by ``9``, or a root followed by ``9`` + one digit.
+    """
+    if display and "unspecified" in display.lower():
+        return True
+    norm = icd10_normalize(code)
+    if not norm:
+        return False
+    if len(norm) == 3:
+        return True
+    tail = norm[3:]
+    if tail == "9":
+        return True
+    return len(tail) == 2 and tail[0] == "9" and tail[1].isdigit()
+
+
+def _is_symptom_or_context(code: str) -> bool:
+    """ICD-10 Chapter 18 (``R``, symptoms/signs) or ``Z`` (contextual) code."""
+    norm = icd10_normalize(code)
+    return bool(norm) and norm[0] in ("R", "Z")
+
+
+def provenance_label(candidate: DiagnosisCandidate) -> str:
+    """Human-readable provenance shown next to a candidate in the picker."""
+    source = candidate.source
+    if source == CandidateSource.ACTIVE_PROBLEM:
+        return "Active problem"
+    if source == CandidateSource.PRIOR_CONDITION:
+        status = (candidate.clinical_status or "").lower()
+        if status == "resolved":
+            year = candidate.resolution_date[:4]
+            return f"Resolved {year}" if year.isdigit() else "Resolved"
+        if status == "remission":
+            return "In remission"
+        if status == "relapse":
+            return "Relapse"
+        if status == "investigative":
+            return "Under investigation"
+        return "Prior condition"
+    if source == CandidateSource.NABLA:
+        return "Detected in note"
+    if source == CandidateSource.SCIENCE_SEARCH:
+        return "ICD-10 search"
+    if source == CandidateSource.MORE_SPECIFIC:
+        return "More specific option"
+    return ""
+
+
+def serialize_candidate(candidate: DiagnosisCandidate) -> dict[str, str]:
+    """Picker-option shape consumed by the frontend (DiagnoseRow)."""
+    return {
+        "code": candidate.raw_code or candidate.code,
+        "formatted_code": format_icd10(candidate.code),
+        "display": candidate.display,
+        "provenance": provenance_label(candidate),
+    }
+
+
+def _overlap_bucket(header: str, display: str) -> int:
+    """Coarse word-overlap bucket (avoids float fragility in the sort key)."""
+    overlap = word_overlap(header, display)
+    if overlap >= 0.8:
+        return 2
+    if overlap >= 0.5:
+        return 1
+    return 0
+
+
+def _sort_key(header: str, candidate: DiagnosisCandidate) -> tuple[int, int, int, int, int, int]:
+    """Descending clinical-priority key. Tiers, most significant first:
+
+    1. active problem-list match;
+    2. prior-condition (inactive history) match;
+    3. display word-overlap with the header (bucketed);
+    4. definitive code over symptom/context (R/Z) — only discriminates when a
+       non-R/Z candidate exists, since a uniform tier is a no-op in the sort;
+    5. specificity (longer/leaf code wins);
+    6. earlier Nabla order (final tiebreak).
+    """
+    tier_active = 1 if candidate.source == CandidateSource.ACTIVE_PROBLEM else 0
+    tier_prior = 1 if candidate.source == CandidateSource.PRIOR_CONDITION else 0
+    tier_overlap = _overlap_bucket(header, candidate.display)
+    tier_definitive = 0 if _is_symptom_or_context(candidate.code) else 1
+    tier_specificity = len(candidate.code)
+    tier_nabla = -candidate.nabla_order
+    return (tier_active, tier_prior, tier_overlap, tier_definitive, tier_specificity, tier_nabla)
+
+
+def _dedup_by_code(candidates: list[DiagnosisCandidate]) -> list[DiagnosisCandidate]:
+    """Keep one candidate per normalized code, preferring the highest-trust source."""
+    by_code: dict[str, DiagnosisCandidate] = {}
+    for candidate in candidates:
+        existing = by_code.get(candidate.code)
+        if existing is None or _SOURCE_TRUST[candidate.source] > _SOURCE_TRUST[existing.source]:
+            by_code[candidate.code] = candidate
+    return list(by_code.values())
+
+
+def assemble_block_candidates(
+    header: str,
+    nabla_for_block: list[dict[str, Any]],
+    chart: list[PatientConditionSnapshot],
+    science_search: ScienceSearch | None = None,
+) -> list[DiagnosisCandidate]:
+    """Build the (de-duplicated, unranked) candidate set for one A&P block.
+
+    :param header: the block's problem header text.
+    :param nabla_for_block: the Nabla normalized-condition dicts the caller has
+        already associated with this block (``{"display", "coding": [...]}``).
+        EVERY coding becomes a candidate — this is the no-orphan fix.
+    :param chart: the patient's condition snapshots (active and inactive).
+    :param science_search: optional grounded lookup, used only as a fallback when
+        there is no chart/Nabla support for the block.
+    """
+    candidates: list[DiagnosisCandidate] = []
+
+    # (c) Nabla codings — emit every coding (no first-match discard).
+    nabla_family_roots: set[str] = set()
+    has_nabla = False
+    order = 0
+    for condition in nabla_for_block or []:
+        condition_display = condition.get("display") or ""
+        for coding in condition.get("coding") or []:
+            raw = coding.get("code")
+            if not raw:
+                continue
+            code = icd10_normalize(raw)
+            if not code:
+                continue
+            candidates.append(
+                DiagnosisCandidate(
+                    code=code,
+                    raw_code=raw,
+                    display=coding.get("display") or condition_display or header,
+                    source=CandidateSource.NABLA,
+                    nabla_order=order,
+                )
+            )
+            order += 1
+            has_nabla = True
+            nabla_family_roots.add(_icd10_family_root(code))
+
+    # (a)/(b) Chart conditions that match the block (by header overlap or by
+    # sharing an ICD-10 family root with a Nabla code for this block).
+    has_chart_match = False
+    for snapshot in chart or []:
+        if not snapshot.code:
+            continue
+        code = icd10_normalize(snapshot.code)
+        if not code:
+            continue
+        matches = word_overlap(header, snapshot.display) >= 0.5 or _icd10_family_root(code) in nabla_family_roots
+        if not matches:
+            continue
+        is_active = (snapshot.clinical_status or "").lower() == "active"
+        candidates.append(
+            DiagnosisCandidate(
+                code=code,
+                raw_code=snapshot.code,
+                display=snapshot.display,
+                source=CandidateSource.ACTIVE_PROBLEM if is_active else CandidateSource.PRIOR_CONDITION,
+                # condition_id flows ONLY for active matches (assess-flip eligibility).
+                condition_id=snapshot.condition_id if is_active else "",
+                clinical_status=snapshot.clinical_status,
+                onset_date=snapshot.onset_date,
+                resolution_date=snapshot.resolution_date,
+            )
+        )
+        has_chart_match = True
+
+    # (d) Science-search fallback — only when nothing grounded the block yet.
+    if science_search is not None and not has_nabla and not has_chart_match:
+        expression = " ".join(significant_words(header)) or header.strip()
+        if expression:
+            try:
+                for hit in science_search([expression]) or []:
+                    code = icd10_normalize(getattr(hit, "code", ""))
+                    if not code:
+                        continue
+                    candidates.append(
+                        DiagnosisCandidate(
+                            code=code,
+                            raw_code=getattr(hit, "code", ""),
+                            display=getattr(hit, "label", ""),
+                            source=CandidateSource.SCIENCE_SEARCH,
+                        )
+                    )
+            except Exception:
+                # Best-effort: a science outage must never break candidate assembly.
+                pass
+
+    return _dedup_by_code(candidates)
+
+
+def rank_candidates(header: str, candidates: list[DiagnosisCandidate]) -> list[DiagnosisCandidate]:
+    """Return candidates sorted best-first by clinical priority (see ``_sort_key``)."""
+    return sorted(candidates, key=lambda candidate: _sort_key(header, candidate), reverse=True)
+
+
+def resolve_choice(header: str, ranked: list[DiagnosisCandidate]) -> tuple[DiagnosisCandidate | None, bool]:
+    """Decide whether to auto-apply the top candidate or surface a picker.
+
+    Returns ``(chosen, ambiguous)``. ``chosen`` is non-None only when one
+    candidate is confident enough to auto-apply. ``ambiguous`` is True when the
+    block should stay uncoded with options surfaced. ``(None, False)`` means there
+    are simply no candidates (uncoded, nothing to surface).
+    """
+    if not ranked:
+        return None, False
+    top = ranked[0]
+
+    # An active problem-list match is always trusted.
+    if top.source == CandidateSource.ACTIVE_PROBLEM:
+        return top, False
+
+    # A science-only candidate has no chart/Nabla support — never auto-stamp it.
+    if top.source == CandidateSource.SCIENCE_SEARCH:
+        return None, True
+
+    # A symptom/context (R/Z) code at the top is auto-applied only when it strongly
+    # matches the block (it IS the documented problem, e.g. R19.7 "Diarrhea,
+    # unspecified" for a Diarrhea block). A weakly-matching symptom code is
+    # incidental (e.g. R45.851 "Suicidal ideations" surfaced under a depression
+    # header with no definitive code) — surface it for the provider, never stamp it.
+    if _is_symptom_or_context(top.code) and _overlap_bucket(header, top.display) < 1:
+        return None, True
+
+    # If a second candidate ties the top through the meaningful tiers (1..4 — i.e.
+    # only specificity/order separate them), it's genuinely ambiguous; surface both.
+    if len(ranked) >= 2:
+        second = ranked[1]
+        if _sort_key(header, top)[:4] == _sort_key(header, second)[:4]:
+            return None, True
+
+    return top, False
+
+
+def build_block_candidates(
+    block_id: str,
+    header: str,
+    nabla_for_block: list[dict[str, Any]],
+    chart: list[PatientConditionSnapshot],
+    science_search: ScienceSearch | None = None,
+) -> BlockCandidates:
+    """Assemble → rank → resolve for one block, in one call (the belt's entry point)."""
+    ranked = rank_candidates(header, assemble_block_candidates(header, nabla_for_block, chart, science_search))
+    chosen, ambiguous = resolve_choice(header, ranked)
+    return BlockCandidates(block_id=block_id, header=header, candidates=ranked, chosen=chosen, ambiguous=ambiguous)
+
+
+def expand_unspecified(
+    chosen: DiagnosisCandidate,
+    science_search: ScienceSearch | None,
+) -> list[DiagnosisCandidate]:
+    """Return more-specific children of an unspecified ``chosen`` code.
+
+    Used for the "Unspecified — consider refining" nudge: the working code stays
+    applied, but the provider is offered grounded, more-specific siblings from the
+    same ICD-10 family (looked up via the science service). Returns ``[]`` when no
+    search is available or nothing more specific is found.
+    """
+    if science_search is None:
+        return []
+    root = _icd10_family_root(chosen.code)
+    if not root:
+        return []
+    try:
+        hits = science_search([root]) or []
+    except Exception:
+        return []
+    children: list[DiagnosisCandidate] = []
+    seen: set[str] = {chosen.code}
+    for hit in hits:
+        code = icd10_normalize(getattr(hit, "code", ""))
+        display = getattr(hit, "label", "")
+        if not code or code in seen:
+            continue
+        # Same family, and itself a specified code. We deliberately do NOT use
+        # "longer code = more specific": an unspecified bucket like ``G47.00`` has
+        # equally-long specified siblings (``G47.01``, ``G47.09``). Excluding other
+        # unspecified codes (the family root, ``*.9``) is the right filter.
+        if _icd10_family_root(code) != root or is_unspecified_code(code, display):
+            continue
+        seen.add(code)
+        children.append(
+            DiagnosisCandidate(
+                code=code,
+                raw_code=getattr(hit, "code", ""),
+                display=getattr(hit, "label", ""),
+                source=CandidateSource.MORE_SPECIFIC,
+            )
+        )
+    return children

--- a/hyperscribe/scribe/commands/diagnosis_candidates.py
+++ b/hyperscribe/scribe/commands/diagnosis_candidates.py
@@ -191,6 +191,24 @@ def serialize_candidate(candidate: DiagnosisCandidate) -> dict[str, str]:
     }
 
 
+# Cap on how many options a picker surfaces — enough to choose from, few enough to
+# scan (e.g. E03 hypothyroidism has 8 family members; the provider needs a handful).
+MAX_SURFACED_SUGGESTIONS = 6
+
+
+def surface_candidates(candidates: list[DiagnosisCandidate]) -> list[DiagnosisCandidate]:
+    """Trim a ranked candidate list for display in the picker.
+
+    Drops symptom/context (R/Z) codes when a definitive option exists — so an
+    incidental code Nabla attached to the block (e.g. R45.851 "Suicidal ideations"
+    under a depression problem) is never offered as a diagnosis to pick — and caps
+    the count so the list stays scannable. Order is preserved (already ranked).
+    """
+    has_definitive = any(not _is_symptom_or_context(candidate.code) for candidate in candidates)
+    trimmed = [c for c in candidates if not (has_definitive and _is_symptom_or_context(c.code))]
+    return trimmed[:MAX_SURFACED_SUGGESTIONS]
+
+
 def _overlap_bucket(header: str, display: str) -> int:
     """Coarse word-overlap bucket (avoids float fragility in the sort key)."""
     overlap = word_overlap(header, display)

--- a/hyperscribe/scribe/commands/diagnosis_candidates.py
+++ b/hyperscribe/scribe/commands/diagnosis_candidates.py
@@ -417,12 +417,15 @@ def build_block_candidates(
 def expand_unspecified(
     chosen: DiagnosisCandidate,
     science_search: ScienceSearch | None,
+    context_text: str = "",
 ) -> list[DiagnosisCandidate]:
     """Return more-specific children of an unspecified ``chosen`` code.
 
-    Used for the "Unspecified — consider refining" nudge: the working code stays
-    applied, but the provider is offered grounded, more-specific siblings from the
-    same ICD-10 family (looked up via the science service). Returns ``[]`` when no
+    The working code stays valid, but the provider is offered grounded, more-specific
+    siblings from the same ICD-10 sub-category (looked up via the science service).
+    When ``context_text`` (the block header + assessment) is given, children are ranked
+    by word-overlap with it, so a specificity the note actually documents (e.g.
+    "moderate" -> ``F32.1``) leads and irrelevant siblings sink. Returns ``[]`` when no
     search is available or nothing more specific is found.
     """
     if science_search is None:
@@ -431,13 +434,12 @@ def expand_unspecified(
     root = _icd10_family_root(norm)
     if not root:
         return []
-    # Scope the refinements to the unspecified code's own sub-category, not the whole
-    # 3-char family. ``G47.00`` ("Insomnia, unspecified") sits under ``G47.0`` (insomnia)
-    # within the broader ``G47`` (all sleep disorders) — so its refinements are
-    # ``G47.0x`` (G47.01/.09), NOT ``G47.33`` sleep apnea or ``G47.63`` bruxism. When the
-    # 4th char is itself the unspecified marker ``9`` (``E03.9``, ``F33.9``, ``E11.9``),
-    # the whole 3-char family IS the sub-category, so the root is the right scope.
-    scope_prefix = norm[:4] if len(norm) >= 4 and norm[3] != "9" else root
+    # Scope the refinements to the unspecified code's own sub-category. A 5+ char code
+    # (``G4700`` "Insomnia, unspecified") sits inside a real 4-char sub-rubric (``G47.0``
+    # insomnia, distinct from ``G47.3`` apnea), so refinements share the 4-char prefix.
+    # A 4-char code (``E785``, ``E039``, ``F329``, ``K219``, ``E119``) is unspecified at
+    # the 3-char rubric, so its refinements are the 3-char-root siblings.
+    scope_prefix = norm[:4] if len(norm) >= 5 else root
     try:
         hits = science_search([root]) or []
     except Exception:
@@ -463,4 +465,6 @@ def expand_unspecified(
                 source=CandidateSource.MORE_SPECIFIC,
             )
         )
+    if context_text:
+        children.sort(key=lambda candidate: word_overlap(context_text, candidate.display), reverse=True)
     return children

--- a/hyperscribe/scribe/commands/diagnosis_candidates.py
+++ b/hyperscribe/scribe/commands/diagnosis_candidates.py
@@ -168,17 +168,10 @@ def provenance_label(candidate: DiagnosisCandidate) -> str:
     if source == CandidateSource.ACTIVE_PROBLEM:
         return "Active problem"
     if source == CandidateSource.PRIOR_CONDITION:
-        status = (candidate.clinical_status or "").lower()
-        if status == "resolved":
-            year = candidate.resolution_date[:4]
-            return f"Resolved {year}" if year.isdigit() else "Resolved"
-        if status == "remission":
-            return "In remission"
-        if status == "relapse":
-            return "Relapse"
-        if status == "investigative":
-            return "Under investigation"
-        return "Prior condition"
+        # One catch-all for every non-active status (resolved / remission / relapse /
+        # investigative) — the date/status variants add noise without changing what
+        # the provider does (pick it to re-document).
+        return "Past condition"
     if source == CandidateSource.NABLA:
         return "Detected in note"
     if source == CandidateSource.SCIENCE_SEARCH:

--- a/hyperscribe/scribe/commands/diagnosis_candidates.py
+++ b/hyperscribe/scribe/commands/diagnosis_candidates.py
@@ -351,10 +351,6 @@ def resolve_choice(header: str, ranked: list[DiagnosisCandidate]) -> tuple[Diagn
         return None, False
     top = ranked[0]
 
-    # An active problem-list match is always trusted.
-    if top.source == CandidateSource.ACTIVE_PROBLEM:
-        return top, False
-
     # A science-only candidate has no chart/Nabla support — never auto-stamp it.
     if top.source == CandidateSource.SCIENCE_SEARCH:
         return None, True
@@ -366,6 +362,23 @@ def resolve_choice(header: str, ranked: list[DiagnosisCandidate]) -> tuple[Diagn
     # header with no definitive code) — surface it for the provider, never stamp it.
     if _is_symptom_or_context(top.code) and _overlap_bucket(header, top.display) < 1:
         return None, True
+
+    # Cross-entity conflict: another candidate in a DIFFERENT ICD-10 family matches the
+    # header at least as well as the top. That's a genuine disagreement about WHICH
+    # condition is being coded — most importantly a stale chart code vs the encounter's
+    # documented code (e.g. active-problem F32.1 "single episode" vs Nabla F33.1
+    # "recurrent" for a header that says "recurrent"). Never auto-pick the chart code
+    # over the documented one; surface both with provenance and let the provider choose.
+    top_root = _icd10_family_root(top.code)
+    top_bucket = _overlap_bucket(header, top.display)
+    for other in ranked[1:]:
+        if _icd10_family_root(other.code) != top_root and _overlap_bucket(header, other.display) >= top_bucket:
+            return None, True
+
+    # An active problem-list match (with no cross-family conflict above) is trusted
+    # for continuity of care.
+    if top.source == CandidateSource.ACTIVE_PROBLEM:
+        return top, False
 
     # If a second candidate ties the top through the meaningful tiers (1..4 — i.e.
     # only specificity/order separate them), it's genuinely ambiguous; surface both.
@@ -403,25 +416,32 @@ def expand_unspecified(
     """
     if science_search is None:
         return []
-    root = _icd10_family_root(chosen.code)
+    norm = icd10_normalize(chosen.code)
+    root = _icd10_family_root(norm)
     if not root:
         return []
+    # Scope the refinements to the unspecified code's own sub-category, not the whole
+    # 3-char family. ``G47.00`` ("Insomnia, unspecified") sits under ``G47.0`` (insomnia)
+    # within the broader ``G47`` (all sleep disorders) — so its refinements are
+    # ``G47.0x`` (G47.01/.09), NOT ``G47.33`` sleep apnea or ``G47.63`` bruxism. When the
+    # 4th char is itself the unspecified marker ``9`` (``E03.9``, ``F33.9``, ``E11.9``),
+    # the whole 3-char family IS the sub-category, so the root is the right scope.
+    scope_prefix = norm[:4] if len(norm) >= 4 and norm[3] != "9" else root
     try:
         hits = science_search([root]) or []
     except Exception:
         return []
     children: list[DiagnosisCandidate] = []
-    seen: set[str] = {chosen.code}
+    seen: set[str] = {norm}
     for hit in hits:
         code = icd10_normalize(getattr(hit, "code", ""))
         display = getattr(hit, "label", "")
         if not code or code in seen:
             continue
-        # Same family, and itself a specified code. We deliberately do NOT use
-        # "longer code = more specific": an unspecified bucket like ``G47.00`` has
-        # equally-long specified siblings (``G47.01``, ``G47.09``). Excluding other
-        # unspecified codes (the family root, ``*.9``) is the right filter.
-        if _icd10_family_root(code) != root or is_unspecified_code(code, display):
+        # Within the unspecified code's sub-category, and itself a specified code. We do
+        # NOT use "longer code = more specific": an unspecified bucket like ``G47.00`` has
+        # equally-long specified siblings (``G47.01``, ``G47.09``).
+        if not code.startswith(scope_prefix) or is_unspecified_code(code, display):
             continue
         seen.add(code)
         children.append(

--- a/hyperscribe/scribe/recommendations/__init__.py
+++ b/hyperscribe/scribe/recommendations/__init__.py
@@ -27,6 +27,15 @@ def _make_settings(api_key: str) -> LlmSettingsAnthropic:
     )
 
 
+def make_llm_client(api_key: str) -> LlmAnthropic:
+    """Public factory for an Anthropic client with the recommendations settings.
+
+    Lets callers outside this module (e.g. the diagnosis LLM resolver wired into
+    ``session_view``) build a client without reaching into ``_make_settings``.
+    """
+    return LlmAnthropic(_make_settings(api_key))
+
+
 def prescription_dispense_enabled(allowlist_raw: str | None, provider_id: str | None) -> bool:
     """Whether the prescription dispense-field engine is enabled for this provider.
 

--- a/hyperscribe/scribe/recommendations/_referral_diagnosis.py
+++ b/hyperscribe/scribe/recommendations/_referral_diagnosis.py
@@ -10,9 +10,14 @@ Sources are consulted in priority order:
 
 1. ``diagnose`` commands that already carry a populated ``icd10_code`` — the
    note's own coded assessment, the most authoritative source.
-2. ``diagnosis_suggestions`` — science-service-validated codes suggested for the
-   note's still-uncoded problem headers.
-3. ``unmatched_conditions`` — the patient's active problem list codings.
+2. ``unmatched_conditions`` — the patient's active problem list codings.
+
+We deliberately do NOT link from an uncoded block's ``candidate_suggestions``: a
+suggestion is only a ranked guess until the provider picks, so pre-filling from it
+would stamp a code the provider may not choose (the class of stale-code bug this
+pipeline exists to prevent). Referrals whose indication resolves only to a still-
+uncoded diagnosis are left blank here and linked to the provider's FINAL code at
+reconciliation time by the frontend live-linker (summary.js).
 
 It never fabricates: a referral whose indication matches nothing keeps its
 existing (empty) ``diagnosis_codes`` and remains a non-blocking, provider-review
@@ -60,20 +65,6 @@ def _codes_from_diagnose_commands(commands: list[dict[str, Any]]) -> dict[str, t
     return result
 
 
-def _codes_from_suggestions(diagnosis_suggestions: dict[str, Any]) -> dict[str, tuple[str, str]]:
-    result: dict[str, tuple[str, str]] = {}
-    for header, suggestions in (diagnosis_suggestions or {}).items():
-        if not suggestions:
-            continue
-        first = suggestions[0]
-        code = first.get("formatted_code") or first.get("code")
-        display = (first.get("display") or "").strip()
-        key = _normalize(header)
-        if code and key:
-            result.setdefault(key, (code, display))
-    return result
-
-
 def _codes_from_unmatched_conditions(unmatched_conditions: list[dict[str, Any]]) -> dict[str, tuple[str, str]]:
     result: dict[str, tuple[str, str]] = {}
     for condition in unmatched_conditions or []:
@@ -96,7 +87,6 @@ def link_referral_diagnoses(
     recommendations: list[dict[str, Any]],
     commands: list[dict[str, Any]],
     unmatched_conditions: list[dict[str, Any]],
-    diagnosis_suggestions: dict[str, Any],
 ) -> None:
     """Attach a validated ICD-10 indication to each generic ``refer`` proposal, in place.
 
@@ -107,7 +97,6 @@ def link_referral_diagnoses(
     match is found (no fabrication).
     """
     diagnose_codes = _codes_from_diagnose_commands(commands)
-    suggestion_codes = _codes_from_suggestions(diagnosis_suggestions)
     unmatched_codes = _codes_from_unmatched_conditions(unmatched_conditions)
 
     for proposal in recommendations:
@@ -119,11 +108,7 @@ def link_referral_diagnoses(
         indication = _normalize(data.get("indication"))
         if not indication:
             continue
-        match = (
-            _match(indication, diagnose_codes)
-            or _match(indication, suggestion_codes)
-            or _match(indication, unmatched_codes)
-        )
+        match = _match(indication, diagnose_codes) or _match(indication, unmatched_codes)
         if match:
             code, display = match
             data["diagnosis_codes"] = [code]

--- a/hyperscribe/scribe/recommendations/diagnosis_llm_resolver.py
+++ b/hyperscribe/scribe/recommendations/diagnosis_llm_resolver.py
@@ -1,0 +1,231 @@
+"""Grounded-LLM resolver for uncoded A&P diagnosis blocks.
+
+The deterministic belt (``ap_split`` / ``diagnosis_candidates``) leaves a block
+uncoded when neither Nabla nor the patient chart supplied a code and the lexical
+science-search fallback found nothing useful (or found a clinically wrong lexical
+match). This module resolves those blocks with a **retrieval-augmented, grounded**
+LLM step — the same "oracle over a retrieved set" pattern as
+``libraries/selector_chat.SelectorChat.condition_from``, extended with an adaptive
+query-expansion round.
+
+Per uncoded block (at most ``_MAX_ROUNDS`` LLM calls, usually one):
+
+1. Show the LLM the block header + assessment body + the candidate ICD-10 codes the
+   belt already assembled. It returns a :class:`DiagnosisResolutionStep`: a selection
+   from the provided list, a confidence, a ranked shortlist, and — when nothing
+   provided fits — clinical ``more_search_terms``.
+2. If it returns search terms and made no selection, retrieve real codes via
+   ``science_search`` (Canvas science service), merge them into the candidate pool,
+   and ask again.
+
+**Anti-hallucination is structural**: the LLM may only choose codes that are present
+in the retrieved pool; any code it returns that is not in the pool is dropped. No code
+is ever invented. Everything is best-effort — any failure returns no resolution for
+that block, leaving the belt's deterministic output untouched.
+"""
+
+from __future__ import annotations
+
+import json
+from http import HTTPStatus
+from typing import Any, Callable, NamedTuple
+
+from logger import log
+
+from hyperscribe.scribe.commands.diagnosis_candidates import format_icd10, icd10_normalize
+from hyperscribe.scribe.recommendations.schemas import DiagnosisResolutionStep
+
+# Injected callables (kept abstract so tests can supply fakes/mocks).
+ScienceSearch = Callable[[list[str]], list[Any]]
+ClientFactory = Callable[[], Any]
+
+_MAX_ROUNDS = 2
+_MAX_SUGGESTIONS = 6
+
+_SYSTEM_PROMPT = (
+    "You are a clinical coding assistant. You are given one problem from a note's assessment "
+    "& plan and a list of candidate ICD-10 codes retrieved from a medical ontology. Choose the "
+    "single ICD-10 code that best matches the DOCUMENTED clinical picture, taking the full "
+    "assessment text into account (labs, findings, and the DIRECTION of any abnormality). "
+    "You may ONLY choose codes from the provided candidate list — never invent, modify, or "
+    "reformat a code. Copy codes verbatim. "
+    "If none of the provided candidates fit the documented picture, do NOT force a choice: "
+    "leave selected_code null and return `more_search_terms` with the precise clinical term(s) "
+    "or differential to look up — e.g. the specific diagnosis, a synonym, or the correct "
+    "direction (return 'hypoalbuminemia', never 'hyperalimentation', for a low-albumin note). "
+    "A plan/management header that is not itself a diagnosis, or a symptom with no matching "
+    "candidate, should return low confidence with no selection."
+)
+
+
+class BlockContext(NamedTuple):
+    """One uncoded diagnose block handed to the resolver."""
+
+    block_id: str
+    header: str
+    body: str
+    # The belt's already-assembled suggestions (serialize_candidate shape:
+    # ``{code, formatted_code, display, provenance}``); may be empty.
+    candidates: list[dict[str, str]]
+
+
+class BlockResolution(NamedTuple):
+    """The resolver's grounded outcome for one block.
+
+    ``chosen`` is ``(formatted_code, display)`` only on a high-confidence single match
+    (the caller auto-applies it). ``suggestions`` is the ranked, in-pool picker list
+    (serialize_candidate shape). Both grounded — never an invented code.
+    """
+
+    chosen: tuple[str, str] | None
+    confidence: str
+    suggestions: list[dict[str, str]]
+
+
+def _pool_entry(code: str, formatted_code: str, display: str, provenance: str) -> dict[str, str]:
+    return {"code": code, "formatted_code": formatted_code, "display": display, "provenance": provenance}
+
+
+def _build_user_prompt(block: BlockContext, pool: dict[str, dict[str, str]]) -> str:
+    lines = [
+        "Problem (assessment & plan header):",
+        block.header or "(none)",
+        "",
+        "Full assessment text:",
+        block.body or "(none)",
+        "",
+        "Candidate ICD-10 codes — you may ONLY select from these:",
+    ]
+    if pool:
+        for meta in pool.values():
+            lines.append(f" * {meta['formatted_code']} — {meta['display']}")
+    else:
+        lines.append(" (none retrieved yet — return more_search_terms)")
+    lines += [
+        "",
+        "Select the single best-matching code (selected_code) and rank the most relevant "
+        "candidates (ranked_codes), copying each verbatim from the list above. If none fit the "
+        "documented picture, leave selected_code null and provide more_search_terms.",
+    ]
+    return "\n".join(lines)
+
+
+def _ask(block: BlockContext, pool: dict[str, dict[str, str]], client: Any) -> DiagnosisResolutionStep | None:
+    """One structured LLM call. Returns None (best-effort) on any transport/parse failure."""
+    client.reset_prompts()
+    client.set_system_prompt([_SYSTEM_PROMPT])
+    client.set_user_prompt([_build_user_prompt(block, pool)])
+    client.set_schema(DiagnosisResolutionStep)
+    try:
+        response = client.request()
+    except Exception:
+        log.exception("LLM request failed for diagnosis resolution")
+        return None
+    if response.code != HTTPStatus.OK:
+        # Do not log response.response: it is derived from the note and may contain PHI.
+        log.info(f"LLM returned {response.code} for diagnosis resolution")
+        return None
+    try:
+        parsed: DiagnosisResolutionStep = DiagnosisResolutionStep.model_validate(json.loads(response.response))
+    except Exception:
+        log.exception("Failed to parse diagnosis resolution response")
+        return None
+    return parsed
+
+
+def _merge_science(terms: list[str], pool: dict[str, dict[str, str]], science_search: ScienceSearch) -> bool:
+    """Retrieve real codes for ``terms`` and add any new ones to ``pool``. Returns True if added."""
+    added = False
+    try:
+        hits = science_search([t for t in terms if (t or "").strip()]) or []
+    except Exception:
+        # Best-effort: a science outage must not break resolution.
+        return False
+    for hit in hits:
+        norm = icd10_normalize(getattr(hit, "code", ""))
+        if not norm or norm in pool:
+            continue
+        pool[norm] = _pool_entry(
+            code=getattr(hit, "code", "") or norm,
+            formatted_code=format_icd10(norm),
+            display=getattr(hit, "label", "") or "",
+            provenance="ICD-10 search",
+        )
+        added = True
+    return added
+
+
+def _suggestions_from(step: DiagnosisResolutionStep, pool: dict[str, dict[str, str]]) -> list[dict[str, str]]:
+    """Build the ranked, in-pool picker list from the model's ranked_codes (+ selection first).
+
+    Hard anti-hallucination gate: only codes present in ``pool`` survive.
+    """
+    ordered: list[str] = []
+    for code in [step.selected_code, *step.ranked_codes]:
+        norm = icd10_normalize(code or "")
+        if norm and norm in pool and norm not in ordered:
+            ordered.append(norm)
+    return [dict(pool[norm]) for norm in ordered[:_MAX_SUGGESTIONS]]
+
+
+def _resolve_one(block: BlockContext, client: Any, science_search: ScienceSearch) -> BlockResolution | None:
+    # Seed the pool from the belt's existing suggestions, keyed by normalized code.
+    pool: dict[str, dict[str, str]] = {}
+    for candidate in block.candidates or []:
+        norm = icd10_normalize(candidate.get("code") or candidate.get("formatted_code") or "")
+        if not norm or norm in pool:
+            continue
+        pool[norm] = _pool_entry(
+            code=candidate.get("code") or norm,
+            formatted_code=candidate.get("formatted_code") or format_icd10(norm),
+            display=candidate.get("display") or "",
+            provenance=candidate.get("provenance") or "Detected in note",
+        )
+
+    last_step: DiagnosisResolutionStep | None = None
+    for _round in range(_MAX_ROUNDS):
+        step = _ask(block, pool, client)
+        if step is None:
+            break
+        last_step = step
+        selected_norm = icd10_normalize(step.selected_code or "")
+        if selected_norm and selected_norm in pool:
+            entry = pool[selected_norm]
+            suggestions = _suggestions_from(step, pool)
+            # Auto-apply only on high confidence; otherwise surface for the provider.
+            chosen = (entry["formatted_code"], entry["display"]) if step.confidence == "high" else None
+            return BlockResolution(chosen=chosen, confidence=step.confidence, suggestions=suggestions)
+        # No valid in-pool selection: expand the search and try once more.
+        if not _merge_science(step.more_search_terms, pool, science_search):
+            break
+
+    # Exhausted rounds without a confident selection. Surface whatever the last step
+    # ranked (in-pool) so the provider still gets grounded options; else give up.
+    if last_step is not None:
+        suggestions = _suggestions_from(last_step, pool)
+        if suggestions:
+            return BlockResolution(chosen=None, confidence=last_step.confidence, suggestions=suggestions)
+    return None
+
+
+def resolve_uncoded_blocks(
+    blocks: list[BlockContext],
+    make_client: ClientFactory,
+    science_search: ScienceSearch,
+) -> dict[str, BlockResolution]:
+    """Resolve each uncoded block. Returns ``{block_id: BlockResolution}``.
+
+    A fresh client is built per block (mirrors ``recommend_commands``). Every block is
+    best-effort: a failure logs and is skipped, so a block simply keeps the belt's
+    deterministic output.
+    """
+    results: dict[str, BlockResolution] = {}
+    for block in blocks:
+        try:
+            resolution = _resolve_one(block, make_client(), science_search)
+        except Exception:
+            log.exception("diagnosis resolution failed for a block")
+            resolution = None
+        if resolution is not None:
+            results[block.block_id] = resolution
+    return results

--- a/hyperscribe/scribe/recommendations/diagnosis_llm_resolver.py
+++ b/hyperscribe/scribe/recommendations/diagnosis_llm_resolver.py
@@ -202,19 +202,11 @@ def _resolve_one(block: BlockContext, client: Any, science_search: ScienceSearch
         last_step = step
         selected_norm = icd10_normalize(step.selected_code or "")
         if selected_norm and selected_norm in pool:
-            entry = pool[selected_norm]
+            # Never auto-apply: the resolver only curates the grounded suggestion list; the
+            # provider always picks the code from the picker. The model's selection simply
+            # leads the ranked suggestions.
             suggestions = _suggestions_from(step, pool)
-            # Auto-apply only on high confidence AND not a contextual Z-code. A Z-code
-            # (Chapter 21 — factors influencing health status, e.g. Z75.8 "problems
-            # related to access to care") is a coding judgment the provider should make
-            # deliberately, not have silently stamped onto an administrative header —
-            # so a high-confidence Z pick is surfaced for confirmation, not applied.
-            chosen = (
-                (entry["formatted_code"], entry["display"])
-                if step.confidence == "high" and not _is_contextual_z(selected_norm)
-                else None
-            )
-            return BlockResolution(chosen=chosen, confidence=step.confidence, suggestions=suggestions)
+            return BlockResolution(chosen=None, confidence=step.confidence, suggestions=suggestions)
         # No valid in-pool selection: expand the search and try once more.
         if not _merge_science(step.more_search_terms, pool, science_search):
             break

--- a/hyperscribe/scribe/recommendations/diagnosis_llm_resolver.py
+++ b/hyperscribe/scribe/recommendations/diagnosis_llm_resolver.py
@@ -93,6 +93,11 @@ def _pool_entry(code: str, formatted_code: str, display: str, provenance: str) -
     return {"code": code, "formatted_code": formatted_code, "display": display, "provenance": provenance}
 
 
+def _is_contextual_z(code: str) -> bool:
+    """True for an ICD-10 Chapter 21 ``Z`` code (factors influencing health status)."""
+    return icd10_normalize(code).startswith("Z")
+
+
 def _build_user_prompt(block: BlockContext, pool: dict[str, dict[str, str]]) -> str:
     lines = [
         "Problem (assessment & plan header):",
@@ -199,8 +204,16 @@ def _resolve_one(block: BlockContext, client: Any, science_search: ScienceSearch
         if selected_norm and selected_norm in pool:
             entry = pool[selected_norm]
             suggestions = _suggestions_from(step, pool)
-            # Auto-apply only on high confidence; otherwise surface for the provider.
-            chosen = (entry["formatted_code"], entry["display"]) if step.confidence == "high" else None
+            # Auto-apply only on high confidence AND not a contextual Z-code. A Z-code
+            # (Chapter 21 — factors influencing health status, e.g. Z75.8 "problems
+            # related to access to care") is a coding judgment the provider should make
+            # deliberately, not have silently stamped onto an administrative header —
+            # so a high-confidence Z pick is surfaced for confirmation, not applied.
+            chosen = (
+                (entry["formatted_code"], entry["display"])
+                if step.confidence == "high" and not _is_contextual_z(selected_norm)
+                else None
+            )
             return BlockResolution(chosen=chosen, confidence=step.confidence, suggestions=suggestions)
         # No valid in-pool selection: expand the search and try once more.
         if not _merge_science(step.more_search_terms, pool, science_search):

--- a/hyperscribe/scribe/recommendations/diagnosis_llm_resolver.py
+++ b/hyperscribe/scribe/recommendations/diagnosis_llm_resolver.py
@@ -53,8 +53,15 @@ _SYSTEM_PROMPT = (
     "leave selected_code null and return `more_search_terms` with the precise clinical term(s) "
     "or differential to look up — e.g. the specific diagnosis, a synonym, or the correct "
     "direction (return 'hypoalbuminemia', never 'hyperalimentation', for a low-albumin note). "
-    "A plan/management header that is not itself a diagnosis, or a symptom with no matching "
-    "candidate, should return low confidence with no selection."
+    "A condition that is being actively managed, treated, or monitored is STILL a current "
+    "diagnosis to code, even when today's labs or vitals are normal BECAUSE of that treatment — "
+    "code the underlying condition being managed, not 'normal'. For example, ongoing "
+    "prescription-strength vitamin D supplementation implies vitamin D deficiency (a normal level "
+    "on supplementation means it is controlled, not absent); a chronic disease that is 'well "
+    "controlled' on medication is still that disease. When the header names a treatment/"
+    "supplement rather than the diagnosis, search for the condition that treatment manages. "
+    "A purely administrative or logistical header with no underlying clinical condition (e.g. an "
+    "access or scheduling problem) should return low confidence with no selection."
 )
 
 

--- a/hyperscribe/scribe/recommendations/diagnosis_suggestion.py
+++ b/hyperscribe/scribe/recommendations/diagnosis_suggestion.py
@@ -1,110 +1,43 @@
+"""Grounded ICD-10 suggestions for uncoded condition headers.
+
+This REPLACES the former free-generation path, in which the LLM emitted ICD-10
+codes that were only existence-checked — a hallucination risk (a plausible but
+clinically-wrong code that happens to exist would pass). Codes now come ONLY from
+the Canvas science service and are ranked by the shared deterministic engine
+(``diagnosis_candidates``). No LLM is involved, so a code that the ontology does
+not return can never be surfaced.
+
+In the main ``/generate-summary`` flow these options are produced inline by the
+A&P belt (``split_plan_into_diagnoses`` stamps ``candidate_suggestions`` on each
+uncoded diagnose proposal, keyed by ``block_id``). This module backs the
+standalone ``/suggest-diagnoses`` endpoint, which resolves a list of free-text
+condition headers to grounded, ranked code options.
+"""
+
 from __future__ import annotations
 
-import json
-from http import HTTPStatus
-
-from logger import log
-
-from canvas_sdk.clients.llms.libraries import LlmAnthropic
-from canvas_sdk.clients.llms.structures.settings import LlmSettingsAnthropic
-from canvas_sdk.utils.http import science_http
-
-from hyperscribe.scribe.recommendations.schemas import DiagnosisSuggestionList
-
-_MODEL = "claude-sonnet-4-5-20250929"
-
-_SYSTEM_PROMPT = (
-    "You are a clinical coding assistant. "
-    "For each condition description provided, suggest 2-3 ICD-10-CM codes that best match. "
-    "Return only the ICD-10 codes without dots (e.g. R519 not R51.9)."
-)
+from hyperscribe.libraries.canvas_science import CanvasScience
+from hyperscribe.scribe.commands.diagnosis_candidates import build_block_candidates, serialize_candidate
 
 
-def _make_settings(api_key: str) -> LlmSettingsAnthropic:
-    return LlmSettingsAnthropic(
-        api_key=api_key,
-        model=_MODEL,
-        temperature=0.0,
-        max_tokens=2048,
-    )
+def suggest_diagnoses(conditions: list[str]) -> dict[str, list[dict[str, str]]]:
+    """Return ``{condition_text: [ranked grounded code options]}``.
 
-
-def _validate_code(code: str) -> dict[str, str] | None:
-    """Search the science service to confirm an ICD-10 code exists. Return resolved info or None."""
-    try:
-        resp = science_http.get_json(f"/search/condition/?query={code}&limit=5")
-        data = resp.json() or {}
-    except Exception:
-        log.exception(f"Science search failed for code {code}")
-        return None
-
-    clean = code.replace(".", "").upper()
-    for r in data.get("results", []):
-        result_code = (r.get("icd10_code") or "").replace(".", "").upper()
-        if result_code == clean:
-            raw = r["icd10_code"]
-            formatted = raw[:3] + "." + raw[3:] if len(raw) > 3 else raw
-            return {
-                "code": raw,
-                "display": r.get("icd10_text", ""),
-                "formatted_code": formatted,
-            }
-    return None
-
-
-def suggest_diagnoses(conditions: list[str], api_key: str) -> dict[str, list[dict[str, str]]]:
-    """Call Anthropic LLM to suggest ICD-10 codes for each condition, then validate via science service."""
-    if not conditions:
-        return {}
-
-    client = LlmAnthropic(_make_settings(api_key))
-    client.reset_prompts()
-    client.set_system_prompt([_SYSTEM_PROMPT])
-
-    user_prompt = "Suggest ICD-10 codes for each condition:\n"
-    for i, cond in enumerate(conditions, 1):
-        user_prompt += f"{i}. {cond}\n"
-    client.set_user_prompt([user_prompt])
-    client.set_schema(DiagnosisSuggestionList)
-
-    try:
-        response = client.request()
-    except Exception:
-        log.exception("LLM request failed for diagnosis suggestions")
-        return {}
-
-    if response.code != HTTPStatus.OK:
-        log.info(f"LLM returned {response.code} for diagnosis suggestions: {response.response}")
-        return {}
-
-    try:
-        parsed = DiagnosisSuggestionList.model_validate(json.loads(response.response))
-    except Exception:
-        log.exception(f"Failed to parse diagnosis suggestion LLM response: {response.response}")
-        return {}
-
-    # Build a lookup to map LLM-returned condition_text back to the original input strings.
-    originals_lower = {c.strip().lower(): c for c in conditions}
-
+    Each option is grounded in a Canvas science-service search for the condition
+    text and carries ``{code, formatted_code, display, provenance}``. No code is
+    invented: a condition with no science match yields an empty list (the provider
+    falls back to manual search). Blank conditions are skipped.
+    """
     result: dict[str, list[dict[str, str]]] = {}
-    for suggestion in parsed.suggestions:
-        validated: list[dict[str, str]] = []
-        for code in suggestion.icd10_codes:
-            info = _validate_code(code)
-            if info:
-                validated.append(info)
-        if not validated:
+    for condition in conditions:
+        if not (condition or "").strip():
             continue
-
-        # Use the original condition string as the key so the frontend can match exactly.
-        llm_text = suggestion.condition_text.strip().lower()
-        key = originals_lower.get(llm_text)
-        if not key:
-            # Fallback: partial substring match.
-            for orig_lower, orig in originals_lower.items():
-                if llm_text in orig_lower or orig_lower in llm_text:
-                    key = orig
-                    break
-        result[key or suggestion.condition_text] = validated
-
+        block = build_block_candidates(
+            block_id="",
+            header=condition.strip(),
+            nabla_for_block=[],
+            chart=[],
+            science_search=CanvasScience.search_conditions,
+        )
+        result[condition] = [serialize_candidate(candidate) for candidate in block.candidates[:5]]
     return result

--- a/hyperscribe/scribe/recommendations/schemas.py
+++ b/hyperscribe/scribe/recommendations/schemas.py
@@ -168,15 +168,3 @@ class TaskRecommendationList(BaseModelLlmJson):
         default_factory=list,
         description="List of tasks extracted from the transcript and clinical note",
     )
-
-
-class DiagnosisSuggestion(BaseModelLlmJson):
-    condition_text: str = Field(description="The original condition text")
-    icd10_codes: list[str] = Field(description="2-3 ICD-10 codes (e.g. R519, G43009)")
-
-
-class DiagnosisSuggestionList(BaseModelLlmJson):
-    suggestions: list[DiagnosisSuggestion] = Field(
-        default_factory=list,
-        description="List of diagnosis suggestions per condition",
-    )

--- a/hyperscribe/scribe/recommendations/schemas.py
+++ b/hyperscribe/scribe/recommendations/schemas.py
@@ -168,3 +168,44 @@ class TaskRecommendationList(BaseModelLlmJson):
         default_factory=list,
         description="List of tasks extracted from the transcript and clinical note",
     )
+
+
+class DiagnosisResolutionStep(BaseModelLlmJson):
+    """One grounded-selection step for an uncoded diagnosis block.
+
+    The model is an oracle over a retrieved set of REAL ICD-10 codes — it may only
+    select codes present in the candidate list it was shown, never invent one. When
+    nothing in the shown list fits the documented clinical picture, it returns
+    ``more_search_terms`` so the caller can retrieve better candidates and ask again.
+    """
+
+    selected_code: str | None = Field(
+        default=None,
+        description=(
+            "The single best ICD-10 code for this block, copied VERBATIM from the provided "
+            "candidate list. Null if none of the provided candidates fit the documented picture."
+        ),
+    )
+    confidence: str = Field(
+        default="low",
+        description=(
+            "'high' only when one provided candidate clearly and specifically matches the "
+            "documented diagnosis; 'medium' when a candidate is plausible but not certain; "
+            "'low' when no provided candidate is a good fit."
+        ),
+    )
+    ranked_codes: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Up to 6 ICD-10 codes from the provided candidate list, best-first, to offer the "
+            "provider. Every entry MUST be copied verbatim from the provided list."
+        ),
+    )
+    more_search_terms: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Clinical search terms (synonyms, the specific diagnosis, or differential) to look "
+            "up when no provided candidate fits — e.g. 'hypoalbuminemia', 'pulmonary edema', "
+            "'iron deficiency anemia'. Leave empty when a provided candidate is selected."
+        ),
+    )

--- a/hyperscribe/scribe/static/debug.js
+++ b/hyperscribe/scribe/static/debug.js
@@ -132,6 +132,7 @@ const SUMMARY_FIELDS = [
   { key: 'selected_template_name', name: 'selected_template_name', type: 'text' },
   { key: 'mode', name: 'mode', type: 'text' },
   { key: 'raw_response', name: 'raw_response', type: 'json' },
+  { key: 'raw_normalized_response', name: 'raw_normalized_response', type: 'json' },
   { key: 'updated_at', name: 'updated_at', type: 'text' },
 ];
 

--- a/hyperscribe/scribe/static/diagnose-row.js
+++ b/hyperscribe/scribe/static/diagnose-row.js
@@ -289,14 +289,6 @@ export function DiagnoseRow({ command, commandIndex, onEdit, onMoveToPlan, readO
   // "Change" affordance, not by clicking the code.
   const titleText = hasCode ? (data.icd10_display || conditionHeader) : conditionHeader;
 
-  // The original Nabla-generated A&P problem name. Once a code is chosen the card
-  // title becomes the diagnosis (and `condition_header` may be rewritten to the ICD
-  // display), so the original headline is preserved in `_original_header`. Surface it
-  // as a quasi-header inside Today's assessment so it persists for reference. Hidden
-  // when it would just duplicate the card title (e.g. an uncoded card).
-  const originalHeader = (data._original_header || data.condition_header || '').trim();
-  const showAssessmentHeader = originalHeader && originalHeader !== titleText;
-
   const recCodes = suggestions || [];
 
   // Integrated picker — search input on top, then live results (while typing)
@@ -396,7 +388,6 @@ export function DiagnoseRow({ command, commandIndex, onEdit, onMoveToPlan, readO
             `)}
           `}
           <div class="diagnose-body-label">Today's assessment</div>
-          ${showAssessmentHeader && html`<div class="diagnose-assessment-header">${originalHeader}</div>`}
           ${(data.today_assessment || '').length > 0
             ? (data.today_assessment || '').split('\n').map((line, i) => html`
                 <div key=${i} class="diagnose-body-line">${line}</div>
@@ -433,7 +424,6 @@ export function DiagnoseRow({ command, commandIndex, onEdit, onMoveToPlan, readO
             `}
           <div class="diagnose-field">
             <div class="diagnose-body-label">Today's assessment</div>
-            ${showAssessmentHeader && html`<div class="diagnose-assessment-header">${originalHeader}</div>`}
             <textarea
               ref=${textareaRef}
               class="command-row-textarea"

--- a/hyperscribe/scribe/static/diagnose-row.js
+++ b/hyperscribe/scribe/static/diagnose-row.js
@@ -7,6 +7,8 @@ const html = htm.bind(h);
 const ICON_PENCIL = html`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 20h9"/><path d="M16.5 3.5a2.1 2.1 0 0 1 3 3L7 19l-4 1 1-4Z"/></svg>`;
 const ICON_SEARCH = html`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="7"/><line x1="20" y1="20" x2="16.65" y2="16.65"/></svg>`;
 const ICON_X = html`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="6" y1="6" x2="18" y2="18"/><line x1="6" y1="18" x2="18" y2="6"/></svg>`;
+// How many recommendations the picker shows before the "See more" toggle.
+const MAX_VISIBLE_RECS = 4;
 
 const API_BASE = '/plugin-io/api/hyperscribe/scribe-session';
 const DEBOUNCE_MS = 300;
@@ -76,6 +78,9 @@ export function DiagnoseRow({ command, commandIndex, onEdit, onMoveToPlan, readO
   // Progressive disclosure for the "not a diagnosis" escape hatch: the picker shows a
   // quiet "Not a diagnosis?" trigger; clicking it reveals the "Move to Wrap Up" action.
   const [showMoveOption, setShowMoveOption] = useState(false);
+  // The recommendations list shows the top few; "See more" reveals the rest AND the
+  // move-to-wrap-up action. Reset (collapsed) whenever the picker is opened/closed.
+  const [showAllRecs, setShowAllRecs] = useState(false);
   const [assessment, setAssessment] = useState(data.today_assessment || '');
   // KOALA_5635_BACKGROUND_TEXTAREA — local state mirrors AssessNarrative's
   // pattern (soap-group.js): seed from ``data.background``, sync on
@@ -228,6 +233,7 @@ export function DiagnoseRow({ command, commandIndex, onEdit, onMoveToPlan, readO
     setSearched(false);
     setSearching(false);
     setShowMoveOption(false); // reopen the picker collapsed to "Not a diagnosis?"
+    setShowAllRecs(false); // reopen showing only the top recommendations
   };
 
   // Close the "Change" picker on a coded card and revert to showing the code.
@@ -239,6 +245,7 @@ export function DiagnoseRow({ command, commandIndex, onEdit, onMoveToPlan, readO
     setSearched(false);
     setSearching(false);
     setShowMoveOption(false); // collapse the "Not a diagnosis?" disclosure on close
+    setShowAllRecs(false); // collapse the recommendations back to the top few
   };
 
   const handleAddBackground = () => {
@@ -313,58 +320,66 @@ export function DiagnoseRow({ command, commandIndex, onEdit, onMoveToPlan, readO
         />
         ${onClose && html`<button type="button" class="diagnose-picker-close" onClick=${onClose} title="Close" aria-label="Close search">${ICON_X}</button>`}
       </div>
-      ${results.length > 0
-        ? html`
-          <div class="diagnose-picker-list">
-            ${results.map((r, i) => html`
-              <div
-                key=${r.code || ('r' + i)}
-                class="diagnose-picker-row"
-                onMouseDown=${(e) => { e.preventDefault(); handleSelect(r); }}
-              >
-                <span class="diagnose-picker-name">${r.display || r.description}</span>
-                <span class="diagnose-picker-code">${formatIcdCode(r.code)}</span>
-              </div>
-            `)}
-          </div>
-        `
-        : (query.length < 2 && recCodes.length > 0)
-        ? html`
-          <div class="diagnose-picker-list">
-            ${recCodes.map(s => html`
-              <div
-                key=${s.code}
-                class="diagnose-picker-row"
-                onMouseDown=${(e) => { e.preventDefault(); handleSelect({ code: s.code, display: s.display, formatted_code: s.formatted_code }); }}
-              >
-                <span class="diagnose-picker-name">${s.display}</span>
-                <span class="diagnose-picker-code">${s.formatted_code}</span>
-                ${s.provenance ? html`<span class="diagnose-picker-prov">${s.provenance}</span>` : ''}
-              </div>
-            `)}
-          </div>
-        `
-        : searching
-        ? html`<div class="diagnose-picker-empty">Searching…</div>`
-        : (searched && query.length >= 2)
-        ? html`<div class="diagnose-picker-empty">No diagnoses found</div>`
-        : null}
-      ${/* Move this card's content to the Wrap Up section (for A&P items that aren't a
-          codeable diagnosis). A single self-arming row that reads like the search results:
-          first click swaps the label to "Confirm", second click performs the move. No
-          separate cancel — showMoveOption resets on picker open/close (and it stays
-          disarmed until clicked). onMouseDown+preventDefault so the search input's blur
-          doesn't eat the click. */ ''}
-      ${onMoveToPlan && html`
-        <button
-          type="button"
-          class="diagnose-picker-disclose"
-          title=${showMoveOption
-            ? 'Click again to confirm — moves this content to the wrap up section'
-            : "Move this card's free-text content to the wrap up section — use when the item isn't a codeable diagnosis."}
-          onMouseDown=${(e) => { e.preventDefault(); showMoveOption ? onMoveToPlan(commandIndex) : setShowMoveOption(true); }}
-        >${showMoveOption ? 'Confirm' : 'Move to the wrap up section'}</button>
-      `}
+      ${query.length >= 2
+        ? (results.length > 0
+          ? html`
+            <div class="diagnose-picker-list">
+              ${results.map((r, i) => html`
+                <div
+                  key=${r.code || ('r' + i)}
+                  class="diagnose-picker-row"
+                  onMouseDown=${(e) => { e.preventDefault(); handleSelect(r); }}
+                >
+                  <span class="diagnose-picker-name">${r.display || r.description}</span>
+                  <span class="diagnose-picker-code">${formatIcdCode(r.code)}</span>
+                </div>
+              `)}
+            </div>
+          `
+          : searching
+          ? html`<div class="diagnose-picker-empty">Searching…</div>`
+          : searched
+          ? html`<div class="diagnose-picker-empty">No diagnoses found</div>`
+          : null)
+        : html`
+          ${/* Recommendations (empty query): show the top few, best first. "See more"
+              reveals the rest AND the "move to wrap up" action beneath them. */ ''}
+          ${recCodes.length > 0 && html`
+            <div class="diagnose-picker-list">
+              ${(showAllRecs ? recCodes : recCodes.slice(0, MAX_VISIBLE_RECS)).map(s => html`
+                <div
+                  key=${s.code}
+                  class="diagnose-picker-row"
+                  onMouseDown=${(e) => { e.preventDefault(); handleSelect({ code: s.code, display: s.display, formatted_code: s.formatted_code }); }}
+                >
+                  <span class="diagnose-picker-name">${s.display}</span>
+                  <span class="diagnose-picker-code">${s.formatted_code}</span>
+                  ${s.provenance ? html`<span class="diagnose-picker-prov">${s.provenance}</span>` : ''}
+                </div>
+              `)}
+            </div>
+          `}
+          ${!showAllRecs && (recCodes.length > MAX_VISIBLE_RECS || onMoveToPlan) && html`
+            <button type="button" class="diagnose-picker-more" onMouseDown=${(e) => { e.preventDefault(); setShowAllRecs(true); }}>See more</button>
+          `}
+          ${showAllRecs && recCodes.length > MAX_VISIBLE_RECS && html`
+            <button type="button" class="diagnose-picker-more" onMouseDown=${(e) => { e.preventDefault(); setShowAllRecs(false); }}>See less</button>
+          `}
+          ${/* Move this card's content to the Wrap Up section (for A&P items that aren't a
+              codeable diagnosis) — revealed under "See more". Self-arming: first click swaps
+              the label to "Confirm", second click performs the move. onMouseDown+preventDefault
+              so the search input's blur doesn't eat the click. */ ''}
+          ${showAllRecs && onMoveToPlan && html`
+            <button
+              type="button"
+              class="diagnose-picker-disclose"
+              title=${showMoveOption
+                ? 'Click again to confirm — moves this content to the wrap up section'
+                : "Move this card's free-text content to the wrap up section — use when the item isn't a codeable diagnosis."}
+              onMouseDown=${(e) => { e.preventDefault(); showMoveOption ? onMoveToPlan(commandIndex) : setShowMoveOption(true); }}
+            >${showMoveOption ? 'Confirm' : 'Move to the wrap up section'}</button>
+          `}
+        `}
     </div>
   `;
 

--- a/hyperscribe/scribe/static/diagnose-row.js
+++ b/hyperscribe/scribe/static/diagnose-row.js
@@ -74,6 +74,9 @@ export function DiagnoseRow({ command, commandIndex, onEdit, onMoveToPlan, readO
   const [results, setResults] = useState([]);
   const [searching, setSearching] = useState(false);
   const [searched, setSearched] = useState(false);
+  // Progressive disclosure for the "not a diagnosis" escape hatch: the picker shows a
+  // quiet "Not a diagnosis?" trigger; clicking it reveals the "Move to Wrap Up" action.
+  const [showMoveOption, setShowMoveOption] = useState(false);
   const [assessment, setAssessment] = useState(data.today_assessment || '');
   // KOALA_5635_BACKGROUND_TEXTAREA — local state mirrors AssessNarrative's
   // pattern (soap-group.js): seed from ``data.background``, sync on
@@ -346,22 +349,25 @@ export function DiagnoseRow({ command, commandIndex, onEdit, onMoveToPlan, readO
         ? html`<div class="diagnose-picker-empty">No diagnoses found</div>`
         : null}
       ${/* Not a diagnosis? Reclassify the card as a plan narrative in Wrap Up. Lives in
-          the picker so it's available both for an uncoded card and when changing a code.
+          the picker (available both for an uncoded card and when changing a code) behind a
+          quiet "Not a diagnosis?" trigger that reveals the "Move to Wrap Up" action.
           onMouseDown+preventDefault so the search input's blur doesn't eat the click. */ ''}
-      ${onMoveToPlan && html`
-        <button
-          type="button"
-          class="diagnose-picker-action"
-          title="Not a diagnosis — move this to Wrap Up"
-          onMouseDown=${(e) => { e.preventDefault(); onMoveToPlan(commandIndex); }}
-        >
-          ${ICON_MOVE}
-          <span class="diagnose-picker-action-text">
-            <span class="diagnose-picker-action-title">Move to Wrap Up</span>
-            <span class="diagnose-picker-action-sub">Not a diagnosis</span>
-          </span>
-        </button>
-      `}
+      ${onMoveToPlan && (showMoveOption
+        ? html`
+          <button
+            type="button"
+            class="diagnose-picker-action"
+            title="Moves this card's content out of the diagnosis list into the Wrap Up section. Use when the item isn't a codeable diagnosis (e.g. a plan or administrative note)."
+            onMouseDown=${(e) => { e.preventDefault(); onMoveToPlan(commandIndex); }}
+          >${ICON_MOVE} Move to Wrap Up</button>
+        `
+        : html`
+          <button
+            type="button"
+            class="diagnose-picker-disclose"
+            onMouseDown=${(e) => { e.preventDefault(); setShowMoveOption(true); }}
+          >Not a diagnosis?</button>
+        `)}
     </div>
   `;
 

--- a/hyperscribe/scribe/static/diagnose-row.js
+++ b/hyperscribe/scribe/static/diagnose-row.js
@@ -289,6 +289,14 @@ export function DiagnoseRow({ command, commandIndex, onEdit, onMoveToPlan, readO
   // "Change" affordance, not by clicking the code.
   const titleText = hasCode ? (data.icd10_display || conditionHeader) : conditionHeader;
 
+  // The original Nabla-generated A&P problem name. Once a code is chosen the card
+  // title becomes the diagnosis (and `condition_header` may be rewritten to the ICD
+  // display), so the original headline is preserved in `_original_header`. Surface it
+  // as a quasi-header inside Today's assessment so it persists for reference. Hidden
+  // when it would just duplicate the card title (e.g. an uncoded card).
+  const originalHeader = (data._original_header || data.condition_header || '').trim();
+  const showAssessmentHeader = originalHeader && originalHeader !== titleText;
+
   const recCodes = suggestions || [];
 
   // Integrated picker — search input on top, then live results (while typing)
@@ -388,6 +396,7 @@ export function DiagnoseRow({ command, commandIndex, onEdit, onMoveToPlan, readO
             `)}
           `}
           <div class="diagnose-body-label">Today's assessment</div>
+          ${showAssessmentHeader && html`<div class="diagnose-assessment-header">${originalHeader}</div>`}
           ${(data.today_assessment || '').length > 0
             ? (data.today_assessment || '').split('\n').map((line, i) => html`
                 <div key=${i} class="diagnose-body-line">${line}</div>
@@ -424,6 +433,7 @@ export function DiagnoseRow({ command, commandIndex, onEdit, onMoveToPlan, readO
             `}
           <div class="diagnose-field">
             <div class="diagnose-body-label">Today's assessment</div>
+            ${showAssessmentHeader && html`<div class="diagnose-assessment-header">${originalHeader}</div>`}
             <textarea
               ref=${textareaRef}
               class="command-row-textarea"

--- a/hyperscribe/scribe/static/diagnose-row.js
+++ b/hyperscribe/scribe/static/diagnose-row.js
@@ -230,6 +230,7 @@ export function DiagnoseRow({ command, commandIndex, onEdit, onMoveToPlan, readO
     setResults([]);
     setSearched(false);
     setSearching(false);
+    setShowMoveOption(false); // reopen the picker collapsed to "Not a diagnosis?"
   };
 
   // Close the "Change" picker on a coded card and revert to showing the code.
@@ -240,6 +241,7 @@ export function DiagnoseRow({ command, commandIndex, onEdit, onMoveToPlan, readO
     setResults([]);
     setSearched(false);
     setSearching(false);
+    setShowMoveOption(false); // collapse the "Not a diagnosis?" disclosure on close
   };
 
   const handleAddBackground = () => {

--- a/hyperscribe/scribe/static/diagnose-row.js
+++ b/hyperscribe/scribe/static/diagnose-row.js
@@ -358,7 +358,7 @@ export function DiagnoseRow({ command, commandIndex, onEdit, onMoveToPlan, readO
       ${onMoveToPlan && html`
         <button
           type="button"
-          class=${`diagnose-picker-disclose${showMoveOption ? ' armed' : ''}`}
+          class="diagnose-picker-disclose"
           title=${showMoveOption
             ? 'Click again to confirm — moves this content to the wrap up section'
             : "Move this card's free-text content to the wrap up section — use when the item isn't a codeable diagnosis."}

--- a/hyperscribe/scribe/static/diagnose-row.js
+++ b/hyperscribe/scribe/static/diagnose-row.js
@@ -8,6 +8,8 @@ const ICON_PENCIL = html`<svg viewBox="0 0 24 24" fill="none" stroke="currentCol
 const ICON_SEARCH = html`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="7"/><line x1="20" y1="20" x2="16.65" y2="16.65"/></svg>`;
 const ICON_X = html`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="6" y1="6" x2="18" y2="18"/><line x1="6" y1="18" x2="18" y2="6"/></svg>`;
 const ICON_MOVE = html`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg>`;
+const ICON_TAG = html`<svg class="nd-lead" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20.59 13.41 13.42 20.6a2 2 0 0 1-2.83 0L3 13V3h10l7.59 7.59a2 2 0 0 1 0 2.82z"/><line x1="7" y1="7" x2="7.01" y2="7"/></svg>`;
+const ICON_CHEVRON = html`<svg class="nd-chev" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 18 15 12 9 6"/></svg>`;
 
 const API_BASE = '/plugin-io/api/hyperscribe/scribe-session';
 const DEBOUNCE_MS = 300;
@@ -357,16 +359,16 @@ export function DiagnoseRow({ command, commandIndex, onEdit, onMoveToPlan, readO
           <button
             type="button"
             class="diagnose-picker-action"
-            title="Moves this card's content out of the diagnosis list into the Wrap Up section. Use when the item isn't a codeable diagnosis (e.g. a plan or administrative note)."
+            title="Moves this card's free-text content out of the diagnosis list into the Wrap Up section. Use when the item isn't a codeable diagnosis (e.g. a plan or administrative note)."
             onMouseDown=${(e) => { e.preventDefault(); onMoveToPlan(commandIndex); }}
-          >${ICON_MOVE} Move to Wrap Up</button>
+          >${ICON_MOVE} Move free text content to Wrap Up section</button>
         `
         : html`
           <button
             type="button"
             class="diagnose-picker-disclose"
             onMouseDown=${(e) => { e.preventDefault(); setShowMoveOption(true); }}
-          >Not a diagnosis?</button>
+          >${ICON_TAG}Not a diagnosis?${ICON_CHEVRON}</button>
         `)}
     </div>
   `;

--- a/hyperscribe/scribe/static/diagnose-row.js
+++ b/hyperscribe/scribe/static/diagnose-row.js
@@ -350,29 +350,21 @@ export function DiagnoseRow({ command, commandIndex, onEdit, onMoveToPlan, readO
         ? html`<div class="diagnose-picker-empty">No diagnoses found</div>`
         : null}
       ${/* Move this card's content to the Wrap Up section (for A&P items that aren't a
-          codeable diagnosis). Lives in the picker — available on an uncoded card and when
-          changing a code — as a two-click inline confirm: the "Move to the wrap up section"
-          trigger arms an inline Cancel/Confirm carrying the SAME label. onMouseDown+
-          preventDefault so the search input's blur doesn't eat the click; showMoveOption
-          resets on picker open/close so it always reopens disarmed. */ ''}
-      ${onMoveToPlan && (showMoveOption
-        ? html`
-          <div class="diagnose-move-confirm">
-            <span class="diagnose-move-label">Move to the wrap up section</span>
-            <span class="diagnose-move-actions">
-              <button type="button" class="diagnose-move-cancel" onMouseDown=${(e) => { e.preventDefault(); setShowMoveOption(false); }}>Cancel</button>
-              <button type="button" class="diagnose-move-confirm-btn" onMouseDown=${(e) => { e.preventDefault(); onMoveToPlan(commandIndex); }}>Confirm</button>
-            </span>
-          </div>
-        `
-        : html`
-          <button
-            type="button"
-            class="diagnose-picker-disclose"
-            title="Move this card's free-text content to the wrap up section — use when the item isn't a codeable diagnosis."
-            onMouseDown=${(e) => { e.preventDefault(); setShowMoveOption(true); }}
-          >Move to the wrap up section</button>
-        `)}
+          codeable diagnosis). A single self-arming row that reads like the search results:
+          first click swaps the label to "Confirm", second click performs the move. No
+          separate cancel — showMoveOption resets on picker open/close (and it stays
+          disarmed until clicked). onMouseDown+preventDefault so the search input's blur
+          doesn't eat the click. */ ''}
+      ${onMoveToPlan && html`
+        <button
+          type="button"
+          class=${`diagnose-picker-disclose${showMoveOption ? ' armed' : ''}`}
+          title=${showMoveOption
+            ? 'Click again to confirm — moves this content to the wrap up section'
+            : "Move this card's free-text content to the wrap up section — use when the item isn't a codeable diagnosis."}
+          onMouseDown=${(e) => { e.preventDefault(); showMoveOption ? onMoveToPlan(commandIndex) : setShowMoveOption(true); }}
+        >${showMoveOption ? 'Confirm' : 'Move to the wrap up section'}</button>
+      `}
     </div>
   `;
 

--- a/hyperscribe/scribe/static/diagnose-row.js
+++ b/hyperscribe/scribe/static/diagnose-row.js
@@ -326,7 +326,6 @@ export function DiagnoseRow({ command, commandIndex, onEdit, onMoveToPlan, readO
         `
         : (query.length < 2 && recCodes.length > 0)
         ? html`
-          <div class="diagnose-picker-label">Recommended</div>
           <div class="diagnose-picker-list">
             ${recCodes.map(s => html`
               <div

--- a/hyperscribe/scribe/static/diagnose-row.js
+++ b/hyperscribe/scribe/static/diagnose-row.js
@@ -358,8 +358,10 @@ export function DiagnoseRow({ command, commandIndex, onEdit, onMoveToPlan, readO
           <button type="button" class="diagnose-change-btn" onClick=${handleClearCode} title="Change diagnosis">${ICON_PENCIL} Change</button>
         `}
         ${/* Reclassify a non-diagnosis A&P item (e.g. "Physical therapy access") as a
-            plan narrative — preserves the content without forcing an ICD-10 code. */ ''}
-        ${!readOnly && onMoveToPlan && html`
+            plan narrative — preserves the content without forcing an ICD-10 code. Only
+            offered while the card is UNCODED; once a diagnosis is assigned it's a real
+            diagnosis, so the affordance is hidden. */ ''}
+        ${!hasCode && !readOnly && onMoveToPlan && html`
           <button type="button" class="diagnose-change-btn" onClick=${() => onMoveToPlan(commandIndex)} title="Not a diagnosis — move this to the plan">${ICON_MOVE} Move to plan</button>
         `}
       </div>

--- a/hyperscribe/scribe/static/diagnose-row.js
+++ b/hyperscribe/scribe/static/diagnose-row.js
@@ -360,10 +360,7 @@ export function DiagnoseRow({ command, commandIndex, onEdit, onMoveToPlan, readO
             </div>
           `}
           ${!showAllRecs && (recCodes.length > MAX_VISIBLE_RECS || onMoveToPlan) && html`
-            <button type="button" class="diagnose-picker-more" onMouseDown=${(e) => { e.preventDefault(); setShowAllRecs(true); }}>See more</button>
-          `}
-          ${showAllRecs && recCodes.length > MAX_VISIBLE_RECS && html`
-            <button type="button" class="diagnose-picker-more" onMouseDown=${(e) => { e.preventDefault(); setShowAllRecs(false); }}>See less</button>
+            <button type="button" class="diagnose-picker-more" onMouseDown=${(e) => { e.preventDefault(); setShowAllRecs(true); }}>More options</button>
           `}
           ${/* Move this card's content to the Wrap Up section (for A&P items that aren't a
               codeable diagnosis) — revealed under "See more". Self-arming: first click swaps

--- a/hyperscribe/scribe/static/diagnose-row.js
+++ b/hyperscribe/scribe/static/diagnose-row.js
@@ -363,7 +363,7 @@ export function DiagnoseRow({ command, commandIndex, onEdit, onMoveToPlan, readO
             class="diagnose-picker-action"
             title="Moves this card's free-text content out of the diagnosis list into the wrap up section. Use when the item isn't a codeable diagnosis (e.g. a plan or administrative note)."
             onMouseDown=${(e) => { e.preventDefault(); onMoveToPlan(commandIndex); }}
-          >${ICON_MOVE} Move free text content to wrap up section</button>
+          >${ICON_MOVE} Move content to free text wrap up section below</button>
         `
         : html`
           <button

--- a/hyperscribe/scribe/static/diagnose-row.js
+++ b/hyperscribe/scribe/static/diagnose-row.js
@@ -359,9 +359,9 @@ export function DiagnoseRow({ command, commandIndex, onEdit, onMoveToPlan, readO
           <button
             type="button"
             class="diagnose-picker-action"
-            title="Moves this card's free-text content out of the diagnosis list into the Wrap Up section. Use when the item isn't a codeable diagnosis (e.g. a plan or administrative note)."
+            title="Moves this card's free-text content out of the diagnosis list into the wrap up section. Use when the item isn't a codeable diagnosis (e.g. a plan or administrative note)."
             onMouseDown=${(e) => { e.preventDefault(); onMoveToPlan(commandIndex); }}
-          >${ICON_MOVE} Move free text content to Wrap Up section</button>
+          >${ICON_MOVE} Move free text content to wrap up section</button>
         `
         : html`
           <button

--- a/hyperscribe/scribe/static/diagnose-row.js
+++ b/hyperscribe/scribe/static/diagnose-row.js
@@ -334,6 +334,7 @@ export function DiagnoseRow({ command, commandIndex, onEdit, readOnly, suggestio
                 onMouseDown=${(e) => { e.preventDefault(); handleSelect({ code: s.code, display: s.display, formatted_code: s.formatted_code }); }}
               >
                 <span class="diagnose-picker-name">${s.display}</span>
+                ${s.provenance ? html`<span class="diagnose-picker-prov">${s.provenance}</span>` : ''}
                 <span class="diagnose-picker-code">${s.formatted_code}</span>
               </div>
             `)}
@@ -355,12 +356,22 @@ export function DiagnoseRow({ command, commandIndex, onEdit, readOnly, suggestio
         ${hasCode && !readOnly && html`
           <button type="button" class="diagnose-change-btn" onClick=${handleClearCode} title="Change diagnosis">${ICON_PENCIL} Change</button>
         `}
+        ${/* Unspecified nudge — the working code stays applied; clicking opens the
+            Change picker, pre-loaded with grounded more-specific siblings. */ ''}
+        ${hasCode && !readOnly && data.unspecified && html`
+          <button type="button" class="diagnose-unspecified-nudge" onClick=${handleClearCode} title="This code is unspecified — pick a more specific one">Unspecified — refine</button>
+        `}
       </div>
 
       ${/* "Change diagnosis" picker (already-coded card). */ ''}
       ${hasCode && editingCode && !readOnly && pickerPanel('Search for a different code…', handleCloseChange)}
 
-      ${/* No-diagnosis-code state: the integrated picker is the persistent UI. */ ''}
+      ${/* No-diagnosis-code state: the integrated picker is the persistent UI. When
+          the ranker left this block intentionally uncoded (ambiguous), it sent
+          ranked options — tell the provider it's theirs to choose. */ ''}
+      ${!hasCode && !readOnly && recCodes.length > 0 && html`
+        <div class="diagnose-ambiguity-hint">Multiple possible codes — select one</div>
+      `}
       ${!hasCode && !readOnly && pickerPanel('Search a diagnosis code, or pick a recommendation below…')}
 
       ${!editingText && html`

--- a/hyperscribe/scribe/static/diagnose-row.js
+++ b/hyperscribe/scribe/static/diagnose-row.js
@@ -25,7 +25,7 @@ function formatIcdCode(raw) {
   return code.length > 3 ? code.slice(0, 3) + '.' + code.slice(3) : code;
 }
 
-export function DiagnoseRow({ command, commandIndex, onEdit, readOnly, suggestions, onEditingChange }) {
+export function DiagnoseRow({ command, commandIndex, onEdit, onMoveToPlan, readOnly, suggestions, onEditingChange }) {
   const data = command.data || {};
   const hasCode = !!data.icd10_code;
   // KOALA_5635_BACKGROUND_ALWAYS_RENDER — Background is available on EVERY
@@ -355,6 +355,11 @@ export function DiagnoseRow({ command, commandIndex, onEdit, readOnly, suggestio
         ${hasCode && html`<span class="diagnose-icd-code">${formattedCode}</span>`}
         ${hasCode && !readOnly && html`
           <button type="button" class="diagnose-change-btn" onClick=${handleClearCode} title="Change diagnosis">${ICON_PENCIL} Change</button>
+        `}
+        ${/* Reclassify a non-diagnosis A&P item (e.g. "Physical therapy access") as a
+            plan narrative — preserves the content without forcing an ICD-10 code. */ ''}
+        ${!readOnly && onMoveToPlan && html`
+          <button type="button" class="diagnose-change-btn" onClick=${() => onMoveToPlan(commandIndex)} title="Not a diagnosis — move this to the plan">Move to plan</button>
         `}
       </div>
 

--- a/hyperscribe/scribe/static/diagnose-row.js
+++ b/hyperscribe/scribe/static/diagnose-row.js
@@ -7,6 +7,7 @@ const html = htm.bind(h);
 const ICON_PENCIL = html`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 20h9"/><path d="M16.5 3.5a2.1 2.1 0 0 1 3 3L7 19l-4 1 1-4Z"/></svg>`;
 const ICON_SEARCH = html`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="7"/><line x1="20" y1="20" x2="16.65" y2="16.65"/></svg>`;
 const ICON_X = html`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="6" y1="6" x2="18" y2="18"/><line x1="6" y1="18" x2="18" y2="6"/></svg>`;
+const ICON_MOVE = html`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg>`;
 
 const API_BASE = '/plugin-io/api/hyperscribe/scribe-session';
 const DEBOUNCE_MS = 300;
@@ -359,7 +360,7 @@ export function DiagnoseRow({ command, commandIndex, onEdit, onMoveToPlan, readO
         ${/* Reclassify a non-diagnosis A&P item (e.g. "Physical therapy access") as a
             plan narrative — preserves the content without forcing an ICD-10 code. */ ''}
         ${!readOnly && onMoveToPlan && html`
-          <button type="button" class="diagnose-change-btn" onClick=${() => onMoveToPlan(commandIndex)} title="Not a diagnosis — move this to the plan">Move to plan</button>
+          <button type="button" class="diagnose-change-btn" onClick=${() => onMoveToPlan(commandIndex)} title="Not a diagnosis — move this to the plan">${ICON_MOVE} Move to plan</button>
         `}
       </div>
 

--- a/hyperscribe/scribe/static/diagnose-row.js
+++ b/hyperscribe/scribe/static/diagnose-row.js
@@ -7,6 +7,9 @@ const html = htm.bind(h);
 const ICON_PENCIL = html`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 20h9"/><path d="M16.5 3.5a2.1 2.1 0 0 1 3 3L7 19l-4 1 1-4Z"/></svg>`;
 const ICON_SEARCH = html`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="7"/><line x1="20" y1="20" x2="16.65" y2="16.65"/></svg>`;
 const ICON_X = html`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="6" y1="6" x2="18" y2="18"/><line x1="6" y1="18" x2="18" y2="6"/></svg>`;
+// Vertical ⋮ for the search-bar overflow menu, and a "move to a list/section" glyph for its item.
+const ICON_DOTS = html`<svg viewBox="0 0 24 24" fill="currentColor"><circle cx="12" cy="5" r="1.6"/><circle cx="12" cy="12" r="1.6"/><circle cx="12" cy="19" r="1.6"/></svg>`;
+const ICON_MOVE = html`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 7h11"/><path d="M4 12h11"/><path d="M4 17h7"/><path d="M15 15l4 2-4 2"/></svg>`;
 // How many recommendations the picker shows before the "See more" toggle.
 const MAX_VISIBLE_RECS = 4;
 
@@ -75,11 +78,12 @@ export function DiagnoseRow({ command, commandIndex, onEdit, onMoveToPlan, readO
   const [results, setResults] = useState([]);
   const [searching, setSearching] = useState(false);
   const [searched, setSearched] = useState(false);
-  // Progressive disclosure for the "not a diagnosis" escape hatch: the picker shows a
-  // quiet "Not a diagnosis?" trigger; clicking it reveals the "Move to Wrap Up" action.
-  const [showMoveOption, setShowMoveOption] = useState(false);
-  // The recommendations list shows the top few; "See more" reveals the rest AND the
-  // move-to-wrap-up action. Reset (collapsed) whenever the picker is opened/closed.
+  // "Move to Wrap Up" lives in a small ⋮ menu pinned to the right of the picker's
+  // search bar (for A&P items that aren't a codeable diagnosis). Open/close state;
+  // reset whenever the picker is opened/closed.
+  const [showMenu, setShowMenu] = useState(false);
+  // The recommendations list shows the top few; "More options" reveals the rest.
+  // Reset (collapsed) whenever the picker is opened/closed.
   const [showAllRecs, setShowAllRecs] = useState(false);
   const [assessment, setAssessment] = useState(data.today_assessment || '');
   // KOALA_5635_BACKGROUND_TEXTAREA — local state mirrors AssessNarrative's
@@ -91,6 +95,7 @@ export function DiagnoseRow({ command, commandIndex, onEdit, onMoveToPlan, readO
   // preexisting background; the "+ Add background" pill flips it on otherwise.
   const [showBackground, setShowBackground] = useState((data.background || '').length > 0);
   const inputRef = useRef(null);
+  const menuRef = useRef(null);
   const containerRef = useRef(null);
   const textareaRef = useRef(null);
   const backgroundRef = useRef(null);
@@ -148,6 +153,16 @@ export function DiagnoseRow({ command, commandIndex, onEdit, onMoveToPlan, readO
     document.addEventListener('mousedown', handler);
     return () => document.removeEventListener('mousedown', handler);
   }, [editingCode, hasCode]);
+
+  // Close the ⋮ "Move to Wrap Up" menu on any click outside it.
+  useEffect(() => {
+    if (!showMenu) return;
+    const handler = (e) => {
+      if (menuRef.current && !menuRef.current.contains(e.target)) setShowMenu(false);
+    };
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, [showMenu]);
 
   const doSearch = useCallback(async (q) => {
     if (!q || q.length < 2) {
@@ -232,7 +247,7 @@ export function DiagnoseRow({ command, commandIndex, onEdit, onMoveToPlan, readO
     setResults([]);
     setSearched(false);
     setSearching(false);
-    setShowMoveOption(false); // reopen the picker collapsed to "Not a diagnosis?"
+    setShowMenu(false); // reopen with the ⋮ menu closed
     setShowAllRecs(false); // reopen showing only the top recommendations
   };
 
@@ -244,7 +259,7 @@ export function DiagnoseRow({ command, commandIndex, onEdit, onMoveToPlan, readO
     setResults([]);
     setSearched(false);
     setSearching(false);
-    setShowMoveOption(false); // collapse the "Not a diagnosis?" disclosure on close
+    setShowMenu(false); // close the ⋮ menu on close
     setShowAllRecs(false); // collapse the recommendations back to the top few
   };
 
@@ -317,9 +332,43 @@ export function DiagnoseRow({ command, commandIndex, onEdit, onMoveToPlan, readO
           onInput=${handleInput}
           onKeyDown=${handleKeyDown}
           placeholder=${placeholder}
+          aria-label="Search diagnosis codes"
         />
+        ${/* ⋮ menu — the escape hatch for A&P items that aren't a codeable diagnosis.
+            Pinned to the right of the search bar so it stays out of the code list and
+            the Reject/Accept buttons. Only offered when the card can be moved. */ ''}
+        ${onMoveToPlan && html`
+          <div class="diagnose-picker-menu" ref=${menuRef}>
+            <button
+              type="button"
+              class="diagnose-picker-menu-btn"
+              title="More actions"
+              aria-label="More actions"
+              aria-haspopup="true"
+              aria-expanded=${showMenu ? 'true' : 'false'}
+              onClick=${(e) => { e.stopPropagation(); setShowMenu(v => !v); }}
+            >${ICON_DOTS}</button>
+            ${showMenu && html`
+              <div class="diagnose-picker-menu-pop" role="menu">
+                <button
+                  type="button"
+                  role="menuitem"
+                  class="diagnose-picker-menu-item"
+                  onMouseDown=${(e) => { e.preventDefault(); setShowMenu(false); onMoveToPlan(commandIndex); }}
+                >
+                  ${ICON_MOVE}
+                  <span>
+                    <span class="dpm-title">Move to Wrap Up</span>
+                    <span class="dpm-help">Not a codeable diagnosis — moves this card's free-text content to the Wrap Up section.</span>
+                  </span>
+                </button>
+              </div>
+            `}
+          </div>
+        `}
         ${onClose && html`<button type="button" class="diagnose-picker-close" onClick=${onClose} title="Close" aria-label="Close search">${ICON_X}</button>`}
       </div>
+      <div class="diagnose-picker-body">
       ${query.length >= 2
         ? (results.length > 0
           ? html`
@@ -342,8 +391,8 @@ export function DiagnoseRow({ command, commandIndex, onEdit, onMoveToPlan, readO
           ? html`<div class="diagnose-picker-empty">No diagnoses found</div>`
           : null)
         : html`
-          ${/* Recommendations (empty query): show the top few, best first. "See more"
-              reveals the rest AND the "move to wrap up" action beneath them. */ ''}
+          ${/* Recommendations (empty query): show the top few, best first. "More options"
+              reveals the rest. The move-to-wrap-up action lives in the ⋮ menu above. */ ''}
           ${recCodes.length > 0 && html`
             <div class="diagnose-picker-list">
               ${(showAllRecs ? recCodes : recCodes.slice(0, MAX_VISIBLE_RECS)).map(s => html`
@@ -359,24 +408,11 @@ export function DiagnoseRow({ command, commandIndex, onEdit, onMoveToPlan, readO
               `)}
             </div>
           `}
-          ${!showAllRecs && (recCodes.length > MAX_VISIBLE_RECS || onMoveToPlan) && html`
+          ${!showAllRecs && recCodes.length > MAX_VISIBLE_RECS && html`
             <button type="button" class="diagnose-picker-more" onMouseDown=${(e) => { e.preventDefault(); setShowAllRecs(true); }}>More options</button>
           `}
-          ${/* Move this card's content to the Wrap Up section (for A&P items that aren't a
-              codeable diagnosis) — revealed under "See more". Self-arming: first click swaps
-              the label to "Confirm", second click performs the move. onMouseDown+preventDefault
-              so the search input's blur doesn't eat the click. */ ''}
-          ${showAllRecs && onMoveToPlan && html`
-            <button
-              type="button"
-              class="diagnose-picker-disclose"
-              title=${showMoveOption
-                ? 'Click again to confirm — moves this content to the wrap up section'
-                : "Move this card's free-text content to the wrap up section — use when the item isn't a codeable diagnosis."}
-              onMouseDown=${(e) => { e.preventDefault(); showMoveOption ? onMoveToPlan(commandIndex) : setShowMoveOption(true); }}
-            >${showMoveOption ? 'Confirm' : 'Move to the wrap up section'}</button>
-          `}
         `}
+      </div>
     </div>
   `;
 
@@ -385,20 +421,24 @@ export function DiagnoseRow({ command, commandIndex, onEdit, onMoveToPlan, readO
       <div class="diagnose-row-header">
         <span class="diagnose-row-title">${titleText}</span>
         ${hasCode && html`<span class="diagnose-icd-code">${formattedCode}</span>`}
+        ${/* Uncoded card: the amber "needs-a-pick" badge lives next to the title
+            (not down in the Reject/Accept action column), so the missing-code
+            signal reads right where the diagnosis name is. */ ''}
+        ${!hasCode && !readOnly && html`<span class="rec-warning-pill">Missing: Diagnosis Code</span>`}
         ${hasCode && !readOnly && html`
           <button type="button" class="diagnose-change-btn" onClick=${handleClearCode} title="Change diagnosis">${ICON_PENCIL} Change</button>
         `}
       </div>
 
       ${/* "Change diagnosis" picker (already-coded card). */ ''}
-      ${hasCode && editingCode && !readOnly && pickerPanel('Search for a different code…', handleCloseChange)}
+      ${hasCode && editingCode && !readOnly && pickerPanel('Search diagnosis codes', handleCloseChange)}
 
       ${/* No-diagnosis-code state: the integrated picker is the persistent UI. The
           ranker leaves a block uncoded when codes conflict or an unspecified code
           has more-specific options; the picker's ranked recommendations (with
           provenance) are the provider's pick list. The "Missing: Diagnosis Code"
           action pill is the sole needs-a-pick signal — no separate hint. */ ''}
-      ${!hasCode && !readOnly && pickerPanel('Search a diagnosis code, or pick a recommendation below…')}
+      ${!hasCode && !readOnly && pickerPanel('Search diagnosis codes')}
 
       ${!editingText && html`
         <div

--- a/hyperscribe/scribe/static/diagnose-row.js
+++ b/hyperscribe/scribe/static/diagnose-row.js
@@ -334,8 +334,8 @@ export function DiagnoseRow({ command, commandIndex, onEdit, readOnly, suggestio
                 onMouseDown=${(e) => { e.preventDefault(); handleSelect({ code: s.code, display: s.display, formatted_code: s.formatted_code }); }}
               >
                 <span class="diagnose-picker-name">${s.display}</span>
-                ${s.provenance ? html`<span class="diagnose-picker-prov">${s.provenance}</span>` : ''}
                 <span class="diagnose-picker-code">${s.formatted_code}</span>
+                ${s.provenance ? html`<span class="diagnose-picker-prov">${s.provenance}</span>` : ''}
               </div>
             `)}
           </div>
@@ -356,22 +356,16 @@ export function DiagnoseRow({ command, commandIndex, onEdit, readOnly, suggestio
         ${hasCode && !readOnly && html`
           <button type="button" class="diagnose-change-btn" onClick=${handleClearCode} title="Change diagnosis">${ICON_PENCIL} Change</button>
         `}
-        ${/* Unspecified nudge — the working code stays applied; clicking opens the
-            Change picker, pre-loaded with grounded more-specific siblings. */ ''}
-        ${hasCode && !readOnly && data.unspecified && html`
-          <button type="button" class="diagnose-unspecified-nudge" onClick=${handleClearCode} title="This code is unspecified — pick a more specific one">Unspecified — refine</button>
-        `}
       </div>
 
       ${/* "Change diagnosis" picker (already-coded card). */ ''}
       ${hasCode && editingCode && !readOnly && pickerPanel('Search for a different code…', handleCloseChange)}
 
-      ${/* No-diagnosis-code state: the integrated picker is the persistent UI. When
-          the ranker left this block intentionally uncoded (ambiguous), it sent
-          ranked options — tell the provider it's theirs to choose. */ ''}
-      ${!hasCode && !readOnly && recCodes.length > 0 && html`
-        <div class="diagnose-ambiguity-hint">Multiple possible codes — select one</div>
-      `}
+      ${/* No-diagnosis-code state: the integrated picker is the persistent UI. The
+          ranker leaves a block uncoded when codes conflict or an unspecified code
+          has more-specific options; the picker's ranked recommendations (with
+          provenance) are the provider's pick list. The "Missing: Diagnosis Code"
+          action pill is the sole needs-a-pick signal — no separate hint. */ ''}
       ${!hasCode && !readOnly && pickerPanel('Search a diagnosis code, or pick a recommendation below…')}
 
       ${!editingText && html`

--- a/hyperscribe/scribe/static/diagnose-row.js
+++ b/hyperscribe/scribe/static/diagnose-row.js
@@ -7,9 +7,6 @@ const html = htm.bind(h);
 const ICON_PENCIL = html`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 20h9"/><path d="M16.5 3.5a2.1 2.1 0 0 1 3 3L7 19l-4 1 1-4Z"/></svg>`;
 const ICON_SEARCH = html`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="7"/><line x1="20" y1="20" x2="16.65" y2="16.65"/></svg>`;
 const ICON_X = html`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="6" y1="6" x2="18" y2="18"/><line x1="6" y1="18" x2="18" y2="6"/></svg>`;
-const ICON_MOVE = html`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg>`;
-const ICON_TAG = html`<svg class="nd-lead" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20.59 13.41 13.42 20.6a2 2 0 0 1-2.83 0L3 13V3h10l7.59 7.59a2 2 0 0 1 0 2.82z"/><line x1="7" y1="7" x2="7.01" y2="7"/></svg>`;
-const ICON_CHEVRON = html`<svg class="nd-chev" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 18 15 12 9 6"/></svg>`;
 
 const API_BASE = '/plugin-io/api/hyperscribe/scribe-session';
 const DEBOUNCE_MS = 300;
@@ -352,25 +349,29 @@ export function DiagnoseRow({ command, commandIndex, onEdit, onMoveToPlan, readO
         : (searched && query.length >= 2)
         ? html`<div class="diagnose-picker-empty">No diagnoses found</div>`
         : null}
-      ${/* Not a diagnosis? Reclassify the card as a plan narrative in Wrap Up. Lives in
-          the picker (available both for an uncoded card and when changing a code) behind a
-          quiet "Not a diagnosis?" trigger that reveals the "Move to Wrap Up" action.
-          onMouseDown+preventDefault so the search input's blur doesn't eat the click. */ ''}
+      ${/* Move this card's content to the Wrap Up section (for A&P items that aren't a
+          codeable diagnosis). Lives in the picker — available on an uncoded card and when
+          changing a code — as a two-click inline confirm: the "Move to the wrap up section"
+          trigger arms an inline Cancel/Confirm carrying the SAME label. onMouseDown+
+          preventDefault so the search input's blur doesn't eat the click; showMoveOption
+          resets on picker open/close so it always reopens disarmed. */ ''}
       ${onMoveToPlan && (showMoveOption
         ? html`
-          <button
-            type="button"
-            class="diagnose-picker-action"
-            title="Moves this card's free-text content out of the diagnosis list into the wrap up section. Use when the item isn't a codeable diagnosis (e.g. a plan or administrative note)."
-            onMouseDown=${(e) => { e.preventDefault(); onMoveToPlan(commandIndex); }}
-          >${ICON_MOVE} Move content to free text wrap up section below</button>
+          <div class="diagnose-move-confirm">
+            <span class="diagnose-move-label">Move to the wrap up section</span>
+            <span class="diagnose-move-actions">
+              <button type="button" class="diagnose-move-cancel" onMouseDown=${(e) => { e.preventDefault(); setShowMoveOption(false); }}>Cancel</button>
+              <button type="button" class="diagnose-move-confirm-btn" onMouseDown=${(e) => { e.preventDefault(); onMoveToPlan(commandIndex); }}>Confirm</button>
+            </span>
+          </div>
         `
         : html`
           <button
             type="button"
             class="diagnose-picker-disclose"
+            title="Move this card's free-text content to the wrap up section — use when the item isn't a codeable diagnosis."
             onMouseDown=${(e) => { e.preventDefault(); setShowMoveOption(true); }}
-          >${ICON_TAG}Not a diagnosis?${ICON_CHEVRON}</button>
+          >Move to the wrap up section</button>
         `)}
     </div>
   `;

--- a/hyperscribe/scribe/static/diagnose-row.js
+++ b/hyperscribe/scribe/static/diagnose-row.js
@@ -345,6 +345,17 @@ export function DiagnoseRow({ command, commandIndex, onEdit, onMoveToPlan, readO
         : (searched && query.length >= 2)
         ? html`<div class="diagnose-picker-empty">No diagnoses found</div>`
         : null}
+      ${/* Not a diagnosis? Reclassify the card as a plan narrative in Wrap Up. Lives in
+          the picker so it's available both for an uncoded card and when changing a code.
+          onMouseDown+preventDefault so the search input's blur doesn't eat the click. */ ''}
+      ${onMoveToPlan && html`
+        <button
+          type="button"
+          class="diagnose-picker-action"
+          title="Not a diagnosis — move this to Wrap Up"
+          onMouseDown=${(e) => { e.preventDefault(); onMoveToPlan(commandIndex); }}
+        >${ICON_MOVE} Move to plan</button>
+      `}
     </div>
   `;
 
@@ -355,13 +366,6 @@ export function DiagnoseRow({ command, commandIndex, onEdit, onMoveToPlan, readO
         ${hasCode && html`<span class="diagnose-icd-code">${formattedCode}</span>`}
         ${hasCode && !readOnly && html`
           <button type="button" class="diagnose-change-btn" onClick=${handleClearCode} title="Change diagnosis">${ICON_PENCIL} Change</button>
-        `}
-        ${/* Reclassify a non-diagnosis A&P item (e.g. "Physical therapy access") as a
-            plan narrative — preserves the content without forcing an ICD-10 code. Only
-            offered while the card is UNCODED; once a diagnosis is assigned it's a real
-            diagnosis, so the affordance is hidden. */ ''}
-        ${!hasCode && !readOnly && onMoveToPlan && html`
-          <button type="button" class="diagnose-change-btn" onClick=${() => onMoveToPlan(commandIndex)} title="Not a diagnosis — move this to the plan">${ICON_MOVE} Move to plan</button>
         `}
       </div>
 

--- a/hyperscribe/scribe/static/diagnose-row.js
+++ b/hyperscribe/scribe/static/diagnose-row.js
@@ -354,7 +354,13 @@ export function DiagnoseRow({ command, commandIndex, onEdit, onMoveToPlan, readO
           class="diagnose-picker-action"
           title="Not a diagnosis — move this to Wrap Up"
           onMouseDown=${(e) => { e.preventDefault(); onMoveToPlan(commandIndex); }}
-        >${ICON_MOVE} Move to plan</button>
+        >
+          ${ICON_MOVE}
+          <span class="diagnose-picker-action-text">
+            <span class="diagnose-picker-action-title">Move to Wrap Up</span>
+            <span class="diagnose-picker-action-sub">Not a diagnosis</span>
+          </span>
+        </button>
       `}
     </div>
   `;

--- a/hyperscribe/scribe/static/soap-group.js
+++ b/hyperscribe/scribe/static/soap-group.js
@@ -398,6 +398,7 @@ const DEBOUNCE_MS = 300;
 const ICON_X = html`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><line x1="6" y1="6" x2="18" y2="18"/><line x1="6" y1="18" x2="18" y2="6"/></svg>`;
 const ICON_CHECK = html`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="4 12 10 18 20 6"/></svg>`;
 const ICON_LOCK = html`<svg class="command-row-icon-lock" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="3" y="11" width="18" height="11" rx="2" ry="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg>`;
+const ICON_PENCIL = html`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 20h9"/><path d="M16.5 3.5a2.1 2.1 0 0 1 3 3L7 19l-4 1 1-4Z"/></svg>`;
 
 // Standalone delete-X action button used by most row render branches. Suppressed
 // in readOnly mode and for any command that's already in the chart (e.g. synced
@@ -841,6 +842,19 @@ export function SoapGroup({ title, groupColor, sections, commandBySectionKey, on
                             <div class="diagnose-row-header">
                               <span class="diagnose-row-title">${entry.command.display}</span>
                               ${aFormatted ? html`<span class="diagnose-icd-code">${aFormatted}</span>` : ''}
+                              ${/* Change on an assess (existing-condition) card: re-pick the ICD-10
+                                  code. A different code means a different condition, so convert to a
+                                  fresh uncoded diagnose (drops condition_id → no false assess against
+                                  the chart problem) and open the picker. handleEdit's diagnose branch
+                                  replaces data wholesale, so omitting condition_id here removes it. */ ''}
+                              ${!assessRowReadOnly && html`
+                                <button
+                                  type="button"
+                                  class="diagnose-change-btn"
+                                  title="Change diagnosis"
+                                  onClick=${() => onEditCommand(entry.index, { icd10_code: null, icd10_display: '', condition_header: entry.command.display || '', today_assessment: aData.narrative || '', background: aData.background || null }, 'diagnose')}
+                                >${ICON_PENCIL} Change</button>
+                              `}
                             </div>
                             <${AssessNarrative}
                               command=${entry.command}

--- a/hyperscribe/scribe/static/soap-group.js
+++ b/hyperscribe/scribe/static/soap-group.js
@@ -714,7 +714,7 @@ function AddConditionSearch({ onAdd, patientId }) {
   `;
 }
 
-export function SoapGroup({ title, groupColor, sections, commandBySectionKey, onEditCommand, onDeleteCommand, adHocCommands, assignees, onAddTask, onAddOrder, onAddPlan, onAddVitals, onAddPhysicalExam, onAddMentalStatusExam, onAddMedication, onAddAllergy, onAddStopMedication, onAddRemoveAllergy, onAddResolveCondition, onAddHistory, onAddQuestionnaire, onAddCharge, readOnly, isAmending = false, sectionConditions, patientId, noteId, staffId, staffName, recommendations, onEditRecommendation, onDeleteRecommendation, onAcceptRecommendation, onRejectRecommendation, onAddCondition, unmatchedConditions, diagnosisSuggestions, noteDiagnoses = [], onAddNow, hideRejected, alertFacilityEnabled, onEditingChange, questionnaireScores, chargeMatrixDiagnoses = [], chargeMatrixCharges = [], searchCharges = () => {}, suggestedCharges = [], onToggleChargePointer = () => {}, onReorderDiagnoses = () => {}, onAddChargeModifier = () => {}, onRemoveChargeModifier = () => {}, onSetChargeComment = () => {}, onClearChargeComment = () => {}, onRemoveChargeByUuid = () => {}, examTemplates, onCarryForwardExam, isPsychiatry = false }) {
+export function SoapGroup({ title, groupColor, sections, commandBySectionKey, onEditCommand, onDeleteCommand, adHocCommands, assignees, onAddTask, onAddOrder, onAddPlan, onMoveToPlan, onAddVitals, onAddPhysicalExam, onAddMentalStatusExam, onAddMedication, onAddAllergy, onAddStopMedication, onAddRemoveAllergy, onAddResolveCondition, onAddHistory, onAddQuestionnaire, onAddCharge, readOnly, isAmending = false, sectionConditions, patientId, noteId, staffId, staffName, recommendations, onEditRecommendation, onDeleteRecommendation, onAcceptRecommendation, onRejectRecommendation, onAddCondition, unmatchedConditions, diagnosisSuggestions, noteDiagnoses = [], onAddNow, hideRejected, alertFacilityEnabled, onEditingChange, questionnaireScores, chargeMatrixDiagnoses = [], chargeMatrixCharges = [], searchCharges = () => {}, suggestedCharges = [], onToggleChargePointer = () => {}, onReorderDiagnoses = () => {}, onAddChargeModifier = () => {}, onRemoveChargeModifier = () => {}, onSetChargeComment = () => {}, onClearChargeComment = () => {}, onRemoveChargeByUuid = () => {}, examTemplates, onCarryForwardExam, isPsychiatry = false }) {
   const isCharges = title === 'CHARGES';
   const coveredKeys = getCoveredKeys(commandBySectionKey);
 
@@ -857,6 +857,7 @@ export function SoapGroup({ title, groupColor, sections, commandBySectionKey, on
                             command=${entry.command}
                             commandIndex=${entry.index}
                             onEdit=${onEditCommand}
+                            onMoveToPlan=${diagnoseRowReadOnly || isRejected ? null : onMoveToPlan}
                             readOnly=${diagnoseRowReadOnly || isRejected}
                             suggestions=${suggestions}
                             onEditingChange=${onEditingChange}
@@ -872,6 +873,25 @@ export function SoapGroup({ title, groupColor, sections, commandBySectionKey, on
                           ${(dxData.today_assessment || '').length > 2048 && html`<span class="rec-warning-pill">Assessment too long</span>`}
                           ${renderRecActions({ command: entry.command, index: entry.index, isAccepted, isRejected, incomplete: isIncomplete, missingLabel: 'Diagnosis Code', acceptDisabled: isIncomplete, readOnly, onAccept: handleAcceptDiagnose, onReject: handleRejectDiagnose, onAddNow: null })}
                         </div>
+                      </div>
+                    `;
+                  })}
+                  ${/* Plan narratives living in the A&P split view — including diagnosis
+                      cards the provider reclassified via "Move to plan". Rendered as a
+                      plain narrative (no ICD-10 code), with a Remove action. */ ''}
+                  ${cmds.filter(e => e.command.command_type === 'plan' && (!readOnly || wasInserted(e.command))).map(entry => {
+                    const planRowReadOnly = rowLocked(entry.command, readOnly, isAmending);
+                    return html`
+                      <div class=${`content-block rec-narrative${planRowReadOnly && entry.command.already_documented ? ' command-locked' : ''}`} key=${entry.index}>
+                        ${planRowReadOnly && entry.command.already_documented && ICON_LOCK}
+                        <${CommandRow}
+                          command=${entry.command}
+                          commandIndex=${entry.index}
+                          onEdit=${onEditCommand}
+                          readOnly=${planRowReadOnly}
+                          onEditingChange=${onEditingChange}
+                        />
+                        ${!readOnly && !entry.command.already_documented && !entry.command._adding && html`<div class="recommendation-actions"><button type="button" class="rec-remove-x" onClick=${() => onDeleteCommand(entry.index)} title="Remove">${ICON_X}</button></div>`}
                       </div>
                     `;
                   })}

--- a/hyperscribe/scribe/static/soap-group.js
+++ b/hyperscribe/scribe/static/soap-group.js
@@ -783,20 +783,25 @@ export function SoapGroup({ title, groupColor, sections, commandBySectionKey, on
             if (readOnly && apptCmds.length === 0) return null;
             return html`
               <div class="subsection" key=${s.key}>
-                <div class="subsection-title">${s.title}</div>
+                <div class="subsection-title">Wrap Up</div>
                 ${apptCmds.map(entry => {
                   const apptRowReadOnly = rowLocked(entry.command, readOnly, isAmending);
+                  const showRemove = !readOnly && !entry.command.already_documented && !entry.command._adding;
+                  // recommendation-block flex → content left, remove-X pinned upper-right,
+                  // matching every other card.
                   return html`
-                    <div class=${`content-block rec-narrative${apptRowReadOnly && entry.command.already_documented ? ' command-locked' : ''}`} key=${entry.index}>
+                    <div class=${`content-block recommendation-block rec-narrative${apptRowReadOnly && entry.command.already_documented ? ' command-locked' : ''}`} key=${entry.index}>
                       ${apptRowReadOnly && entry.command.already_documented && ICON_LOCK}
-                      <${CommandRow}
-                        command=${entry.command}
-                        commandIndex=${entry.index}
-                        onEdit=${onEditCommand}
-                        readOnly=${apptRowReadOnly}
-                        onEditingChange=${onEditingChange}
-                      />
-                      ${!readOnly && !entry.command.already_documented && !entry.command._adding && html`<div class="recommendation-actions"><button type="button" class="rec-remove-x" onClick=${() => onDeleteCommand(entry.index)} title="Remove">${ICON_X}</button></div>`}
+                      <div class="recommendation-content">
+                        <${CommandRow}
+                          command=${entry.command}
+                          commandIndex=${entry.index}
+                          onEdit=${onEditCommand}
+                          readOnly=${apptRowReadOnly}
+                          onEditingChange=${onEditingChange}
+                        />
+                      </div>
+                      ${showRemove && html`<div class="recommendation-actions"><button type="button" class="rec-remove-x" onClick=${() => onDeleteCommand(entry.index)} title="Remove">${ICON_X}</button></div>`}
                     </div>
                   `;
                 })}

--- a/hyperscribe/scribe/static/soap-group.js
+++ b/hyperscribe/scribe/static/soap-group.js
@@ -948,7 +948,11 @@ export function SoapGroup({ title, groupColor, sections, commandBySectionKey, on
                         <div class="recommendation-actions">
                           ${(dxData.background || '').length > 2048 && html`<span class="rec-warning-pill">Background too long</span>`}
                           ${(dxData.today_assessment || '').length > 2048 && html`<span class="rec-warning-pill">Assessment too long</span>`}
-                          ${renderRecActions({ command: entry.command, index: entry.index, isAccepted, isRejected, incomplete: isIncomplete, missingLabel: 'Diagnosis Code', acceptDisabled: isIncomplete, readOnly, onAccept: handleAcceptDiagnose, onReject: handleRejectDiagnose, onAddNow: null })}
+                          ${/* incomplete:false → the "Missing: Diagnosis Code" pill is
+                            rendered in the DiagnoseRow header (next to the title) instead
+                            of here in the action column. acceptDisabled still keys off
+                            isIncomplete so Accept stays disabled until a code is picked. */ ''}
+                        ${renderRecActions({ command: entry.command, index: entry.index, isAccepted, isRejected, incomplete: false, missingLabel: 'Diagnosis Code', acceptDisabled: isIncomplete, readOnly, onAccept: handleAcceptDiagnose, onReject: handleRejectDiagnose, onAddNow: null })}
                         </div>
                       </div>
                     `;

--- a/hyperscribe/scribe/static/soap-group.js
+++ b/hyperscribe/scribe/static/soap-group.js
@@ -838,13 +838,12 @@ export function SoapGroup({ title, groupColor, sections, commandBySectionKey, on
                     // diagnosisSuggestions map. (Header-string keying was fragile and
                     // is gone.)
                     const blockId = dxData.block_id || '';
-                    // Uncoded card: ranked grounded options to pick from. Coded-but-
-                    // unspecified card: the more-specific children for the refine nudge.
-                    const suggestions = (!isRejected && (
-                      (!hasCode && (dxData.candidate_suggestions
-                        || (diagnosisSuggestions && blockId && diagnosisSuggestions[blockId])))
-                      || (hasCode && dxData.unspecified && dxData.candidate_suggestions)
-                    )) || null;
+                    // Uncoded card: ranked grounded options to pick from. The belt stamps
+                    // them on the command (data.candidate_suggestions), keyed by block_id;
+                    // fall back to the block_id-keyed diagnosisSuggestions map.
+                    const suggestions = (!hasCode && !isRejected
+                      && (dxData.candidate_suggestions
+                        || (diagnosisSuggestions && blockId && diagnosisSuggestions[blockId]))) || null;
 
                     const handleAcceptDiagnose = () => onEditCommand(entry.index, { ...entry.command.data, accepted: true, rejected: false }, 'diagnose');
                     const handleRejectDiagnose = () => onEditCommand(entry.index, { ...entry.command.data, rejected: true, accepted: false }, 'diagnose');
@@ -871,7 +870,7 @@ export function SoapGroup({ title, groupColor, sections, commandBySectionKey, on
                         <div class="recommendation-actions">
                           ${(dxData.background || '').length > 2048 && html`<span class="rec-warning-pill">Background too long</span>`}
                           ${(dxData.today_assessment || '').length > 2048 && html`<span class="rec-warning-pill">Assessment too long</span>`}
-                          ${renderRecActions({ command: entry.command, index: entry.index, isAccepted, isRejected, incomplete: isIncomplete, missingLabel: 'Diagnosis Code', acceptDisabled: false, readOnly, onAccept: handleAcceptDiagnose, onReject: handleRejectDiagnose, onAddNow: null })}
+                          ${renderRecActions({ command: entry.command, index: entry.index, isAccepted, isRejected, incomplete: isIncomplete, missingLabel: 'Diagnosis Code', acceptDisabled: isIncomplete, readOnly, onAccept: handleAcceptDiagnose, onReject: handleRejectDiagnose, onAddNow: null })}
                         </div>
                       </div>
                     `;

--- a/hyperscribe/scribe/static/soap-group.js
+++ b/hyperscribe/scribe/static/soap-group.js
@@ -1397,7 +1397,11 @@ export function SoapGroup({ title, groupColor, sections, commandBySectionKey, on
           const historyEntries = historyType
             ? visibleAdHoc.filter(e => e.command.command_type === historyType)
             : [];
-          const showHistoryText = s.text && !isCoveredHistory;
+          // Never render the raw note A&P text: its content is command-driven (diagnose/
+          // plan commands), so raw `s.text` is always a duplicate — and it becomes a stale,
+          // uneditable duplicate once every card is moved to Wrap Up (which empties
+          // assessment_and_plan of commands and drops rendering into this fallback).
+          const showHistoryText = s.text && !isCoveredHistory && key !== 'assessment_and_plan';
           // social_history has no manual input affordance (not in NARRATIVE_SECTIONS,
           // no SECTION_TO_HISTORY_TYPE entry), so an empty Social History section is a
           // dead, un-fillable header. Hide it whenever it has nothing to show; the AI
@@ -1412,7 +1416,7 @@ export function SoapGroup({ title, groupColor, sections, commandBySectionKey, on
           if (!showHistoryText && historyEntries.length === 0 && !onAddHistory && !cmds && !planAddable) return null;
           return html`
             <div class="subsection" key=${s.key}>
-              <div class="subsection-title">${s.title}</div>
+              <div class="subsection-title">${key === 'assessment_and_plan' ? 'Conditions' : s.title}</div>
               ${showHistoryText && html`<p class="section-text">${s.text}</p>`}
               ${historyEntries.map(entry => {
                 const historyRowReadOnly = rowLocked(entry.command, readOnly, isAmending);

--- a/hyperscribe/scribe/static/soap-group.js
+++ b/hyperscribe/scribe/static/soap-group.js
@@ -714,7 +714,7 @@ function AddConditionSearch({ onAdd, patientId }) {
   `;
 }
 
-export function SoapGroup({ title, groupColor, sections, commandBySectionKey, onEditCommand, onDeleteCommand, adHocCommands, assignees, onAddTask, onAddOrder, onAddPlan, onMoveToPlan, onAddVitals, onAddPhysicalExam, onAddMentalStatusExam, onAddMedication, onAddAllergy, onAddStopMedication, onAddRemoveAllergy, onAddResolveCondition, onAddHistory, onAddQuestionnaire, onAddCharge, readOnly, isAmending = false, sectionConditions, patientId, noteId, staffId, staffName, recommendations, onEditRecommendation, onDeleteRecommendation, onAcceptRecommendation, onRejectRecommendation, onAddCondition, unmatchedConditions, diagnosisSuggestions, noteDiagnoses = [], onAddNow, hideRejected, alertFacilityEnabled, onEditingChange, questionnaireScores, chargeMatrixDiagnoses = [], chargeMatrixCharges = [], searchCharges = () => {}, suggestedCharges = [], onToggleChargePointer = () => {}, onReorderDiagnoses = () => {}, onAddChargeModifier = () => {}, onRemoveChargeModifier = () => {}, onSetChargeComment = () => {}, onClearChargeComment = () => {}, onRemoveChargeByUuid = () => {}, examTemplates, onCarryForwardExam, isPsychiatry = false }) {
+export function SoapGroup({ title, groupColor, sections, commandBySectionKey, onEditCommand, onDeleteCommand, adHocCommands, assignees, onAddTask, onAddOrder, onAddPlan, onMoveToPlan, onAddAppointment, onAddVitals, onAddPhysicalExam, onAddMentalStatusExam, onAddMedication, onAddAllergy, onAddStopMedication, onAddRemoveAllergy, onAddResolveCondition, onAddHistory, onAddQuestionnaire, onAddCharge, readOnly, isAmending = false, sectionConditions, patientId, noteId, staffId, staffName, recommendations, onEditRecommendation, onDeleteRecommendation, onAcceptRecommendation, onRejectRecommendation, onAddCondition, unmatchedConditions, diagnosisSuggestions, noteDiagnoses = [], onAddNow, hideRejected, alertFacilityEnabled, onEditingChange, questionnaireScores, chargeMatrixDiagnoses = [], chargeMatrixCharges = [], searchCharges = () => {}, suggestedCharges = [], onToggleChargePointer = () => {}, onReorderDiagnoses = () => {}, onAddChargeModifier = () => {}, onRemoveChargeModifier = () => {}, onSetChargeComment = () => {}, onClearChargeComment = () => {}, onRemoveChargeByUuid = () => {}, examTemplates, onCarryForwardExam, isPsychiatry = false }) {
   const isCharges = title === 'CHARGES';
   const coveredKeys = getCoveredKeys(commandBySectionKey);
 
@@ -770,6 +770,50 @@ export function SoapGroup({ title, groupColor, sections, commandBySectionKey, on
           const isCoveredHistory = coveredKeys.has(key) && HISTORY_SECTION_KEYS.has(key);
           if (coveredKeys.has(key) && !hasRecsForKey && !DEDICATED_SECTION_KEYS.has(key) && !HISTORY_SECTION_KEYS.has(key)) return null;
           const cmds = commandBySectionKey && commandBySectionKey[key];
+
+          if (key === 'appointments') {
+            // Appointments component: always present (ENSURE_KEYS). Renders EVERY plan
+            // command here — including cards moved via "Move to plan" — as an editable
+            // narrative with Remove. When empty and editable, a "Tap to enter text"
+            // placeholder promotes into a real command via onAddAppointment (mirrors the
+            // Physical Exam always-on editor). Uncoded diagnoses never live here, so no
+            // ICD gate applies.
+            const apptCmds = (cmds || []).filter(e => e.command.command_type === 'plan');
+            const apptPlaceholder = { command_type: 'plan', section_key: 'appointments', display: '', selected: true, already_documented: false, data: { narrative: '' } };
+            if (readOnly && apptCmds.length === 0) return null;
+            return html`
+              <div class="subsection" key=${s.key}>
+                <div class="subsection-title">${s.title}</div>
+                ${apptCmds.map(entry => {
+                  const apptRowReadOnly = rowLocked(entry.command, readOnly, isAmending);
+                  return html`
+                    <div class=${`content-block rec-narrative${apptRowReadOnly && entry.command.already_documented ? ' command-locked' : ''}`} key=${entry.index}>
+                      ${apptRowReadOnly && entry.command.already_documented && ICON_LOCK}
+                      <${CommandRow}
+                        command=${entry.command}
+                        commandIndex=${entry.index}
+                        onEdit=${onEditCommand}
+                        readOnly=${apptRowReadOnly}
+                        onEditingChange=${onEditingChange}
+                      />
+                      ${!readOnly && !entry.command.already_documented && !entry.command._adding && html`<div class="recommendation-actions"><button type="button" class="rec-remove-x" onClick=${() => onDeleteCommand(entry.index)} title="Remove">${ICON_X}</button></div>`}
+                    </div>
+                  `;
+                })}
+                ${apptCmds.length === 0 && !readOnly && onAddAppointment && html`
+                  <div class="content-block rec-narrative">
+                    <${CommandRow}
+                      command=${apptPlaceholder}
+                      commandIndex="appointments_placeholder"
+                      onEdit=${(_, data) => onAddAppointment(data)}
+                      readOnly=${false}
+                      onEditingChange=${onEditingChange}
+                    />
+                  </div>
+                `}
+              </div>
+            `;
+          }
 
           if (cmds && NARRATIVE_SECTIONS.has(key)) {
             const isPlan = PLAN_SECTIONS.has(key);

--- a/hyperscribe/scribe/static/soap-group.js
+++ b/hyperscribe/scribe/static/soap-group.js
@@ -827,7 +827,7 @@ export function SoapGroup({ title, groupColor, sections, commandBySectionKey, on
             if (hasConditionCommands) {
               return html`
                 <div class="subsection" key=${s.key}>
-                  <div class="subsection-title">${s.title}</div>
+                  <div class="subsection-title">${key === 'assessment_and_plan' ? 'Conditions' : s.title}</div>
                   ${cmds.filter(e => e.command.command_type === 'assess').map(entry => {
                     const aData = entry.command.data || {};
                     const aCode = aData.icd10_code ? aData.icd10_code.replace(/\./g, '').trim().toUpperCase() : '';
@@ -985,7 +985,7 @@ export function SoapGroup({ title, groupColor, sections, commandBySectionKey, on
             const narrativeRowReadOnly = rowLocked(entry.command, readOnly, isAmending);
             return html`
               <div class="subsection" key=${s.key}>
-                <div class="subsection-title">${s.title}</div>
+                <div class="subsection-title">${key === 'assessment_and_plan' ? 'Conditions' : s.title}</div>
                 <div class=${`content-block rec-narrative${narrativeRowReadOnly && entry.command.already_documented ? ' command-locked' : ''}`}>
                   ${narrativeRowReadOnly && entry.command.already_documented && ICON_LOCK}
                   <${CommandRow}

--- a/hyperscribe/scribe/static/soap-group.js
+++ b/hyperscribe/scribe/static/soap-group.js
@@ -827,7 +827,14 @@ export function SoapGroup({ title, groupColor, sections, commandBySectionKey, on
             const hasConditionCommands = isPlan && cmds.some(e => e.command.command_type === 'diagnose' || e.command.command_type === 'assess');
             if (hasConditionCommands) {
               return html`
-                <div class="subsection" key=${s.key}>
+                ${/* Distinct key per structural variant: the empty A&P (fallback branch
+                     below) and the narrative-only branch render the SAME section under
+                     key=s.key. Sharing the key made Preact reconcile these very different
+                     subtrees IN PLACE on the empty→first-condition transition, leaving
+                     stale card handlers (card looked present but was uneditable) and the
+                     "+ Add Condition" button matched against a card vnode (button vanished).
+                     A variant-specific key forces a clean remount instead. */ ''}
+                <div class="subsection" key=${s.key + '-conditions'}>
                   <div class="subsection-title">${key === 'assessment_and_plan' ? 'Conditions' : s.title}</div>
                   ${cmds.filter(e => e.command.command_type === 'assess').map(entry => {
                     const aData = entry.command.data || {};
@@ -998,7 +1005,7 @@ export function SoapGroup({ title, groupColor, sections, commandBySectionKey, on
             const planResolves = isPlan ? visibleAdHoc.filter(e => e.command.command_type === 'resolve_condition') : [];
             const narrativeRowReadOnly = rowLocked(entry.command, readOnly, isAmending);
             return html`
-              <div class="subsection" key=${s.key}>
+              <div class="subsection" key=${isPlan ? s.key + '-narrative' : s.key}>
                 <div class="subsection-title">${key === 'assessment_and_plan' ? 'Conditions' : s.title}</div>
                 <div class=${`content-block rec-narrative${narrativeRowReadOnly && entry.command.already_documented ? ' command-locked' : ''}`}>
                   ${narrativeRowReadOnly && entry.command.already_documented && ICON_LOCK}
@@ -1430,7 +1437,7 @@ export function SoapGroup({ title, groupColor, sections, commandBySectionKey, on
           const planAddable = PLAN_SECTIONS.has(key) && (onAddCondition || onAddResolveCondition);
           if (!showHistoryText && historyEntries.length === 0 && !onAddHistory && !cmds && !planAddable) return null;
           return html`
-            <div class="subsection" key=${s.key}>
+            <div class="subsection" key=${PLAN_SECTIONS.has(key) ? s.key + '-empty' : s.key}>
               <div class="subsection-title">${key === 'assessment_and_plan' ? 'Conditions' : s.title}</div>
               ${showHistoryText && html`<p class="section-text">${s.text}</p>`}
               ${historyEntries.map(entry => {

--- a/hyperscribe/scribe/static/soap-group.js
+++ b/hyperscribe/scribe/static/soap-group.js
@@ -776,7 +776,6 @@ export function SoapGroup({ title, groupColor, sections, commandBySectionKey, on
             // If the A&P has been split into per-condition commands, render each diagnose as DiagnoseRow and assess as CommandRow.
             const hasConditionCommands = isPlan && cmds.some(e => e.command.command_type === 'diagnose' || e.command.command_type === 'assess');
             if (hasConditionCommands) {
-              const unmatched = unmatchedConditions || [];
               return html`
                 <div class="subsection" key=${s.key}>
                   <div class="subsection-title">${s.title}</div>
@@ -833,7 +832,19 @@ export function SoapGroup({ title, groupColor, sections, commandBySectionKey, on
                     const isRejected = dxData.rejected;
                     const isIncomplete = !hasCode && !isRejected;
                     const header = dxData.condition_header || '';
-                    const suggestions = (!hasCode && !isRejected && diagnosisSuggestions && diagnosisSuggestions[header]) || null;
+                    // Ranked, grounded code options for an uncoded card. The belt
+                    // stamps them directly on the command (data.candidate_suggestions),
+                    // keyed by the stable block_id; fall back to the block_id-keyed
+                    // diagnosisSuggestions map. (Header-string keying was fragile and
+                    // is gone.)
+                    const blockId = dxData.block_id || '';
+                    // Uncoded card: ranked grounded options to pick from. Coded-but-
+                    // unspecified card: the more-specific children for the refine nudge.
+                    const suggestions = (!isRejected && (
+                      (!hasCode && (dxData.candidate_suggestions
+                        || (diagnosisSuggestions && blockId && diagnosisSuggestions[blockId])))
+                      || (hasCode && dxData.unspecified && dxData.candidate_suggestions)
+                    )) || null;
 
                     const handleAcceptDiagnose = () => onEditCommand(entry.index, { ...entry.command.data, accepted: true, rejected: false }, 'diagnose');
                     const handleRejectDiagnose = () => onEditCommand(entry.index, { ...entry.command.data, rejected: true, accepted: false }, 'diagnose');
@@ -865,29 +876,12 @@ export function SoapGroup({ title, groupColor, sections, commandBySectionKey, on
                       </div>
                     `;
                   })}
-                  ${!readOnly && unmatched.length > 0 && html`
-                    <div class="diagnose-suggestions" style="margin-top: 12px;">
-                      <div class="history-form-label">Other detected conditions</div>
-                      <div class="diagnose-suggestions-list">
-                        ${unmatched.map(c => {
-                          const codes = (c.coding || []).filter(cd => cd.code);
-                          const code = codes[0];
-                          if (!code) return null;
-                          const stripped = code.code.replace(/\./g, '');
-                          const formatted = stripped.length > 3 ? stripped.slice(0, 3) + '.' + stripped.slice(3) : stripped;
-                          const display = c.display || code.display || formatted;
-                          return html`
-                            <button
-                              key=${code.code}
-                              type="button"
-                              class="diagnose-suggestion-btn"
-                              onClick=${() => onAddCondition && onAddCondition(code.code, display)}
-                            ><strong>${formatted}</strong>${' '}${display}</button>
-                          `;
-                        })}
-                      </div>
-                    </div>
-                  `}
+                  ${/* The "Other detected conditions" section was removed: the
+                      grounded ranker now relocates block-relevant conditions onto
+                      their own cards, so what remained here was incidental detection
+                      that invited accidental one-click coding. The backend
+                      ``unmatched_conditions`` data is still emitted (referral
+                      indication linking + analysis), just not surfaced as a section. */ ''}
                   ${(visibleAdHoc.filter(e => e.command.command_type === 'resolve_condition')).map(re => {
                     const reRowReadOnly = rowLocked(re.command, readOnly, isAmending);
                     return html`

--- a/hyperscribe/scribe/static/styles.css
+++ b/hyperscribe/scribe/static/styles.css
@@ -1044,6 +1044,8 @@ select.history-form-input {
 .diagnose-body-empty { color: #aaa; font-style: italic; }
 .diagnose-body-label { font-size: 11px; font-weight: 600; color: #6b7280; text-transform: uppercase; letter-spacing: 0.5px; margin-top: 6px; }
 .diagnose-body-label:first-child { margin-top: 0; }
+/* Original Nabla A&P headline, kept as a quasi-header inside Today's assessment. */
+.diagnose-assessment-header { font-weight: 600; color: #374151; margin: 2px 0 4px; }
 /* Edit-area vertical rhythm: generous gap BETWEEN field groups; tight WITHIN
    each group (label->box->help) via the .diagnose-field wrapper + label margin.
    Shared by DiagnoseRow and AssessNarrative edit views. */

--- a/hyperscribe/scribe/static/styles.css
+++ b/hyperscribe/scribe/static/styles.css
@@ -1102,11 +1102,17 @@ select.history-form-input {
    "Detected in note", "More specific option"). Trails the code as a quiet, right-aligned
    metadata column (the code pill leads, right after the diagnosis name). */
 .diagnose-picker-prov { margin-left: auto; flex-shrink: 0; font-size: 10.5px; font-weight: 600; color: #6b7785; background: #f1f4f8; border-radius: 5px; padding: 1px 7px; white-space: nowrap; }
-/* "Move to plan" action at the foot of the code picker — a distinct action (not a code
-   option), separated from the list above and styled quieter than a diagnosis row. */
-.diagnose-picker-action { display: flex; align-items: center; gap: 7px; width: 100%; padding: 9px 16px; background: none; border: none; border-top: 1px solid #eef1f5; font-size: 12.5px; font-weight: 600; color: #6b7785; cursor: pointer; text-align: left; transition: background 0.12s, color 0.12s; }
-.diagnose-picker-action:hover { background: #f5f8ff; color: #052B49; }
-.diagnose-picker-action svg { width: 13px; height: 13px; }
+/* "Move to Wrap Up" action at the foot of the code picker — a distinct action (not a code
+   option), separated from the list above and styled quieter than a diagnosis row. Two
+   lines: the action (verb + destination) leads, the rationale ("Not a diagnosis") trails
+   as muted supporting text. */
+.diagnose-picker-action { display: flex; align-items: center; gap: 8px; width: 100%; padding: 9px 16px; background: none; border: none; border-top: 1px solid #eef1f5; cursor: pointer; text-align: left; transition: background 0.12s, color 0.12s; color: #6b7785; }
+.diagnose-picker-action:hover { background: #f5f8ff; }
+.diagnose-picker-action svg { width: 13px; height: 13px; flex-shrink: 0; }
+.diagnose-picker-action-text { display: flex; flex-direction: column; line-height: 1.25; }
+.diagnose-picker-action-title { font-size: 12.5px; font-weight: 600; color: #4a5563; }
+.diagnose-picker-action:hover .diagnose-picker-action-title { color: #052B49; }
+.diagnose-picker-action-sub { font-size: 11px; font-weight: 500; color: #9aa6b2; }
 
 /* Diagnose recommendation: header + actions on one row, everything else full-width below */
 .recommendation-block.rec-diagnose { display: grid; grid-template-columns: 1fr auto; align-items: start; }

--- a/hyperscribe/scribe/static/styles.css
+++ b/hyperscribe/scribe/static/styles.css
@@ -1098,6 +1098,13 @@ select.history-form-input {
 .diagnose-picker-name { font-size: 14px; font-weight: 500; color: #1f2733; flex: 0 1 auto; min-width: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .diagnose-picker-code { display: inline-flex; align-items: center; flex-shrink: 0; font-size: 11.5px; font-weight: 700; color: #059669; background: #ecfdf3; border-radius: 6px; padding: 2px 8px; margin-left: 8px; letter-spacing: 0.2px; white-space: nowrap; }
 .diagnose-picker-empty { padding: 12px 16px; font-size: 13px; color: #9aa6b2; }
+/* Provenance tag on a recommended/candidate code ("Active problem", "Resolved 2021", ...). */
+.diagnose-picker-prov { margin-left: auto; flex-shrink: 0; font-size: 10.5px; font-weight: 600; color: #6b7785; background: #f1f4f8; border-radius: 5px; padding: 1px 7px; white-space: nowrap; }
+/* Shown above the picker when the ranker left a block intentionally uncoded. */
+.diagnose-ambiguity-hint { font-size: 12px; color: #9a6700; background: #fff7e6; border-radius: 6px; padding: 4px 10px; margin: 2px 0 6px; display: inline-block; }
+/* "Unspecified — refine" nudge next to a coded-but-unspecified code. */
+.diagnose-unspecified-nudge { background: #fff7e6; border: 1px solid #f0d090; color: #9a6700; padding: 2px 8px; font-size: 11.5px; font-weight: 600; border-radius: 6px; cursor: pointer; flex-shrink: 0; margin-left: 4px; }
+.diagnose-unspecified-nudge:hover { background: #ffefcc; }
 
 /* Diagnose recommendation: header + actions on one row, everything else full-width below */
 .recommendation-block.rec-diagnose { display: grid; grid-template-columns: 1fr auto; align-items: start; }

--- a/hyperscribe/scribe/static/styles.css
+++ b/hyperscribe/scribe/static/styles.css
@@ -1105,8 +1105,11 @@ select.history-form-input {
 /* "Not a diagnosis?" escape hatch at the foot of the code picker — progressive disclosure:
    a quiet trigger reveals the "Move to Wrap Up" action. Both are separated from the code
    list above and styled quieter than a diagnosis row (they're not code options). */
-.diagnose-picker-disclose { display: flex; align-items: center; width: 100%; padding: 8px 16px; background: none; border: none; border-top: 1px solid #eef1f5; font-size: 12px; font-weight: 500; color: #9aa6b2; cursor: pointer; text-align: left; transition: color 0.12s; }
-.diagnose-picker-disclose:hover { color: #6b7785; }
+.diagnose-picker-disclose { display: flex; align-items: center; gap: 9px; width: 100%; padding: 11px 16px; background: none; border: none; border-top: 1px solid #eef1f5; font-size: 12.5px; font-weight: 600; color: #6b7785; cursor: pointer; text-align: left; transition: background 0.12s, color 0.12s; }
+.diagnose-picker-disclose:hover { background: #f5f8ff; color: #052B49; }
+.diagnose-picker-disclose .nd-lead { width: 14px; height: 14px; color: #9aa6b2; flex-shrink: 0; }
+.diagnose-picker-disclose .nd-chev { width: 14px; height: 14px; color: #9aa6b2; flex-shrink: 0; margin-left: auto; transition: transform 0.12s; }
+.diagnose-picker-disclose:hover .nd-chev { transform: translateX(3px); }
 .diagnose-picker-action { display: flex; align-items: center; gap: 7px; width: 100%; padding: 9px 16px; background: none; border: none; border-top: 1px solid #eef1f5; font-size: 12.5px; font-weight: 600; color: #6b7785; cursor: pointer; text-align: left; transition: background 0.12s, color 0.12s; }
 .diagnose-picker-action:hover { background: #f5f8ff; color: #052B49; }
 .diagnose-picker-action svg { width: 13px; height: 13px; flex-shrink: 0; }

--- a/hyperscribe/scribe/static/styles.css
+++ b/hyperscribe/scribe/static/styles.css
@@ -1102,17 +1102,14 @@ select.history-form-input {
    "Detected in note", "More specific option"). Trails the code as a quiet, right-aligned
    metadata column (the code pill leads, right after the diagnosis name). */
 .diagnose-picker-prov { margin-left: auto; flex-shrink: 0; font-size: 10.5px; font-weight: 600; color: #6b7785; background: #f1f4f8; border-radius: 5px; padding: 1px 7px; white-space: nowrap; }
-/* "Move to Wrap Up" action at the foot of the code picker — a distinct action (not a code
-   option), separated from the list above and styled quieter than a diagnosis row. Two
-   lines: the action (verb + destination) leads, the rationale ("Not a diagnosis") trails
-   as muted supporting text. */
-.diagnose-picker-action { display: flex; align-items: center; gap: 8px; width: 100%; padding: 9px 16px; background: none; border: none; border-top: 1px solid #eef1f5; cursor: pointer; text-align: left; transition: background 0.12s, color 0.12s; color: #6b7785; }
-.diagnose-picker-action:hover { background: #f5f8ff; }
+/* "Not a diagnosis?" escape hatch at the foot of the code picker — progressive disclosure:
+   a quiet trigger reveals the "Move to Wrap Up" action. Both are separated from the code
+   list above and styled quieter than a diagnosis row (they're not code options). */
+.diagnose-picker-disclose { display: flex; align-items: center; width: 100%; padding: 8px 16px; background: none; border: none; border-top: 1px solid #eef1f5; font-size: 12px; font-weight: 500; color: #9aa6b2; cursor: pointer; text-align: left; transition: color 0.12s; }
+.diagnose-picker-disclose:hover { color: #6b7785; }
+.diagnose-picker-action { display: flex; align-items: center; gap: 7px; width: 100%; padding: 9px 16px; background: none; border: none; border-top: 1px solid #eef1f5; font-size: 12.5px; font-weight: 600; color: #6b7785; cursor: pointer; text-align: left; transition: background 0.12s, color 0.12s; }
+.diagnose-picker-action:hover { background: #f5f8ff; color: #052B49; }
 .diagnose-picker-action svg { width: 13px; height: 13px; flex-shrink: 0; }
-.diagnose-picker-action-text { display: flex; flex-direction: column; line-height: 1.25; }
-.diagnose-picker-action-title { font-size: 12.5px; font-weight: 600; color: #4a5563; }
-.diagnose-picker-action:hover .diagnose-picker-action-title { color: #052B49; }
-.diagnose-picker-action-sub { font-size: 11px; font-weight: 500; color: #9aa6b2; }
 
 /* Diagnose recommendation: header + actions on one row, everything else full-width below */
 .recommendation-block.rec-diagnose { display: grid; grid-template-columns: 1fr auto; align-items: start; }

--- a/hyperscribe/scribe/static/styles.css
+++ b/hyperscribe/scribe/static/styles.css
@@ -1111,7 +1111,6 @@ select.history-form-input {
    (accented); a second click performs the move. */
 .diagnose-picker-disclose { display: flex; align-items: center; width: 100%; padding: 9px 16px; background: none; border: none; border-top: 1px solid #eef1f5; font-size: 14px; font-weight: 500; color: #1f2733; cursor: pointer; text-align: left; transition: background 0.12s, color 0.12s; }
 .diagnose-picker-disclose:hover { background: #f5f8ff; }
-.diagnose-picker-disclose.armed { color: #052B49; font-weight: 600; }
 
 /* Diagnose recommendation: header + actions on one row, everything else full-width below */
 .recommendation-block.rec-diagnose { display: grid; grid-template-columns: 1fr auto; align-items: start; }

--- a/hyperscribe/scribe/static/styles.css
+++ b/hyperscribe/scribe/static/styles.css
@@ -1106,19 +1106,12 @@ select.history-form-input {
    a quiet trigger reveals the "Move to Wrap Up" action. Both are separated from the code
    list above and styled quieter than a diagnosis row (they're not code options). */
 /* "Move to the wrap up section" — the escape hatch for A&P items that aren't a codeable
-   diagnosis. Phase A: a flush-left trigger whose label matches the recommendation rows
-   (14px / 500), quieter color. Clicking arms Phase B: the same label + inline Cancel /
-   Confirm. */
-.diagnose-picker-disclose { display: flex; align-items: center; width: 100%; padding: 9px 16px; background: none; border: none; border-top: 1px solid #eef1f5; font-size: 14px; font-weight: 500; color: #6b7785; cursor: pointer; text-align: left; transition: background 0.12s, color 0.12s; }
-.diagnose-picker-disclose:hover { background: #f5f8ff; color: #052B49; }
-.diagnose-move-confirm { display: flex; align-items: center; gap: 10px; width: 100%; padding: 9px 16px; border-top: 1px solid #eef1f5; background: #fafbfd; }
-.diagnose-move-label { font-size: 14px; font-weight: 500; color: #1f2733; }
-.diagnose-move-actions { margin-left: auto; display: flex; gap: 8px; flex-shrink: 0; }
-.diagnose-move-confirm button { font: inherit; font-size: 12.5px; font-weight: 600; border-radius: 7px; padding: 5px 12px; cursor: pointer; border: 1px solid transparent; transition: background 0.12s, color 0.12s; }
-.diagnose-move-cancel { background: none; border-color: #d3dbe4; color: #6b7785; }
-.diagnose-move-cancel:hover { background: #eef2f6; color: #1f2733; }
-.diagnose-move-confirm-btn { background: #052B49; color: #fff; }
-.diagnose-move-confirm-btn:hover { background: #0a3a60; }
+   diagnosis. A single self-arming row whose label matches the search-result names exactly
+   (14px / 500 / #1f2733, hover = bg only). First click swaps the label to "Confirm"
+   (accented); a second click performs the move. */
+.diagnose-picker-disclose { display: flex; align-items: center; width: 100%; padding: 9px 16px; background: none; border: none; border-top: 1px solid #eef1f5; font-size: 14px; font-weight: 500; color: #1f2733; cursor: pointer; text-align: left; transition: background 0.12s, color 0.12s; }
+.diagnose-picker-disclose:hover { background: #f5f8ff; }
+.diagnose-picker-disclose.armed { color: #052B49; font-weight: 600; }
 
 /* Diagnose recommendation: header + actions on one row, everything else full-width below */
 .recommendation-block.rec-diagnose { display: grid; grid-template-columns: 1fr auto; align-items: start; }

--- a/hyperscribe/scribe/static/styles.css
+++ b/hyperscribe/scribe/static/styles.css
@@ -1109,6 +1109,10 @@ select.history-form-input {
    diagnosis. A single self-arming row whose label matches the search-result names exactly
    (14px / 500 / #1f2733, hover = bg only). First click swaps the label to "Confirm"
    (accented); a second click performs the move. */
+/* "See more" / "See less" toggle beneath the recommendations — reveals the rest of the
+   ranked codes and the move-to-wrap-up action. Quiet, full-width, inherits the app font. */
+.diagnose-picker-more { display: flex; align-items: center; width: 100%; padding: 8px 16px; background: none; border: none; border-top: 1px solid #eef1f5; font-family: inherit; font-size: 13px; font-weight: 600; color: #6b7785; cursor: pointer; text-align: left; transition: background 0.12s, color 0.12s; }
+.diagnose-picker-more:hover { background: #f5f8ff; color: #052B49; }
 .diagnose-picker-disclose { display: flex; align-items: center; width: 100%; padding: 9px 16px; background: none; border: none; border-top: 1px solid #eef1f5; font-family: inherit; line-height: inherit; font-size: 14px; font-weight: 500; color: #1f2733; cursor: pointer; text-align: left; transition: background 0.12s, color 0.12s; }
 .diagnose-picker-disclose:hover { background: #f5f8ff; }
 

--- a/hyperscribe/scribe/static/styles.css
+++ b/hyperscribe/scribe/static/styles.css
@@ -1102,6 +1102,11 @@ select.history-form-input {
    "Detected in note", "More specific option"). Trails the code as a quiet, right-aligned
    metadata column (the code pill leads, right after the diagnosis name). */
 .diagnose-picker-prov { margin-left: auto; flex-shrink: 0; font-size: 10.5px; font-weight: 600; color: #6b7785; background: #f1f4f8; border-radius: 5px; padding: 1px 7px; white-space: nowrap; }
+/* "Move to plan" action at the foot of the code picker — a distinct action (not a code
+   option), separated from the list above and styled quieter than a diagnosis row. */
+.diagnose-picker-action { display: flex; align-items: center; gap: 7px; width: 100%; padding: 9px 16px; background: none; border: none; border-top: 1px solid #eef1f5; font-size: 12.5px; font-weight: 600; color: #6b7785; cursor: pointer; text-align: left; transition: background 0.12s, color 0.12s; }
+.diagnose-picker-action:hover { background: #f5f8ff; color: #052B49; }
+.diagnose-picker-action svg { width: 13px; height: 13px; }
 
 /* Diagnose recommendation: header + actions on one row, everything else full-width below */
 .recommendation-block.rec-diagnose { display: grid; grid-template-columns: 1fr auto; align-items: start; }

--- a/hyperscribe/scribe/static/styles.css
+++ b/hyperscribe/scribe/static/styles.css
@@ -1098,13 +1098,10 @@ select.history-form-input {
 .diagnose-picker-name { font-size: 14px; font-weight: 500; color: #1f2733; flex: 0 1 auto; min-width: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .diagnose-picker-code { display: inline-flex; align-items: center; flex-shrink: 0; font-size: 11.5px; font-weight: 700; color: #059669; background: #ecfdf3; border-radius: 6px; padding: 2px 8px; margin-left: 8px; letter-spacing: 0.2px; white-space: nowrap; }
 .diagnose-picker-empty { padding: 12px 16px; font-size: 13px; color: #9aa6b2; }
-/* Provenance tag on a recommended/candidate code ("Active problem", "Resolved 2021", ...). */
+/* Provenance tag on a recommended/candidate code ("Active problem", "Past condition",
+   "Detected in note", "More specific option"). Trails the code as a quiet, right-aligned
+   metadata column (the code pill leads, right after the diagnosis name). */
 .diagnose-picker-prov { margin-left: auto; flex-shrink: 0; font-size: 10.5px; font-weight: 600; color: #6b7785; background: #f1f4f8; border-radius: 5px; padding: 1px 7px; white-space: nowrap; }
-/* Shown above the picker when the ranker left a block intentionally uncoded. */
-.diagnose-ambiguity-hint { font-size: 12px; color: #9a6700; background: #fff7e6; border-radius: 6px; padding: 4px 10px; margin: 2px 0 6px; display: inline-block; }
-/* "Unspecified — refine" nudge next to a coded-but-unspecified code. */
-.diagnose-unspecified-nudge { background: #fff7e6; border: 1px solid #f0d090; color: #9a6700; padding: 2px 8px; font-size: 11.5px; font-weight: 600; border-radius: 6px; cursor: pointer; flex-shrink: 0; margin-left: 4px; }
-.diagnose-unspecified-nudge:hover { background: #ffefcc; }
 
 /* Diagnose recommendation: header + actions on one row, everything else full-width below */
 .recommendation-block.rec-diagnose { display: grid; grid-template-columns: 1fr auto; align-items: start; }

--- a/hyperscribe/scribe/static/styles.css
+++ b/hyperscribe/scribe/static/styles.css
@@ -1044,8 +1044,6 @@ select.history-form-input {
 .diagnose-body-empty { color: #aaa; font-style: italic; }
 .diagnose-body-label { font-size: 11px; font-weight: 600; color: #6b7280; text-transform: uppercase; letter-spacing: 0.5px; margin-top: 6px; }
 .diagnose-body-label:first-child { margin-top: 0; }
-/* Original Nabla A&P headline, kept as a quasi-header inside Today's assessment. */
-.diagnose-assessment-header { font-weight: 600; color: #374151; margin: 2px 0 4px; }
 /* Edit-area vertical rhythm: generous gap BETWEEN field groups; tight WITHIN
    each group (label->box->help) via the .diagnose-field wrapper + label margin.
    Shared by DiagnoseRow and AssessNarrative edit views. */

--- a/hyperscribe/scribe/static/styles.css
+++ b/hyperscribe/scribe/static/styles.css
@@ -1109,7 +1109,7 @@ select.history-form-input {
    diagnosis. A single self-arming row whose label matches the search-result names exactly
    (14px / 500 / #1f2733, hover = bg only). First click swaps the label to "Confirm"
    (accented); a second click performs the move. */
-.diagnose-picker-disclose { display: flex; align-items: center; width: 100%; padding: 9px 16px; background: none; border: none; border-top: 1px solid #eef1f5; font-size: 14px; font-weight: 500; color: #1f2733; cursor: pointer; text-align: left; transition: background 0.12s, color 0.12s; }
+.diagnose-picker-disclose { display: flex; align-items: center; width: 100%; padding: 9px 16px; background: none; border: none; border-top: 1px solid #eef1f5; font-family: inherit; line-height: inherit; font-size: 14px; font-weight: 500; color: #1f2733; cursor: pointer; text-align: left; transition: background 0.12s, color 0.12s; }
 .diagnose-picker-disclose:hover { background: #f5f8ff; }
 
 /* Diagnose recommendation: header + actions on one row, everything else full-width below */

--- a/hyperscribe/scribe/static/styles.css
+++ b/hyperscribe/scribe/static/styles.css
@@ -1105,17 +1105,20 @@ select.history-form-input {
 /* "Not a diagnosis?" escape hatch at the foot of the code picker — progressive disclosure:
    a quiet trigger reveals the "Move to Wrap Up" action. Both are separated from the code
    list above and styled quieter than a diagnosis row (they're not code options). */
-/* Icon column matches .diagnose-picker-search exactly (18px lead icon + 12px gap → text
-   at 46px from the edge; 16px trailing icon right-aligned like the close-X) so the tag,
-   label, and chevron line up with the search row's magnifier, placeholder, and X. */
-.diagnose-picker-disclose { display: flex; align-items: center; gap: 12px; width: 100%; padding: 11px 16px; background: none; border: none; border-top: 1px solid #eef1f5; font-size: 12.5px; font-weight: 600; color: #6b7785; cursor: pointer; text-align: left; transition: background 0.12s, color 0.12s; }
+/* "Move to the wrap up section" — the escape hatch for A&P items that aren't a codeable
+   diagnosis. Phase A: a flush-left trigger whose label matches the recommendation rows
+   (14px / 500), quieter color. Clicking arms Phase B: the same label + inline Cancel /
+   Confirm. */
+.diagnose-picker-disclose { display: flex; align-items: center; width: 100%; padding: 9px 16px; background: none; border: none; border-top: 1px solid #eef1f5; font-size: 14px; font-weight: 500; color: #6b7785; cursor: pointer; text-align: left; transition: background 0.12s, color 0.12s; }
 .diagnose-picker-disclose:hover { background: #f5f8ff; color: #052B49; }
-.diagnose-picker-disclose .nd-lead { width: 18px; height: 18px; color: #9aa6b2; flex-shrink: 0; }
-.diagnose-picker-disclose .nd-chev { width: 16px; height: 16px; color: #9aa6b2; flex-shrink: 0; margin-left: auto; transition: transform 0.12s; }
-.diagnose-picker-disclose:hover .nd-chev { transform: translateX(3px); }
-.diagnose-picker-action { display: flex; align-items: center; gap: 12px; width: 100%; padding: 11px 16px; background: none; border: none; border-top: 1px solid #eef1f5; font-size: 12.5px; font-weight: 600; color: #6b7785; cursor: pointer; text-align: left; transition: background 0.12s, color 0.12s; }
-.diagnose-picker-action:hover { background: #f5f8ff; color: #052B49; }
-.diagnose-picker-action svg { width: 18px; height: 18px; flex-shrink: 0; }
+.diagnose-move-confirm { display: flex; align-items: center; gap: 10px; width: 100%; padding: 9px 16px; border-top: 1px solid #eef1f5; background: #fafbfd; }
+.diagnose-move-label { font-size: 14px; font-weight: 500; color: #1f2733; }
+.diagnose-move-actions { margin-left: auto; display: flex; gap: 8px; flex-shrink: 0; }
+.diagnose-move-confirm button { font: inherit; font-size: 12.5px; font-weight: 600; border-radius: 7px; padding: 5px 12px; cursor: pointer; border: 1px solid transparent; transition: background 0.12s, color 0.12s; }
+.diagnose-move-cancel { background: none; border-color: #d3dbe4; color: #6b7785; }
+.diagnose-move-cancel:hover { background: #eef2f6; color: #1f2733; }
+.diagnose-move-confirm-btn { background: #052B49; color: #fff; }
+.diagnose-move-confirm-btn:hover { background: #0a3a60; }
 
 /* Diagnose recommendation: header + actions on one row, everything else full-width below */
 .recommendation-block.rec-diagnose { display: grid; grid-template-columns: 1fr auto; align-items: start; }

--- a/hyperscribe/scribe/static/styles.css
+++ b/hyperscribe/scribe/static/styles.css
@@ -1119,8 +1119,12 @@ select.history-form-input {
    results listed below. Shared by the no-code state and the "Change" flow.
    Name leads (dark, semibold); the code is a quiet fixed-width identifier so
    codes align in a column. Rows are single-line (ellipsis) for uniform height. */
-.diagnose-picker { margin: 16px 0 18px; border: 1px solid #e4e7ec; border-radius: 12px; overflow: hidden; background: #fff; }
+/* overflow:visible so the search-bar ⋮ menu can drop out over the list below; the
+   inner .diagnose-picker-body re-clips the rounded bottom corners the picker's own
+   overflow:hidden used to provide (row/More-options hover backgrounds). */
+.diagnose-picker { margin: 16px 0 18px; border: 1px solid #e4e7ec; border-radius: 12px; overflow: visible; background: #fff; }
 .diagnose-picker:focus-within { border-color: #052B49; }
+.diagnose-picker-body { border-radius: 0 0 12px 12px; overflow: hidden; }
 .diagnose-picker-search { display: flex; align-items: center; gap: 12px; padding: 11px 16px; border-bottom: 1px solid #eef1f4; }
 .diagnose-picker-search svg { width: 18px; height: 18px; color: #9aa6b2; flex-shrink: 0; }
 .diagnose-picker-search input { border: none; outline: none; font-size: 14.5px; flex: 1; min-width: 0; font-family: inherit; color: #1f2733; background: none; }
@@ -1141,19 +1145,25 @@ select.history-form-input {
    "Detected in note", "More specific option"). Trails the code as a quiet, right-aligned
    metadata column (the code pill leads, right after the diagnosis name). */
 .diagnose-picker-prov { margin-left: auto; flex-shrink: 0; font-size: 10.5px; font-weight: 600; color: #6b7785; background: #f1f4f8; border-radius: 5px; padding: 1px 7px; white-space: nowrap; }
-/* "Not a diagnosis?" escape hatch at the foot of the code picker — progressive disclosure:
-   a quiet trigger reveals the "Move to Wrap Up" action. Both are separated from the code
-   list above and styled quieter than a diagnosis row (they're not code options). */
-/* "Move to the wrap up section" — the escape hatch for A&P items that aren't a codeable
-   diagnosis. A single self-arming row whose label matches the search-result names exactly
-   (14px / 500 / #1f2733, hover = bg only). First click swaps the label to "Confirm"
-   (accented); a second click performs the move. */
-/* "See more" / "See less" toggle beneath the recommendations — reveals the rest of the
-   ranked codes and the move-to-wrap-up action. Quiet, full-width, inherits the app font. */
+/* "More options" toggle beneath the recommendations — reveals the rest of the ranked
+   codes. Quiet, full-width, inherits the app font. */
 .diagnose-picker-more { display: flex; align-items: center; width: 100%; padding: 8px 16px; background: none; border: none; border-top: 1px solid #eef1f5; font-family: inherit; font-size: 13px; font-weight: 600; color: #6b7785; cursor: pointer; text-align: left; transition: background 0.12s, color 0.12s; }
 .diagnose-picker-more:hover { background: #f5f8ff; color: #052B49; }
-.diagnose-picker-disclose { display: flex; align-items: center; width: 100%; padding: 9px 16px; background: none; border: none; border-top: 1px solid #eef1f5; font-family: inherit; line-height: inherit; font-size: 14px; font-weight: 500; color: #1f2733; cursor: pointer; text-align: left; transition: background 0.12s, color 0.12s; }
-.diagnose-picker-disclose:hover { background: #f5f8ff; }
+
+/* ⋮ overflow menu at the right of the search bar — the escape hatch for A&P items that
+   aren't a codeable diagnosis ("Move to Wrap Up"). Faint by default so it stays quiet
+   next to the search field; the dropdown drops down over the code list. */
+.diagnose-picker-menu { position: relative; display: inline-flex; align-items: center; flex-shrink: 0; }
+.diagnose-picker-menu-btn { background: none; border: none; padding: 5px; margin: -2px -6px -2px 0; color: #b6bfc9; cursor: pointer; border-radius: 7px; line-height: 0; display: inline-flex; align-items: center; justify-content: center; transition: color 0.12s, background 0.12s; }
+.diagnose-picker-menu-btn:hover { color: #52606d; background: #f1f3f5; }
+.diagnose-picker-menu-btn svg { width: 18px; height: 18px; color: inherit; }
+.diagnose-picker-menu-pop { position: absolute; top: calc(100% + 10px); right: -6px; width: 264px; background: #fff; border: 1px solid #e4e7ec; border-radius: 11px; box-shadow: 0 12px 30px rgba(16,24,40,0.16); padding: 6px; z-index: 40; }
+.diagnose-picker-menu-pop::before { content: ""; position: absolute; bottom: 100%; right: 14px; border: 6px solid transparent; border-bottom-color: #fff; filter: drop-shadow(0 -1px 0 #e4e7ec); }
+.diagnose-picker-menu-item { display: flex; align-items: flex-start; gap: 10px; width: 100%; background: none; border: none; font-family: inherit; padding: 9px 10px; border-radius: 8px; cursor: pointer; text-align: left; }
+.diagnose-picker-menu-item:hover { background: #f5f8ff; }
+.diagnose-picker-menu-item svg { width: 16px; height: 16px; color: #52606d; flex-shrink: 0; margin-top: 1px; }
+.dpm-title { display: block; font-size: 13.5px; font-weight: 600; color: #1f2733; }
+.dpm-help { display: block; font-size: 11.5px; color: #9aa6b2; line-height: 1.45; margin-top: 2px; }
 
 /* Diagnose recommendation: header + actions on one row, everything else full-width below */
 .recommendation-block.rec-diagnose { display: grid; grid-template-columns: 1fr auto; align-items: start; }

--- a/hyperscribe/scribe/static/styles.css
+++ b/hyperscribe/scribe/static/styles.css
@@ -1105,14 +1105,17 @@ select.history-form-input {
 /* "Not a diagnosis?" escape hatch at the foot of the code picker — progressive disclosure:
    a quiet trigger reveals the "Move to Wrap Up" action. Both are separated from the code
    list above and styled quieter than a diagnosis row (they're not code options). */
-.diagnose-picker-disclose { display: flex; align-items: center; gap: 9px; width: 100%; padding: 11px 16px; background: none; border: none; border-top: 1px solid #eef1f5; font-size: 12.5px; font-weight: 600; color: #6b7785; cursor: pointer; text-align: left; transition: background 0.12s, color 0.12s; }
+/* Icon column matches .diagnose-picker-search exactly (18px lead icon + 12px gap → text
+   at 46px from the edge; 16px trailing icon right-aligned like the close-X) so the tag,
+   label, and chevron line up with the search row's magnifier, placeholder, and X. */
+.diagnose-picker-disclose { display: flex; align-items: center; gap: 12px; width: 100%; padding: 11px 16px; background: none; border: none; border-top: 1px solid #eef1f5; font-size: 12.5px; font-weight: 600; color: #6b7785; cursor: pointer; text-align: left; transition: background 0.12s, color 0.12s; }
 .diagnose-picker-disclose:hover { background: #f5f8ff; color: #052B49; }
-.diagnose-picker-disclose .nd-lead { width: 14px; height: 14px; color: #9aa6b2; flex-shrink: 0; }
-.diagnose-picker-disclose .nd-chev { width: 14px; height: 14px; color: #9aa6b2; flex-shrink: 0; margin-left: auto; transition: transform 0.12s; }
+.diagnose-picker-disclose .nd-lead { width: 18px; height: 18px; color: #9aa6b2; flex-shrink: 0; }
+.diagnose-picker-disclose .nd-chev { width: 16px; height: 16px; color: #9aa6b2; flex-shrink: 0; margin-left: auto; transition: transform 0.12s; }
 .diagnose-picker-disclose:hover .nd-chev { transform: translateX(3px); }
-.diagnose-picker-action { display: flex; align-items: center; gap: 7px; width: 100%; padding: 9px 16px; background: none; border: none; border-top: 1px solid #eef1f5; font-size: 12.5px; font-weight: 600; color: #6b7785; cursor: pointer; text-align: left; transition: background 0.12s, color 0.12s; }
+.diagnose-picker-action { display: flex; align-items: center; gap: 12px; width: 100%; padding: 11px 16px; background: none; border: none; border-top: 1px solid #eef1f5; font-size: 12.5px; font-weight: 600; color: #6b7785; cursor: pointer; text-align: left; transition: background 0.12s, color 0.12s; }
 .diagnose-picker-action:hover { background: #f5f8ff; color: #052B49; }
-.diagnose-picker-action svg { width: 13px; height: 13px; flex-shrink: 0; }
+.diagnose-picker-action svg { width: 18px; height: 18px; flex-shrink: 0; }
 
 /* Diagnose recommendation: header + actions on one row, everything else full-width below */
 .recommendation-block.rec-diagnose { display: grid; grid-template-columns: 1fr auto; align-items: start; }

--- a/hyperscribe/scribe/static/summary.js
+++ b/hyperscribe/scribe/static/summary.js
@@ -1756,22 +1756,36 @@ export function Scribe({ noteId, patientId, staffId, staffName, providerName, pr
     if (!canEdit) return;
     logEvent('MOVE_DX_TO_PLAN', { index });
     setCommands(prev => {
-      const updated = prev.map((c, i) => {
-        if (i !== index || c.command_type !== 'diagnose') return c;
-        const d = c.data || {};
-        const header = (d.condition_header || '').trim();
-        // today_assessment already leads with the headline (baked at generation). The
-        // card title should NOT travel to Wrap Up, so drop that leading header line and
-        // carry only the assessment body.
-        let narrative = (d.today_assessment || '').trim();
-        if (header && narrative.startsWith(header)) {
-          narrative = narrative.slice(header.length).replace(/^\n+/, '');
-        }
-        if (!narrative) narrative = header; // never produce an empty card
-        // Replace `data` wholesale so ICD/accepted/suggestion fields don't linger, and
-        // move it into the Wrap Up (appointments) component.
-        return { ...c, command_type: 'plan', section_key: 'appointments', display: narrative, data: { narrative } };
-      });
+      const src = prev[index];
+      if (!src || src.command_type !== 'diagnose') return prev;
+      const d = src.data || {};
+      // Carry today_assessment verbatim — it already leads with the headline + body
+      // (baked at generation), so the header shows once (no strip, no duplicate).
+      const item = (d.today_assessment || '').trim() || (d.condition_header || '').trim();
+      if (!item) return prev;
+      // Consolidate: all moved items live in the SAME Wrap Up text box. Append to the
+      // first editable `appointments` plan command if one exists; otherwise convert the
+      // source in place into it. Either way the source diagnosis card is removed.
+      const targetIdx = prev.findIndex(
+        c => c.command_type === 'plan' && c.section_key === 'appointments' && !c.already_documented && !c.command_uuid
+      );
+      let updated;
+      if (targetIdx >= 0) {
+        updated = prev
+          .map((c, i) => {
+            if (i !== targetIdx) return c;
+            const existing = (c.data?.narrative || '').trim();
+            const merged = existing ? `${existing}\n\n${item}` : item;
+            return { ...c, display: merged, data: { ...c.data, narrative: merged } };
+          })
+          .filter((_, i) => i !== index);
+      } else {
+        updated = prev.map((c, i) =>
+          i === index
+            ? { ...c, command_type: 'plan', section_key: 'appointments', display: item, data: { narrative: item } }
+            : c
+        );
+      }
       saveSummaryToCache(noteData, updated, false, { recommendations, unmatched_conditions: unmatchedConditions, diagnosis_suggestions: diagnosisSuggestions });
       return updated;
     });

--- a/hyperscribe/scribe/static/summary.js
+++ b/hyperscribe/scribe/static/summary.js
@@ -107,6 +107,52 @@ const _validationErrorMessage = (c, reason, context = 'approving') => {
   return `This command has invalid values. ${suffix}`;
 };
 
+// Normalize a condition/indication string for matching (drop trailing colon,
+// casefold) — mirrors _normalize in the backend _referral_diagnosis module.
+const _normalizeCondition = (t) => (t || '').trim().replace(/:+$/, '').trim().toLowerCase();
+
+// Batch B — referral re-linking at insert time. A referral generated while its
+// indication diagnosis was still uncoded comes through with no diagnosis_codes;
+// once the provider codes that diagnosis, copy the chosen ICD-10 code onto the
+// referral so it's commit-ready. Mirrors the backend link_referral_diagnoses, but
+// runs at approve time so it uses the provider's FINAL code. Mutates refer recs in
+// place (consistent with the insert flow); never fabricates — an indication that
+// matches no coded diagnosis is left untouched (and stays a blocked, review item).
+function relinkReferralDiagnoses(commands, recommendations) {
+  const table = new Map(); // normalized condition/display -> { code, display }
+  for (const c of commands || []) {
+    if (c.command_type !== 'diagnose') continue;
+    const d = c.data || {};
+    const code = (d.icd10_code || '').trim();
+    if (!code) continue;
+    const display = (d.icd10_display || '').trim();
+    for (const key of [_normalizeCondition(d.condition_header), _normalizeCondition(d._original_header), _normalizeCondition(display)]) {
+      if (key && !table.has(key)) table.set(key, { code, display });
+    }
+  }
+  if (table.size === 0) return;
+  const matchIndication = (indication) => {
+    const ind = _normalizeCondition(indication);
+    if (!ind) return null;
+    if (table.has(ind)) return table.get(ind);
+    for (const [key, val] of table) {
+      if (key && (ind.includes(key) || key.includes(ind))) return val;
+    }
+    return null;
+  };
+  for (const rec of recommendations || []) {
+    if (rec.command_type !== 'refer') continue;
+    const d = rec.data || {};
+    if (d.diagnosis_codes && d.diagnosis_codes.length > 0) continue; // already linked
+    const match = matchIndication(d.indication);
+    if (!match) continue;
+    d.diagnosis_codes = [match.code];
+    d.diagnosis_displays = [match.display || match.code];
+    d.diagnosis_formatted = [match.code];
+    rec.data = d;
+  }
+}
+
 function formatTime(ms) {
   const totalSeconds = Math.floor(ms / 1000);
   const minutes = Math.floor(totalSeconds / 60);
@@ -2327,6 +2373,15 @@ export function Scribe({ noteId, patientId, staffId, staffName, providerName, pr
         reason: !c.display ? 'empty_display' : c.selected === false ? 'deselected' : 'validation',
       })) });
     }
+    // Batch B — re-link referrals to the provider's final diagnosis code before
+    // validation, so a referral whose indication diagnosis was uncoded at generation
+    // time inherits the ICD-10 code once the provider picks it (mirrors the backend
+    // link_referral_diagnoses, but with the chosen code). Without this, an otherwise
+    // valid referral is dropped by the diagnosis_codes gate below and blocks approval.
+    // Referrals surface as either recommendation cards or plan-section commands, so
+    // re-link both target lists against the coded diagnose commands in workingCommands.
+    relinkReferralDiagnoses(workingCommands, recommendations);
+    relinkReferralDiagnoses(workingCommands, workingCommands);
     // The Approve filter for recommendations has to apply the same gates the
     // insertable filter applies for Rx + refer — recommendations bypass the
     // OrderRow editor, so without these checks an LLM payload that the

--- a/hyperscribe/scribe/static/summary.js
+++ b/hyperscribe/scribe/static/summary.js
@@ -425,7 +425,7 @@ function buildCommandBySectionKey(commands) {
   return map;
 }
 
-function renderSoapGroups(sections, commandBySectionKey, onEditCommand, onDeleteCommand, { adHocCommands, objectiveAdHocCommands, historyAdHocCommands, subjectiveAdHocCommands, chargeAdHocCommands, assignees, onAddTask, onAddOrder, onAddPlan, onAddMedication, onAddAllergy, onAddStopMedication, onAddRemoveAllergy, onAddResolveCondition, onAddHistory, onAddQuestionnaire, onAddCharge, onAddTemplateCharge, onRemoveChargeByCpt, templateCharges, readOnly, isAmending, sectionConditions, patientId, noteId, staffId, staffName, recommendations, onEditRecommendation, onDeleteRecommendation, onAcceptRecommendation, onRejectRecommendation, onAddCondition, unmatchedConditions, diagnosisSuggestions, onAddNow, onAddVitals, onAddPhysicalExam, onAddMentalStatusExam, hideRejected, alertFacilityEnabled, onEditingChange, questionnaireScores, chargeMatrixDiagnoses, chargeMatrixCharges, searchCharges, suggestedCharges, onToggleChargePointer, onReorderDiagnoses, onAddChargeModifier, onRemoveChargeModifier, onSetChargeComment, onClearChargeComment, onRemoveChargeByUuid, examTemplates, onCarryForwardExam, noteDiagnoses, isPsychiatry } = {}) {
+function renderSoapGroups(sections, commandBySectionKey, onEditCommand, onDeleteCommand, { adHocCommands, objectiveAdHocCommands, historyAdHocCommands, subjectiveAdHocCommands, chargeAdHocCommands, assignees, onAddTask, onAddOrder, onAddPlan, onMoveToPlan, onAddMedication, onAddAllergy, onAddStopMedication, onAddRemoveAllergy, onAddResolveCondition, onAddHistory, onAddQuestionnaire, onAddCharge, onAddTemplateCharge, onRemoveChargeByCpt, templateCharges, readOnly, isAmending, sectionConditions, patientId, noteId, staffId, staffName, recommendations, onEditRecommendation, onDeleteRecommendation, onAcceptRecommendation, onRejectRecommendation, onAddCondition, unmatchedConditions, diagnosisSuggestions, onAddNow, onAddVitals, onAddPhysicalExam, onAddMentalStatusExam, hideRejected, alertFacilityEnabled, onEditingChange, questionnaireScores, chargeMatrixDiagnoses, chargeMatrixCharges, searchCharges, suggestedCharges, onToggleChargePointer, onReorderDiagnoses, onAddChargeModifier, onRemoveChargeModifier, onSetChargeComment, onClearChargeComment, onRemoveChargeByUuid, examTemplates, onCarryForwardExam, noteDiagnoses, isPsychiatry } = {}) {
   return SOAP_GROUPS
     .map(group => {
       const matching = sections.filter(s => group.keys.has(s.key.toLowerCase()));
@@ -447,6 +447,7 @@ function renderSoapGroups(sections, commandBySectionKey, onEditCommand, onDelete
         onAddTask=${isPlan ? onAddTask : null}
         onAddOrder=${isPlan ? onAddOrder : null}
         onAddPlan=${isPlan ? onAddPlan : null}
+        onMoveToPlan=${isPlan ? onMoveToPlan : null}
         onAddVitals=${isObjective ? onAddVitals : null}
         onAddPhysicalExam=${isObjective ? onAddPhysicalExam : null}
         onAddMentalStatusExam=${isObjective ? onAddMentalStatusExam : null}
@@ -1738,6 +1739,31 @@ export function Scribe({ noteId, patientId, staffId, staffName, providerName, pr
     if (!canEdit) return;
     setCommands(prev => {
       const updated = prev.filter((_, i) => i !== index);
+      saveSummaryToCache(noteData, updated, false, { recommendations, unmatched_conditions: unmatchedConditions, diagnosis_suggestions: diagnosisSuggestions });
+      return updated;
+    });
+  }, [canEdit, noteData, saveSummaryToCache, recommendations, unmatchedConditions, diagnosisSuggestions]);
+
+  // Reclassify a diagnosis card as a plain plan narrative. Some A&P "problems" are
+  // really management/administrative items (e.g. "Physical therapy access", "Ear
+  // cleaning") that shouldn't carry an ICD-10 code; converting to a `plan` command
+  // preserves the documentation, drops the code requirement, and clears the uncoded-
+  // diagnosis hard block (every gate keys on command_type === 'diagnose'). One-way:
+  // to undo, delete and re-add. The header leads the narrative so the problem name
+  // survives as context.
+  const handleMoveToPlan = useCallback((index) => {
+    if (!canEdit) return;
+    logEvent('MOVE_DX_TO_PLAN', { index });
+    setCommands(prev => {
+      const updated = prev.map((c, i) => {
+        if (i !== index || c.command_type !== 'diagnose') return c;
+        const d = c.data || {};
+        const header = (d.condition_header || '').trim();
+        const body = (d.today_assessment || '').trim();
+        const narrative = header ? (body ? `${header}\n${body}` : header) : body;
+        // Replace `data` wholesale so ICD/accepted/suggestion fields don't linger.
+        return { ...c, command_type: 'plan', display: narrative, data: { narrative } };
+      });
       saveSummaryToCache(noteData, updated, false, { recommendations, unmatched_conditions: unmatchedConditions, diagnosis_suggestions: diagnosisSuggestions });
       return updated;
     });
@@ -3282,6 +3308,7 @@ export function Scribe({ noteId, patientId, staffId, staffName, providerName, pr
           onAddTask: canEdit ? handleAddTask : null,
           onAddOrder: canEdit ? handleAddOrder : null,
           onAddPlan: canEdit ? handleAddPlan : null,
+          onMoveToPlan: canEdit ? handleMoveToPlan : null,
           onAddVitals: canEdit ? handleAddVitals : null,
           onAddPhysicalExam: canEdit ? handleAddPhysicalExam : null,
           onAddMentalStatusExam: canEdit ? handleAddMentalStatusExam : null,

--- a/hyperscribe/scribe/static/summary.js
+++ b/hyperscribe/scribe/static/summary.js
@@ -93,6 +93,7 @@ const _commandValidationReason = (c) => {
   if (c.command_type === 'imaging_order') return 'imaging_incomplete';
   if (c.command_type === 'lab_order') return 'lab_incomplete';
   if (c.command_type === 'perform') return 'perform_incomplete';
+  if (c.command_type === 'diagnose' && !(c.data && c.data.icd10_code)) return 'diagnose_uncoded';
   return 'validation';
 };
 const _validationErrorMessage = (c, reason, context = 'approving') => {
@@ -102,6 +103,7 @@ const _validationErrorMessage = (c, reason, context = 'approving') => {
   if (reason === 'imaging_incomplete') return `This imaging order is missing required fields (image code, service provider, ordering provider, or diagnosis codes). ${suffix}`;
   if (reason === 'lab_incomplete') return `This lab order is missing required fields (lab partner or tests). ${suffix}`;
   if (reason === 'perform_incomplete') return `This perform command is missing a CPT code. ${suffix}`;
+  if (reason === 'diagnose_uncoded') return `This diagnosis needs an ICD-10 code. Pick one (or reject it) before ${context}.`;
   return `This command has invalid values. ${suffix}`;
 };
 
@@ -2305,6 +2307,11 @@ export function Scribe({ noteId, patientId, staffId, staffName, providerName, pr
       if (c.command_type === 'lab_order' && (!c.data.lab_partner || !c.data.tests_order_codes || c.data.tests_order_codes.length === 0)) return false;
       if (c.command_type === 'refer' && (!c.data.service_provider || !c.data.clinical_question || !c.data.notes_to_specialist || !c.data.diagnosis_codes || c.data.diagnosis_codes.length === 0)) return false;
       if (c.command_type === 'perform' && (!c.data.cpt_code || c.selected === false)) return false;
+      // Hard block: a surfaced diagnosis must carry an ICD-10 code before the note
+      // can be approved. The provider either codes it (via the picker) or rejects
+      // it. A coded diagnose that matched an active problem has already flipped to
+      // `assess` upstream (which is exempt — it carries condition_id, not a code).
+      if (c.command_type === 'diagnose' && !(c.data && c.data.icd10_code) && !(c.data && c.data.rejected)) return false;
       return true;
     });
     // Pre-existing finalized notes (signed before the explicit

--- a/hyperscribe/scribe/static/summary.js
+++ b/hyperscribe/scribe/static/summary.js
@@ -425,7 +425,7 @@ function buildCommandBySectionKey(commands) {
   return map;
 }
 
-function renderSoapGroups(sections, commandBySectionKey, onEditCommand, onDeleteCommand, { adHocCommands, objectiveAdHocCommands, historyAdHocCommands, subjectiveAdHocCommands, chargeAdHocCommands, assignees, onAddTask, onAddOrder, onAddPlan, onMoveToPlan, onAddMedication, onAddAllergy, onAddStopMedication, onAddRemoveAllergy, onAddResolveCondition, onAddHistory, onAddQuestionnaire, onAddCharge, onAddTemplateCharge, onRemoveChargeByCpt, templateCharges, readOnly, isAmending, sectionConditions, patientId, noteId, staffId, staffName, recommendations, onEditRecommendation, onDeleteRecommendation, onAcceptRecommendation, onRejectRecommendation, onAddCondition, unmatchedConditions, diagnosisSuggestions, onAddNow, onAddVitals, onAddPhysicalExam, onAddMentalStatusExam, hideRejected, alertFacilityEnabled, onEditingChange, questionnaireScores, chargeMatrixDiagnoses, chargeMatrixCharges, searchCharges, suggestedCharges, onToggleChargePointer, onReorderDiagnoses, onAddChargeModifier, onRemoveChargeModifier, onSetChargeComment, onClearChargeComment, onRemoveChargeByUuid, examTemplates, onCarryForwardExam, noteDiagnoses, isPsychiatry } = {}) {
+function renderSoapGroups(sections, commandBySectionKey, onEditCommand, onDeleteCommand, { adHocCommands, objectiveAdHocCommands, historyAdHocCommands, subjectiveAdHocCommands, chargeAdHocCommands, assignees, onAddTask, onAddOrder, onAddPlan, onMoveToPlan, onAddAppointment, onAddMedication, onAddAllergy, onAddStopMedication, onAddRemoveAllergy, onAddResolveCondition, onAddHistory, onAddQuestionnaire, onAddCharge, onAddTemplateCharge, onRemoveChargeByCpt, templateCharges, readOnly, isAmending, sectionConditions, patientId, noteId, staffId, staffName, recommendations, onEditRecommendation, onDeleteRecommendation, onAcceptRecommendation, onRejectRecommendation, onAddCondition, unmatchedConditions, diagnosisSuggestions, onAddNow, onAddVitals, onAddPhysicalExam, onAddMentalStatusExam, hideRejected, alertFacilityEnabled, onEditingChange, questionnaireScores, chargeMatrixDiagnoses, chargeMatrixCharges, searchCharges, suggestedCharges, onToggleChargePointer, onReorderDiagnoses, onAddChargeModifier, onRemoveChargeModifier, onSetChargeComment, onClearChargeComment, onRemoveChargeByUuid, examTemplates, onCarryForwardExam, noteDiagnoses, isPsychiatry } = {}) {
   return SOAP_GROUPS
     .map(group => {
       const matching = sections.filter(s => group.keys.has(s.key.toLowerCase()));
@@ -448,6 +448,7 @@ function renderSoapGroups(sections, commandBySectionKey, onEditCommand, onDelete
         onAddOrder=${isPlan ? onAddOrder : null}
         onAddPlan=${isPlan ? onAddPlan : null}
         onMoveToPlan=${isPlan ? onMoveToPlan : null}
+        onAddAppointment=${isPlan ? onAddAppointment : null}
         onAddVitals=${isObjective ? onAddVitals : null}
         onAddPhysicalExam=${isObjective ? onAddPhysicalExam : null}
         onAddMentalStatusExam=${isObjective ? onAddMentalStatusExam : null}
@@ -1744,13 +1745,13 @@ export function Scribe({ noteId, patientId, staffId, staffName, providerName, pr
     });
   }, [canEdit, noteData, saveSummaryToCache, recommendations, unmatchedConditions, diagnosisSuggestions]);
 
-  // Reclassify a diagnosis card as a plain plan narrative. Some A&P "problems" are
-  // really management/administrative items (e.g. "Physical therapy access", "Ear
-  // cleaning") that shouldn't carry an ICD-10 code; converting to a `plan` command
-  // preserves the documentation, drops the code requirement, and clears the uncoded-
-  // diagnosis hard block (every gate keys on command_type === 'diagnose'). One-way:
-  // to undo, delete and re-add. The header leads the narrative so the problem name
-  // survives as context.
+  // Reclassify a diagnosis card as a plan narrative in the Appointments component.
+  // Some A&P "problems" are really management/administrative items (e.g. "Physical
+  // therapy access", "Ear cleaning") that shouldn't carry an ICD-10 code; converting
+  // to a `plan` command in the `appointments` section preserves the documentation,
+  // drops the code requirement, and clears the uncoded-diagnosis hard block (every gate
+  // keys on command_type === 'diagnose'). One-way: to undo, delete and re-add. The
+  // header leads the narrative so the problem name survives as context.
   const handleMoveToPlan = useCallback((index) => {
     if (!canEdit) return;
     logEvent('MOVE_DX_TO_PLAN', { index });
@@ -1761,13 +1762,31 @@ export function Scribe({ noteId, patientId, staffId, staffName, providerName, pr
         const header = (d.condition_header || '').trim();
         const body = (d.today_assessment || '').trim();
         const narrative = header ? (body ? `${header}\n${body}` : header) : body;
-        // Replace `data` wholesale so ICD/accepted/suggestion fields don't linger.
-        return { ...c, command_type: 'plan', display: narrative, data: { narrative } };
+        // Replace `data` wholesale so ICD/accepted/suggestion fields don't linger, and
+        // move it into the Appointments component.
+        return { ...c, command_type: 'plan', section_key: 'appointments', display: narrative, data: { narrative } };
       });
       saveSummaryToCache(noteData, updated, false, { recommendations, unmatched_conditions: unmatchedConditions, diagnosis_suggestions: diagnosisSuggestions });
       return updated;
     });
   }, [canEdit, noteData, saveSummaryToCache, recommendations, unmatchedConditions, diagnosisSuggestions]);
+
+  // Promote the always-on blank Appointments placeholder into a real plan command when
+  // the provider types into it (mirrors handleAddPhysicalExam). Empty saves are ignored.
+  const handleAddAppointment = useCallback((data) => {
+    if (!canEdit) return;
+    const narrative = ((data && data.narrative) || '').trim();
+    if (!narrative) return;
+    logEvent('ADD_APPOINTMENT');
+    setCommands(prev => [...prev, {
+      command_type: 'plan',
+      display: narrative,
+      data: { narrative },
+      selected: true,
+      section_key: 'appointments',
+      already_documented: false,
+    }]);
+  }, [canEdit]);
 
   const handleAddTask = useCallback(() => {
     logEvent('ADD_TASK');
@@ -3073,6 +3092,10 @@ export function Scribe({ noteId, patientId, staffId, staffName, providerName, pr
   // the soap-group PE branch is reached and renders the documented card or the
   // empty "Click to add" editor, even when Nabla omits the section.
   ENSURE_KEYS.set('physical_exam', { key: 'physical_exam', title: 'Physical Exam', text: '' });
+  // Appointments is always ensured so its component renders even when empty — a
+  // persistent, editable destination for "Move to plan" and for manual appointment
+  // notes (soap-group appointments branch renders the items or the empty placeholder).
+  ENSURE_KEYS.set('appointments', { key: 'appointments', title: 'Appointments', text: '' });
   const effectiveSections = (() => {
     const base = noteData ? noteData.sections : SKELETON_SECTIONS;
     const existing = new Set(base.map(s => s.key.toLowerCase()));
@@ -3309,6 +3332,7 @@ export function Scribe({ noteId, patientId, staffId, staffName, providerName, pr
           onAddOrder: canEdit ? handleAddOrder : null,
           onAddPlan: canEdit ? handleAddPlan : null,
           onMoveToPlan: canEdit ? handleMoveToPlan : null,
+          onAddAppointment: canEdit ? handleAddAppointment : null,
           onAddVitals: canEdit ? handleAddVitals : null,
           onAddPhysicalExam: canEdit ? handleAddPhysicalExam : null,
           onAddMentalStatusExam: canEdit ? handleAddMentalStatusExam : null,

--- a/hyperscribe/scribe/static/summary.js
+++ b/hyperscribe/scribe/static/summary.js
@@ -1760,10 +1760,16 @@ export function Scribe({ noteId, patientId, staffId, staffName, providerName, pr
         if (i !== index || c.command_type !== 'diagnose') return c;
         const d = c.data || {};
         const header = (d.condition_header || '').trim();
-        const body = (d.today_assessment || '').trim();
-        const narrative = header ? (body ? `${header}\n${body}` : header) : body;
+        // today_assessment already leads with the headline (baked at generation). The
+        // card title should NOT travel to Wrap Up, so drop that leading header line and
+        // carry only the assessment body.
+        let narrative = (d.today_assessment || '').trim();
+        if (header && narrative.startsWith(header)) {
+          narrative = narrative.slice(header.length).replace(/^\n+/, '');
+        }
+        if (!narrative) narrative = header; // never produce an empty card
         // Replace `data` wholesale so ICD/accepted/suggestion fields don't linger, and
-        // move it into the Appointments component.
+        // move it into the Wrap Up (appointments) component.
         return { ...c, command_type: 'plan', section_key: 'appointments', display: narrative, data: { narrative } };
       });
       saveSummaryToCache(noteData, updated, false, { recommendations, unmatched_conditions: unmatchedConditions, diagnosis_suggestions: diagnosisSuggestions });
@@ -3095,7 +3101,7 @@ export function Scribe({ noteId, patientId, staffId, staffName, providerName, pr
   // Appointments is always ensured so its component renders even when empty — a
   // persistent, editable destination for "Move to plan" and for manual appointment
   // notes (soap-group appointments branch renders the items or the empty placeholder).
-  ENSURE_KEYS.set('appointments', { key: 'appointments', title: 'Appointments', text: '' });
+  ENSURE_KEYS.set('appointments', { key: 'appointments', title: 'Wrap Up', text: '' });
   const effectiveSections = (() => {
     const base = noteData ? noteData.sections : SKELETON_SECTIONS;
     const existing = new Set(base.map(s => s.key.toLowerCase()));

--- a/hyperscribe/scribe/static/summary.js
+++ b/hyperscribe/scribe/static/summary.js
@@ -111,40 +111,67 @@ const _validationErrorMessage = (c, reason, context = 'approving') => {
 // casefold) — mirrors _normalize in the backend _referral_diagnosis module.
 const _normalizeCondition = (t) => (t || '').trim().replace(/:+$/, '').trim().toLowerCase();
 
-// Batch B — referral re-linking at insert time. A referral generated while its
-// indication diagnosis was still uncoded comes through with no diagnosis_codes;
-// once the provider codes that diagnosis, copy the chosen ICD-10 code onto the
-// referral so it's commit-ready. Mirrors the backend link_referral_diagnoses, but
-// runs at approve time so it uses the provider's FINAL code. Mutates refer recs in
-// place (consistent with the insert flow); never fabricates — an indication that
-// matches no coded diagnosis is left untouched (and stays a blocked, review item).
-function relinkReferralDiagnoses(commands, recommendations) {
-  const table = new Map(); // normalized condition/display -> { code, display }
-  for (const c of commands || []) {
-    if (c.command_type !== 'diagnose') continue;
-    const d = c.data || {};
-    const code = (d.icd10_code || '').trim();
-    if (!code) continue;
-    const display = (d.icd10_display || '').trim();
-    for (const key of [_normalizeCondition(d.condition_header), _normalizeCondition(d._original_header), _normalizeCondition(display)]) {
-      if (key && !table.has(key)) table.set(key, { code, display });
-    }
+// Resolve a referral's indication to one of the note's coded diagnoses.
+// `noteDiags` is the note's coded-diagnosis set ({ code, display }); each entry
+// comes from a `diagnose` (icd10_code) OR an active-problem match that flipped to
+// `assess` (data.code). Resolution is deliberately conservative so a referral never
+// gets the WRONG code:
+//   - indication text present -> the UNIQUE note diagnosis whose name matches it
+//     (exact, then containment); ambiguous/no match -> null;
+//   - indication blank -> the sole coded diagnosis if there is exactly one, else null.
+// A null result leaves the referral uncoded for the provider to resolve via the
+// referral editor's indication picker. Shared by the live linker and the approve gate.
+function resolveReferralIndication(indication, noteDiags) {
+  const ind = _normalizeCondition(indication);
+  if (ind) {
+    const matches = (noteDiags || []).filter((d) => {
+      const name = _normalizeCondition(d.display);
+      const header = _normalizeCondition(d.condition_header);
+      const orig = _normalizeCondition(d._original_header);
+      return [name, header, orig].some((k) => k && (k === ind || k.includes(ind) || ind.includes(k)));
+    });
+    return matches.length === 1 ? matches[0] : null;
   }
-  if (table.size === 0) return;
-  const matchIndication = (indication) => {
-    const ind = _normalizeCondition(indication);
-    if (!ind) return null;
-    if (table.has(ind)) return table.get(ind);
-    for (const [key, val] of table) {
-      if (key && (ind.includes(key) || key.includes(ind))) return val;
-    }
-    return null;
-  };
-  for (const rec of recommendations || []) {
+  return (noteDiags || []).length === 1 ? noteDiags[0] : null;
+}
+
+// Build the note's coded-diagnosis set from the command list: every `diagnose` with
+// an ICD-10 code and every `assess` carrying a code (an active-problem match that
+// flipped to assess). Mirrors the chargeMatrixDiagnoses / noteDiagnoses source so the
+// approve-time linker sees exactly what the referral editor's picker sees.
+function codedNoteDiagnoses(commands) {
+  const diags = [];
+  for (const c of commands || []) {
+    if (c.command_type !== 'diagnose' && c.command_type !== 'assess') continue;
+    const d = c.data || {};
+    const code = (d.icd10_code || d.code || '').trim();
+    if (!code) continue;
+    diags.push({
+      code,
+      display: (d.icd10_display || d.label || c.display || '').trim(),
+      condition_header: d.condition_header || '',
+      _original_header: d._original_header || '',
+    });
+  }
+  return diags;
+}
+
+// Referral re-linking safety net at approve/insert time. A referral generated while
+// its indication diagnosis was still uncoded comes through with no diagnosis_codes;
+// resolve it against the note's coded diagnoses so it's commit-ready. The live linker
+// (useEffect) normally fills recommendation referrals during reconciliation; this also
+// covers plan-section referrals and any the effect hasn't reached. Mutates refer targets
+// in place (consistent with the insert flow); never fabricates and never overrides a
+// referral the provider has edited (_indicationTouched) or already coded.
+function relinkReferralDiagnoses(commands, targets) {
+  const noteDiags = codedNoteDiagnoses(commands);
+  if (noteDiags.length === 0) return;
+  for (const rec of targets || []) {
     if (rec.command_type !== 'refer') continue;
+    if (rec._indicationTouched) continue;
     const d = rec.data || {};
     if (d.diagnosis_codes && d.diagnosis_codes.length > 0) continue; // already linked
-    const match = matchIndication(d.indication);
+    const match = resolveReferralIndication(d.indication, noteDiags);
     if (!match) continue;
     d.diagnosis_codes = [match.code];
     d.diagnosis_displays = [match.display || match.code];
@@ -623,6 +650,74 @@ export function Scribe({ noteId, patientId, staffId, staffName, providerName, pr
       formatted_code: d.code,
       display: d.label,
     })), [chargeMatrixDiagnoses]);
+
+  // The note's coded diagnoses shaped for referral indication resolution — same
+  // accept filter as chargeMatrixDiagnoses, but carrying the condition headers so a
+  // referral's indication text can match the note's problem name (not just the ICD
+  // label). Includes assess-flipped active problems (they carry data.code, not
+  // data.icd10_code), which the referral linker must see.
+  const linkableNoteDiagnoses = useMemo(() => commands
+    .filter(c => (c.command_type === 'diagnose' || c.command_type === 'assess')
+      && (c.data?.icd10_code || c.data?.code) && c._localId
+      && (c.already_documented || c.command_uuid
+          || (c.command_type === 'assess' ? c.data?.accepted !== false : c.data?.accepted)))
+    .map(c => ({
+      code: c.data?.icd10_code || c.data?.code || '',
+      display: c.data?.icd10_display || c.data?.label || c.display || '',
+      condition_header: c.data?.condition_header || '',
+      _original_header: c.data?._original_header || '',
+    })), [commands]);
+
+  // Live referral re-linking during reconciliation. Referrals frequently arrive with
+  // a blank indication (the extraction LLM leaves it null when the note doesn't restate
+  // the problem near the referral sentence), so they land uncoded and would block
+  // approval. As the provider codes diagnoses — a `diagnose` gets an ICD-10 code, or an
+  // active-problem match flips to `assess` — fill each still-uncoded referral's
+  // diagnosis_codes as soon as it resolves UNAMBIGUOUSLY (unique name match, or the sole
+  // coded diagnosis when the indication is blank). Ambiguous cases are left for the
+  // referral editor's picker.
+  //
+  // Self-correcting: referrals we fill are tagged `_autoIndication` (a rec-level flag,
+  // never inside `data`, so it never reaches the insert payload). On every run we
+  // re-resolve those from scratch and REVERT them to uncoded if they've become ambiguous
+  // — otherwise a blank-indication referral would latch onto whichever diagnosis was
+  // coded first (transiently the "sole" one) and keep a stale/wrong code once more
+  // diagnoses appear. `_indicationTouched` marks referrals the provider has edited, so a
+  // deliberate choice (including a deliberate clear) is never touched. A referral with
+  // codes but neither flag was set some other way and is left alone. Guarded to no-op
+  // when nothing changes, so it can't loop on its own writes.
+  useEffect(() => {
+    setRecommendations(prev => {
+      let changed = false;
+      const next = prev.map(rec => {
+        if (rec.command_type !== 'refer' || rec._indicationTouched) return rec;
+        const d = rec.data || {};
+        const hasCodes = Boolean(d.diagnosis_codes && d.diagnosis_codes.length > 0);
+        const wasAuto = Boolean(rec._autoIndication);
+        if (hasCodes && !wasAuto) return rec; // provider/other-set — leave it
+        const match = resolveReferralIndication(d.indication, linkableNoteDiagnoses);
+        if (match) {
+          if (hasCodes && wasAuto && d.diagnosis_codes[0] === match.code) return rec; // already correct
+          changed = true;
+          return { ...rec, _autoIndication: true, data: { ...d,
+            diagnosis_codes: [match.code],
+            diagnosis_displays: [match.display || match.code],
+            diagnosis_formatted: [match.code],
+          } };
+        }
+        if (hasCodes && wasAuto) { // was auto-filled, now ambiguous → revert to picker
+          changed = true;
+          return { ...rec, _autoIndication: false, data: { ...d,
+            diagnosis_codes: [],
+            diagnosis_displays: [],
+            diagnosis_formatted: [],
+          } };
+        }
+        return rec;
+      });
+      return changed ? next : prev;
+    });
+  }, [linkableNoteDiagnoses, recommendations]);
 
   // Prune stale diagnosis pointers. When a linked diagnosis is rejected or removed
   // it leaves chargeMatrixDiagnoses, but its _localId lingers in charges' _pointers.
@@ -1792,7 +1887,10 @@ export function Scribe({ noteId, patientId, staffId, staffName, providerName, pr
         return { ...cmd, command_type: type, data: newData, display: newData.medication_text || '', accepted: true };
       }
       if (type === 'refer') {
-        return { ...cmd, command_type: type, data: newData, display: newData.refer_to_display || 'Referral', accepted: true };
+        // Provider has taken control of this referral (including its indication) —
+        // mark it so the live auto-linker never overrides their choice, even if they
+        // deliberately cleared the indication.
+        return { ...cmd, command_type: type, data: newData, display: newData.refer_to_display || 'Referral', accepted: true, _indicationTouched: true };
       }
       return { ...cmd, data: newData, accepted: true };
     }));

--- a/tests/hyperscribe/scribe/api/test_session_view.py
+++ b/tests/hyperscribe/scribe/api/test_session_view.py
@@ -4641,7 +4641,9 @@ def test_generate_summary_success(
     # Plan should have been split into diagnose commands.
     diagnose_cmds = [c for c in data["commands"] if c["command_type"] == "diagnose"]
     assert len(diagnose_cmds) == 1
-    assert diagnose_cmds[0]["data"]["icd10_code"] == "G43"
+    # Never auto-applied: uncoded, with the code surfaced as a picker suggestion.
+    assert diagnose_cmds[0]["data"]["icd10_code"] is None
+    assert any(s["formatted_code"] == "G43" for s in diagnose_cmds[0]["data"]["candidate_suggestions"])
     assert len(data["recommendations"]) == 1
     assert data["recommendations"][0]["command_type"] == "medication_statement"
     # Summary should be saved to database.
@@ -4736,12 +4738,14 @@ def test_generate_summary_prefers_patient_specific_icd10_over_nabla_parent(
     data = json.loads(result[0].content)
     diagnose_cmds = [c for c in data["commands"] if c["command_type"] == "diagnose"]
     assert len(diagnose_cmds) == 1, "Expected exactly one diagnose command from the A&P split."
-    # The Nabla-emitted E11.9 must have been rewritten to the patient-specific E11.65
-    # so the frontend belt can match against the active condition and convert to assess.
-    assert diagnose_cmds[0]["data"]["icd10_code"] == "E1165", (
-        "Expected the diagnose command to carry the patient-specific E11.65 code, "
-        f"got {diagnose_cmds[0]['data']['icd10_code']!r}. The Nabla E11.9 parent code "
-        "should have been rewritten before the A&P split picked it up."
+    # The Nabla-emitted E11.9 is rewritten to the patient-specific E11.65 so it leads the
+    # picker; never auto-applied — the card is uncoded and the provider picks E11.65 (which
+    # then flips to assess against the active condition at insert).
+    assert diagnose_cmds[0]["data"]["icd10_code"] is None
+    _formatted = [s["formatted_code"] for s in diagnose_cmds[0]["data"]["candidate_suggestions"]]
+    assert _formatted[0] == "E11.65", (
+        f"Expected the patient-specific E11.65 to lead the picker, got {_formatted!r}. "
+        "The Nabla E11.9 parent code should have been rewritten before the A&P split."
     )
 
     # _load_active_patient_conditions must be called with the patient_id from the request,
@@ -4815,7 +4819,9 @@ def test_generate_summary_empty_active_problem_list_leaves_nabla_code_intact(
     data = json.loads(result[0].content)
     diagnose_cmds = [c for c in data["commands"] if c["command_type"] == "diagnose"]
     assert len(diagnose_cmds) == 1
-    assert diagnose_cmds[0]["data"]["icd10_code"] == "R51"
+    # Never auto-applied: uncoded, with the Nabla code intact as a picker suggestion.
+    assert diagnose_cmds[0]["data"]["icd10_code"] is None
+    assert any(s["formatted_code"] == "R51" for s in diagnose_cmds[0]["data"]["candidate_suggestions"])
 
 
 @patch("hyperscribe.scribe.contacts.resolve_zip_codes", return_value=[])

--- a/tests/hyperscribe/scribe/api/test_session_view.py
+++ b/tests/hyperscribe/scribe/api/test_session_view.py
@@ -4629,7 +4629,10 @@ def test_generate_summary_success(
     view = _helper_instance()
     view.secrets["AnthropicAPIKey"] = "test-key"
     view.request = SimpleNamespace(body=json.dumps({"note_id": "55", "note_uuid": "55"}))
-    result = view.post_generate_summary()
+    # No more-specific options available -> the (3-char/unspecified) Nabla code is
+    # applied as-is rather than surfaced for a pick (decision: no one-option picker).
+    with patch("hyperscribe.scribe.api.session_view.CanvasScience.search_conditions", return_value=[]):
+        result = view.post_generate_summary()
 
     assert result[0].status_code == HTTPStatus.OK
     data = json.loads(result[0].content)
@@ -4803,7 +4806,10 @@ def test_generate_summary_empty_active_problem_list_leaves_nabla_code_intact(
     view = _helper_instance()
     view.secrets["AnthropicAPIKey"] = "test-key"
     view.request = SimpleNamespace(body=json.dumps({"note_id": "55", "note_uuid": "55", "patient_id": "patient-key-1"}))
-    result = view.post_generate_summary()
+    # Mock the science search empty so the unspecified/3-char Nabla code is applied
+    # as-is (no more-specific options to surface) — isolates the active-problem-list path.
+    with patch("hyperscribe.scribe.api.session_view.CanvasScience.search_conditions", return_value=[]):
+        result = view.post_generate_summary()
 
     assert result[0].status_code == HTTPStatus.OK
     data = json.loads(result[0].content)

--- a/tests/hyperscribe/scribe/commands/test_ap_split.py
+++ b/tests/hyperscribe/scribe/commands/test_ap_split.py
@@ -872,3 +872,43 @@ def test_split_plan_prefers_charted_specific_over_nabla_unspecified() -> None:
     updated, _ = split_plan_into_diagnoses(commands, section_conditions, chart_conditions=chart)
     assert updated[0]["data"]["icd10_code"] == "E11.65"
     assert updated[0]["data"]["condition_id"] == "cond-dm"
+
+
+def test_split_plan_surfaces_cross_family_chart_note_conflict() -> None:
+    """UAT regression: a stale active problem F32.1 (single episode) must not override
+    the encounter-documented F33.1 (recurrent). The card is left uncoded with both
+    options surfaced (chart + note provenance) for the provider to choose."""
+    header = "Major depressive disorder, recurrent, moderate to severe"
+    commands = [
+        {
+            "command_type": "plan",
+            "data": {"narrative": f"{header}\n- Increase sertraline"},
+            "section_key": "assessment_and_plan",
+        },
+    ]
+    section_conditions = {
+        "assessment_and_plan": [
+            {
+                "display": "Major depressive disorder, recurrent, moderate",
+                "coding": [{"code": "F33.1", "display": "Major depressive disorder, recurrent, moderate"}],
+                "corresponding_note_problem": header,
+            },
+        ],
+    }
+    chart = [
+        PatientConditionSnapshot(
+            condition_id="cond-mdd",
+            code="F32.1",
+            display="Major depressive disorder, single episode, moderate",
+            system="ICD-10",
+            clinical_status="active",
+            onset_date="2002-01-01",
+            resolution_date="",
+        )
+    ]
+    updated, _ = split_plan_into_diagnoses(commands, section_conditions, chart_conditions=chart)
+    data = updated[0]["data"]
+    assert data["icd10_code"] is None
+    provs = {s["provenance"] for s in data["candidate_suggestions"]}
+    assert "Active problem" in provs
+    assert "Detected in note" in provs

--- a/tests/hyperscribe/scribe/commands/test_ap_split.py
+++ b/tests/hyperscribe/scribe/commands/test_ap_split.py
@@ -11,6 +11,7 @@ from hyperscribe.scribe.commands.ap_split import (
     word_overlap,
 )
 from hyperscribe.scribe.commands.diagnosis_candidates import PatientConditionSnapshot
+from hyperscribe.structures.icd10_condition import Icd10Condition
 
 
 # --- parse_ap_blocks ---
@@ -912,3 +913,63 @@ def test_split_plan_surfaces_cross_family_chart_note_conflict() -> None:
     provs = {s["provenance"] for s in data["candidate_suggestions"]}
     assert "Active problem" in provs
     assert "Detected in note" in provs
+
+
+def test_split_plan_unspecified_with_refinements_left_uncoded() -> None:
+    """An unspecified code is NOT auto-applied when more-specific options exist: the
+    block is left uncoded and the picker offers the unspecified code first, then the
+    refinements (no `unspecified` flag, no auto-stamp)."""
+    commands = [
+        {"command_type": "plan", "data": {"narrative": "Insomnia\n- Trazodone"}, "section_key": "assessment_and_plan"},
+    ]
+    section_conditions = {
+        "assessment_and_plan": [
+            {
+                "display": "Insomnia, unspecified",
+                "coding": [{"code": "G47.00", "display": "Insomnia, unspecified"}],
+                "corresponding_note_problem": "Insomnia",
+            },
+        ],
+    }
+
+    def science(_expressions: list[str]) -> list[Icd10Condition]:
+        return [
+            Icd10Condition(code="G4700", label="Insomnia, unspecified"),
+            Icd10Condition(code="G4701", label="Insomnia due to medical condition"),
+            Icd10Condition(code="G4709", label="Other insomnia"),
+        ]
+
+    updated, _ = split_plan_into_diagnoses(commands, section_conditions, science_search=science)
+    data = updated[0]["data"]
+    assert data["icd10_code"] is None
+    assert "unspecified" not in data
+    formatted = [s["formatted_code"] for s in data["candidate_suggestions"]]
+    assert formatted[0] == "G47.00"  # unspecified offered first
+    assert "G47.01" in formatted and "G47.09" in formatted
+    assert data["candidate_suggestions"][0]["provenance"] == "Detected in note"
+    assert data["candidate_suggestions"][1]["provenance"] == "More specific option"
+
+
+def test_split_plan_unspecified_without_refinements_is_applied() -> None:
+    """When no more-specific option exists, the unspecified code is applied as-is —
+    no pointless one-option picker."""
+    commands = [
+        {
+            "command_type": "plan",
+            "data": {"narrative": "Hypothyroidism\n- Continue levothyroxine"},
+            "section_key": "assessment_and_plan",
+        },
+    ]
+    section_conditions = {
+        "assessment_and_plan": [
+            {
+                "display": "Hypothyroidism, unspecified",
+                "coding": [{"code": "E03.9", "display": "Hypothyroidism, unspecified"}],
+                "corresponding_note_problem": "Hypothyroidism",
+            },
+        ],
+    }
+    updated, _ = split_plan_into_diagnoses(commands, section_conditions, science_search=lambda _e: [])
+    data = updated[0]["data"]
+    assert data["icd10_code"] == "E03.9"
+    assert "candidate_suggestions" not in data

--- a/tests/hyperscribe/scribe/commands/test_ap_split.py
+++ b/tests/hyperscribe/scribe/commands/test_ap_split.py
@@ -224,6 +224,10 @@ def test_split_plan_into_diagnoses_basic() -> None:
     assert updated[2]["command_type"] == "diagnose"
     assert updated[2]["data"]["icd10_code"] == "I10"
     assert unmatched == []
+    # today_assessment leads with the original A&P headline (persisted for reference,
+    # inside the editable text), then the block body.
+    assert updated[1]["data"]["today_assessment"] == "Migraine\n- Start sumatriptan"
+    assert updated[2]["data"]["today_assessment"] == "Hypertension\n- Continue lisinopril"
 
 
 def test_split_plan_into_diagnoses_unmatched() -> None:

--- a/tests/hyperscribe/scribe/commands/test_ap_split.py
+++ b/tests/hyperscribe/scribe/commands/test_ap_split.py
@@ -10,6 +10,7 @@ from hyperscribe.scribe.commands.ap_split import (
     split_plan_into_diagnoses,
     word_overlap,
 )
+from hyperscribe.scribe.commands.diagnosis_candidates import PatientConditionSnapshot
 
 
 # --- parse_ap_blocks ---
@@ -753,3 +754,121 @@ def test_split_plan_no_stamp_when_icd_code_absent() -> None:
     assert updated[0]["command_type"] == "diagnose"
     assert updated[0]["data"]["icd10_code"] is None
     assert "condition_id" not in updated[0]["data"]
+
+
+# --- ICD-10 ranker integration (P2) ---
+
+
+def test_split_plan_stamps_stable_block_id() -> None:
+    commands = [
+        {
+            "command_type": "plan",
+            "data": {"narrative": "Migraine\n- Sumatriptan\n\nHypertension\n- Lisinopril"},
+            "section_key": "assessment_and_plan",
+        },
+    ]
+    section_conditions = {
+        "assessment_and_plan": [
+            {"display": "Migraine", "coding": [{"code": "G43.909", "display": "Migraine, unspecified"}]},
+            {"display": "Hypertension", "coding": [{"code": "I10", "display": "Essential hypertension"}]},
+        ],
+    }
+    updated, _ = split_plan_into_diagnoses(commands, section_conditions)
+    assert updated[0]["data"]["block_id"] == "apblock-0"
+    assert updated[1]["data"]["block_id"] == "apblock-1"
+
+
+def test_split_plan_ranks_definitive_over_incidental_symptom() -> None:
+    """The Jodie Foster regression in the belt's real shape: Nabla returns TWO
+    conditions for one A&P problem (same corresponding_note_problem) — a symptom
+    code listed first and the definitive code second. The ranker must pick the
+    definitive code and orphan nothing."""
+    header = "Major depressive disorder, recurrent, moderate to severe"
+    commands = [
+        {
+            "command_type": "plan",
+            "data": {"narrative": f"{header}\n- Increase sertraline"},
+            "section_key": "assessment_and_plan",
+        },
+    ]
+    suicidal = {
+        "display": "Suicidal ideations",
+        "coding": [{"code": "R45.851", "display": "Suicidal ideations"}],
+        "corresponding_note_problem": header,
+    }
+    depression = {
+        "display": "Major depressive disorder, recurrent, moderate",
+        "coding": [{"code": "F33.1", "display": "Major depressive disorder, recurrent, moderate"}],
+        "corresponding_note_problem": header,
+    }
+    section_conditions = {"assessment_and_plan": [suicidal, depression]}
+    updated, unmatched = split_plan_into_diagnoses(commands, section_conditions)
+    assert len(updated) == 1
+    assert updated[0]["data"]["icd10_code"] == "F33.1"
+    assert updated[0]["data"]["icd10_display"] == "Major depressive disorder, recurrent, moderate"
+    # No orphaning: both conditions were claimed by the block.
+    assert unmatched == []
+
+
+def test_split_plan_ambiguous_block_left_uncoded_with_suggestions() -> None:
+    header = "Headache"
+    commands = [
+        {"command_type": "plan", "data": {"narrative": f"{header}\n- Imaging"}, "section_key": "assessment_and_plan"},
+    ]
+    section_conditions = {
+        "assessment_and_plan": [
+            {
+                "display": "Vascular headache",
+                "coding": [{"code": "G44.1", "display": "Vascular headache, not elsewhere classified"}],
+                "corresponding_note_problem": header,
+            },
+            {
+                "display": "Tension-type headache",
+                "coding": [{"code": "G44.209", "display": "Tension-type headache, unspecified"}],
+                "corresponding_note_problem": header,
+            },
+        ],
+    }
+    updated, unmatched = split_plan_into_diagnoses(commands, section_conditions)
+    assert updated[0]["data"]["icd10_code"] is None
+    suggestions = updated[0]["data"]["candidate_suggestions"]
+    codes = {s["code"] for s in suggestions}
+    assert {"G44.1", "G44.209"} <= codes
+    assert all(s["provenance"] == "Detected in note" for s in suggestions)
+    assert unmatched == []
+
+
+def test_split_plan_prefers_charted_specific_over_nabla_unspecified() -> None:
+    """A more-specific code on the patient's chart beats Nabla's unspecified code,
+    and an active match stamps condition_id for the assess flip."""
+    header = "Type 2 diabetes mellitus"
+    commands = [
+        {
+            "command_type": "plan",
+            "data": {"narrative": f"{header}\n- Continue metformin"},
+            "section_key": "assessment_and_plan",
+        },
+    ]
+    section_conditions = {
+        "assessment_and_plan": [
+            {
+                "display": "Type 2 diabetes mellitus without complications",
+                "coding": [{"code": "E11.9", "display": "Type 2 diabetes mellitus without complications"}],
+                "corresponding_note_problem": header,
+            },
+        ],
+    }
+    chart = [
+        PatientConditionSnapshot(
+            condition_id="cond-dm",
+            code="E11.65",
+            display="Type 2 diabetes mellitus with hyperglycemia",
+            system="ICD-10",
+            clinical_status="active",
+            onset_date="2018-01-01",
+            resolution_date="",
+        )
+    ]
+    updated, _ = split_plan_into_diagnoses(commands, section_conditions, chart_conditions=chart)
+    assert updated[0]["data"]["icd10_code"] == "E11.65"
+    assert updated[0]["data"]["condition_id"] == "cond-dm"

--- a/tests/hyperscribe/scribe/commands/test_ap_split.py
+++ b/tests/hyperscribe/scribe/commands/test_ap_split.py
@@ -894,6 +894,12 @@ def test_split_plan_surfaces_cross_family_chart_note_conflict() -> None:
                 "coding": [{"code": "F33.1", "display": "Major depressive disorder, recurrent, moderate"}],
                 "corresponding_note_problem": header,
             },
+            # Nabla also attached an incidental symptom code to the same problem.
+            {
+                "display": "Suicidal ideations",
+                "coding": [{"code": "R45.851", "display": "Suicidal ideations"}],
+                "corresponding_note_problem": header,
+            },
         ],
     }
     chart = [
@@ -910,6 +916,10 @@ def test_split_plan_surfaces_cross_family_chart_note_conflict() -> None:
     updated, _ = split_plan_into_diagnoses(commands, section_conditions, chart_conditions=chart)
     data = updated[0]["data"]
     assert data["icd10_code"] is None
+    codes = {s["formatted_code"] for s in data["candidate_suggestions"]}
+    assert {"F32.1", "F33.1"} <= codes
+    # The incidental "Suicidal ideations" symptom code is NOT offered as a choice.
+    assert "R45.851" not in codes
     provs = {s["provenance"] for s in data["candidate_suggestions"]}
     assert "Active problem" in provs
     assert "Detected in note" in provs

--- a/tests/hyperscribe/scribe/commands/test_ap_split.py
+++ b/tests/hyperscribe/scribe/commands/test_ap_split.py
@@ -218,11 +218,14 @@ def test_split_plan_into_diagnoses_basic() -> None:
     updated, unmatched = split_plan_into_diagnoses(commands, section_conditions)
     assert len(updated) == 3  # rfv + 2 diagnose
     assert updated[0]["command_type"] == "rfv"
+    # Never auto-applied: every diagnose is uncoded; the code is surfaced as the top pick.
     assert updated[1]["command_type"] == "diagnose"
-    assert updated[1]["data"]["icd10_code"] == "G43.909"
+    assert updated[1]["data"]["icd10_code"] is None
     assert updated[1]["data"]["accepted"] is False
+    assert updated[1]["data"]["candidate_suggestions"][0]["formatted_code"] == "G43.909"
     assert updated[2]["command_type"] == "diagnose"
-    assert updated[2]["data"]["icd10_code"] == "I10"
+    assert updated[2]["data"]["icd10_code"] is None
+    assert updated[2]["data"]["candidate_suggestions"][0]["formatted_code"] == "I10"
     assert unmatched == []
     # today_assessment leads with the original A&P headline (persisted for reference,
     # inside the editable text), then the block body.
@@ -345,8 +348,9 @@ def test_split_plan_corresponding_note_problem() -> None:
     }
     updated, unmatched = split_plan_into_diagnoses(commands, section_conditions)
     assert len(updated) == 1
-    assert updated[0]["data"]["icd10_code"] == "J06.9"
+    assert updated[0]["data"]["icd10_code"] is None
     assert updated[0]["data"]["accepted"] is False
+    assert updated[0]["data"]["candidate_suggestions"][0]["formatted_code"] == "J06.9"
 
 
 def test_split_plan_strips_trailing_colon_from_split_by_problem_header() -> None:
@@ -377,7 +381,8 @@ def test_split_plan_strips_trailing_colon_from_split_by_problem_header() -> None
     }
     updated, unmatched = split_plan_into_diagnoses(commands, section_conditions)
     assert len(updated) == 1
-    assert updated[0]["data"]["icd10_code"] == "M75.41"
+    assert updated[0]["data"]["icd10_code"] is None
+    assert updated[0]["data"]["candidate_suggestions"][0]["formatted_code"] == "M75.41"
     # The stored header is colon-stripped, not "Right rotator cuff tendinitis:".
     assert updated[0]["data"]["condition_header"] == "Right rotator cuff tendinitis"
     assert unmatched == []
@@ -426,10 +431,12 @@ def test_split_plan_corresponding_note_problem_prevents_wrong_match() -> None:
     }
     updated, unmatched = split_plan_into_diagnoses(commands, section_conditions)
     assert len(updated) == 2
-    # Diarrhea gets R19.7, NOT D86.9
-    assert updated[0]["data"]["icd10_code"] == "R19.7"
-    # Sarcoidosis gets D86.9
-    assert updated[1]["data"]["icd10_code"] == "D86.9"
+    # Diarrhea surfaces R19.7, NOT D86.9
+    assert updated[0]["data"]["icd10_code"] is None
+    assert updated[0]["data"]["candidate_suggestions"][0]["formatted_code"] == "R19.7"
+    # Sarcoidosis surfaces D86.9
+    assert updated[1]["data"]["icd10_code"] is None
+    assert updated[1]["data"]["candidate_suggestions"][0]["formatted_code"] == "D86.9"
 
 
 def test_split_plan_corresponding_note_problem_case_insensitive() -> None:
@@ -452,7 +459,8 @@ def test_split_plan_corresponding_note_problem_case_insensitive() -> None:
     }
     updated, unmatched = split_plan_into_diagnoses(commands, section_conditions)
     assert len(updated) == 1
-    assert updated[0]["data"]["icd10_code"] == "J06.9"
+    assert updated[0]["data"]["icd10_code"] is None
+    assert updated[0]["data"]["candidate_suggestions"][0]["formatted_code"] == "J06.9"
 
 
 def test_split_plan_corresponding_note_problem_strips_whitespace() -> None:
@@ -475,7 +483,8 @@ def test_split_plan_corresponding_note_problem_strips_whitespace() -> None:
     }
     updated, unmatched = split_plan_into_diagnoses(commands, section_conditions)
     assert len(updated) == 1
-    assert updated[0]["data"]["icd10_code"] == "R51.9"
+    assert updated[0]["data"]["icd10_code"] is None
+    assert updated[0]["data"]["candidate_suggestions"][0]["formatted_code"] == "R51.9"
 
 
 # --- KOALA-5635: condition_id stamping on diagnose proposals ---
@@ -628,14 +637,11 @@ def test_build_active_condition_icd10_index_swallows_orm_errors() -> None:
     assert index == {}
 
 
-def test_split_plan_stamps_condition_id_when_icd_matches_active_condition() -> None:
-    """KOALA-5635: split_plan_into_diagnoses stamps ``data.condition_id``
-    on diagnose proposals whose ``icd10_code`` matches an active condition
-    on the note's patient.
-
-    This is what makes the per-(patient, condition) background carry-forward
-    eligible for rec-diagnose proposals — without ``condition_id``, the
-    carry_forward_assess_background helper short-circuits.
+def test_split_plan_never_stamps_condition_id() -> None:
+    """Codes are never auto-applied, so the belt never stamps ``condition_id`` — even when
+    the diagnosis matches an active condition on the note's patient. The code is surfaced
+    as the top picker option instead; the diagnose→assess flip now happens at insert time
+    when the provider-picked code matches the active problem list (summary.js).
     """
     commands = [
         {
@@ -657,36 +663,9 @@ def test_split_plan_stamps_condition_id_when_icd_matches_active_condition() -> N
         updated, _ = split_plan_into_diagnoses(commands, section_conditions, note=note)
     assert len(updated) == 1
     assert updated[0]["command_type"] == "diagnose"
-    assert updated[0]["data"]["icd10_code"] == "I10"
-    assert updated[0]["data"]["condition_id"] == "cond-htn"
-
-
-def test_split_plan_stamps_condition_id_normalizes_dots_and_case() -> None:
-    """The active-condition index lookup uses the same normalization as the
-    frontend handleInsert match step (strip dots, uppercase). A proposal
-    with ``icd10_code="e11.9"`` must match an active condition coded
-    ``E119`` and vice-versa.
-    """
-    commands = [
-        {
-            "command_type": "plan",
-            "data": {"narrative": "Type 2 diabetes\n- Continue metformin"},
-            "section_key": "assessment_and_plan",
-        },
-    ]
-    section_conditions = {
-        "assessment_and_plan": [
-            {"display": "Type 2 diabetes", "coding": [{"code": "E11.9", "display": "Type 2 diabetes"}]},
-        ],
-    }
-    note = MagicMock()
-    note.patient.id = "patient-key-1"
-    note.id = "note-uuid-1"
-    # Active condition stored WITHOUT the dot to prove the normalization.
-    rows = [("cond-dm2", "E119", "http://hl7.org/fhir/sid/icd-10-cm")]
-    with _patch_active_conditions_values_list(rows):
-        updated, _ = split_plan_into_diagnoses(commands, section_conditions, note=note)
-    assert updated[0]["data"]["condition_id"] == "cond-dm2"
+    assert updated[0]["data"]["icd10_code"] is None
+    assert "condition_id" not in updated[0]["data"]
+    assert updated[0]["data"]["candidate_suggestions"][0]["formatted_code"] == "I10"
 
 
 def test_split_plan_no_stamp_when_icd_does_not_match_active_condition() -> None:
@@ -809,8 +788,11 @@ def test_split_plan_ranks_definitive_over_incidental_symptom() -> None:
     section_conditions = {"assessment_and_plan": [suicidal, depression]}
     updated, unmatched = split_plan_into_diagnoses(commands, section_conditions)
     assert len(updated) == 1
-    assert updated[0]["data"]["icd10_code"] == "F33.1"
-    assert updated[0]["data"]["icd10_display"] == "Major depressive disorder, recurrent, moderate"
+    # Never auto-applied: uncoded, definitive F33.1 leads the picker, symptom code dropped.
+    assert updated[0]["data"]["icd10_code"] is None
+    codes = [s["formatted_code"] for s in updated[0]["data"]["candidate_suggestions"]]
+    assert codes[0] == "F33.1"  # definitive leads over the incidental symptom code
+    assert "R45.851" not in codes
     # No orphaning: both conditions were claimed by the block.
     assert unmatched == []
 
@@ -844,8 +826,9 @@ def test_split_plan_ambiguous_block_left_uncoded_with_suggestions() -> None:
 
 
 def test_split_plan_prefers_charted_specific_over_nabla_unspecified() -> None:
-    """A more-specific code on the patient's chart beats Nabla's unspecified code,
-    and an active match stamps condition_id for the assess flip."""
+    """A more-specific code on the patient's chart beats Nabla's unspecified code in the
+    ranked picker (it leads). Never auto-applied — the provider picks; the assess flip
+    happens at insert when the picked code matches the active problem."""
     header = "Type 2 diabetes mellitus"
     commands = [
         {
@@ -875,8 +858,10 @@ def test_split_plan_prefers_charted_specific_over_nabla_unspecified() -> None:
         )
     ]
     updated, _ = split_plan_into_diagnoses(commands, section_conditions, chart_conditions=chart)
-    assert updated[0]["data"]["icd10_code"] == "E11.65"
-    assert updated[0]["data"]["condition_id"] == "cond-dm"
+    assert updated[0]["data"]["icd10_code"] is None
+    assert "condition_id" not in updated[0]["data"]  # never auto-applied → no flip-stamp
+    codes = [s["formatted_code"] for s in updated[0]["data"]["candidate_suggestions"]]
+    assert codes[0] == "E11.65"  # charted specific leads over Nabla's E11.9
 
 
 def test_split_plan_surfaces_cross_family_chart_note_conflict() -> None:
@@ -1026,9 +1011,9 @@ def test_split_plan_science_fallback_uses_body_synonym() -> None:
     assert "M75.41" in [s["formatted_code"] for s in data["candidate_suggestions"]]
 
 
-def test_split_plan_unspecified_without_refinements_is_applied() -> None:
-    """When no more-specific option exists, the unspecified code is applied as-is —
-    no pointless one-option picker."""
+def test_split_plan_unspecified_without_refinements_surfaced() -> None:
+    """When no more-specific option exists, the unspecified code is surfaced as the single
+    picker option (never auto-applied)."""
     commands = [
         {
             "command_type": "plan",
@@ -1047,5 +1032,5 @@ def test_split_plan_unspecified_without_refinements_is_applied() -> None:
     }
     updated, _ = split_plan_into_diagnoses(commands, section_conditions, science_search=lambda _e: [])
     data = updated[0]["data"]
-    assert data["icd10_code"] == "E03.9"
-    assert "candidate_suggestions" not in data
+    assert data["icd10_code"] is None
+    assert data["candidate_suggestions"][0]["formatted_code"] == "E03.9"

--- a/tests/hyperscribe/scribe/commands/test_ap_split.py
+++ b/tests/hyperscribe/scribe/commands/test_ap_split.py
@@ -997,6 +997,31 @@ def test_split_plan_unspecified_ranks_documented_specificity_first() -> None:
     assert "F32.9" in formatted  # the unspecified is still offered, just not first
 
 
+def test_split_plan_science_fallback_uses_body_synonym() -> None:
+    """When Nabla emits no code for a block, the science fallback searches the
+    assessment body too, so a synonym there (impingement) recovers M75.4x that the
+    header ('tendinitis') alone would miss."""
+    header = "Right rotator cuff tendinitis"
+    commands = [
+        {
+            "command_type": "plan",
+            "data": {"narrative": f"{header}\n- Consistent with rotator cuff tendinitis or impingement. Refer ortho."},
+            "section_key": "assessment_and_plan",
+        },
+    ]
+    section_conditions: dict[str, list[dict[str, Any]]] = {"assessment_and_plan": []}
+
+    def science(expressions: list[str]) -> list[Icd10Condition]:
+        if any("impingement" in expression for expression in expressions):
+            return [Icd10Condition(code="M7541", label="Impingement syndrome of right shoulder")]
+        return []
+
+    updated, _ = split_plan_into_diagnoses(commands, section_conditions, science_search=science)
+    data = updated[0]["data"]
+    assert data["icd10_code"] is None
+    assert "M75.41" in [s["formatted_code"] for s in data["candidate_suggestions"]]
+
+
 def test_split_plan_unspecified_without_refinements_is_applied() -> None:
     """When no more-specific option exists, the unspecified code is applied as-is —
     no pointless one-option picker."""

--- a/tests/hyperscribe/scribe/commands/test_ap_split.py
+++ b/tests/hyperscribe/scribe/commands/test_ap_split.py
@@ -960,6 +960,43 @@ def test_split_plan_unspecified_with_refinements_left_uncoded() -> None:
     assert data["candidate_suggestions"][1]["provenance"] == "More specific option"
 
 
+def test_split_plan_unspecified_ranks_documented_specificity_first() -> None:
+    """Option B: when the note documents a specificity (e.g. 'moderate'), the matching
+    specific code leads the picker over the unspecified code Nabla emitted."""
+    header = "Major depressive disorder"
+    commands = [
+        {
+            "command_type": "plan",
+            "data": {"narrative": f"{header}\n- Moderate depression, PHQ-9 12. Start therapy."},
+            "section_key": "assessment_and_plan",
+        },
+    ]
+    section_conditions = {
+        "assessment_and_plan": [
+            {
+                "display": "Major depressive disorder, single episode, unspecified",
+                "coding": [{"code": "F32.9", "display": "Major depressive disorder, single episode, unspecified"}],
+                "corresponding_note_problem": header,
+            },
+        ],
+    }
+
+    def science(_expressions: list[str]) -> list[Icd10Condition]:
+        return [
+            Icd10Condition(code="F329", label="Major depressive disorder, single episode, unspecified"),
+            Icd10Condition(code="F320", label="Major depressive disorder, single episode, mild"),
+            Icd10Condition(code="F321", label="Major depressive disorder, single episode, moderate"),
+            Icd10Condition(code="F322", label="Major depressive disorder, single episode, severe"),
+        ]
+
+    updated, _ = split_plan_into_diagnoses(commands, section_conditions, science_search=science)
+    data = updated[0]["data"]
+    assert data["icd10_code"] is None
+    formatted = [s["formatted_code"] for s in data["candidate_suggestions"]]
+    assert formatted[0] == "F32.1"  # documented "moderate" leads
+    assert "F32.9" in formatted  # the unspecified is still offered, just not first
+
+
 def test_split_plan_unspecified_without_refinements_is_applied() -> None:
     """When no more-specific option exists, the unspecified code is applied as-is —
     no pointless one-option picker."""

--- a/tests/hyperscribe/scribe/commands/test_builder.py
+++ b/tests/hyperscribe/scribe/commands/test_builder.py
@@ -451,7 +451,11 @@ _GOOD_RX_DATA = {
 
 def test_validate_proposals_all_valid() -> None:
     proposals: list[dict[str, Any]] = [
-        {"command_type": "diagnose", "data": {"today_assessment": "Short text"}, "display": "Migraine"},
+        {
+            "command_type": "diagnose",
+            "data": {"icd10_code": "G43.909", "today_assessment": "Short text"},
+            "display": "Migraine",
+        },
         {"command_type": "assess", "data": {"narrative": "Brief"}, "display": "HTN"},
         # Prescribe / Refill / Adjust Prescription all share canvas-core's
         # Prescribe schema and need every required field populated to pass.
@@ -462,13 +466,27 @@ def test_validate_proposals_all_valid() -> None:
 
 def test_validate_proposals_diagnose_over_limit() -> None:
     proposals: list[dict[str, Any]] = [
-        {"command_type": "diagnose", "data": {"today_assessment": "x" * 2049}, "display": "Migraine"},
+        {
+            "command_type": "diagnose",
+            "data": {"icd10_code": "G43.909", "today_assessment": "x" * 2049},
+            "display": "Migraine",
+        },
     ]
     errors = validate_proposals(proposals)
     assert len(errors) == 1
     assert errors[0]["command_type"] == "diagnose"
     assert errors[0]["display"] == "Migraine"
     assert "2048" in errors[0]["errors"][0]
+
+
+def test_validate_proposals_diagnose_requires_code() -> None:
+    """Hard block on the insert path: an uncoded diagnose proposal is rejected."""
+    proposals: list[dict[str, Any]] = [
+        {"command_type": "diagnose", "data": {"today_assessment": "Short text"}, "display": "Migraine"},
+    ]
+    errors = validate_proposals(proposals)
+    assert len(errors) == 1
+    assert "ICD-10 code" in errors[0]["errors"][0]
 
 
 def test_validate_proposals_assess_over_limit() -> None:

--- a/tests/hyperscribe/scribe/commands/test_carry_forward.py
+++ b/tests/hyperscribe/scribe/commands/test_carry_forward.py
@@ -482,24 +482,17 @@ def test_split_plan_stamp_and_prefill_diagnose_background_integration() -> None:
         ],
     }
 
-    # Step 1: split — stamps condition_id on the produced diagnose proposal.
+    # Step 1: split never auto-codes now, so it does NOT stamp condition_id — the code
+    # is surfaced as a picker suggestion and the provider chooses it.
     updated, _ = split_plan_into_diagnoses(commands, section_conditions, note=current_note)
     assert len(updated) == 1
     assert updated[0]["command_type"] == "diagnose"
-    assert updated[0]["data"]["icd10_code"] == "I10"
-    assert updated[0]["data"]["condition_id"] == str(cond_htn.id), (
-        "split_plan_into_diagnoses must stamp the SDK condition_id (= "
-        "str(condition.id)) on the diagnose proposal when its icd10_code "
-        "matches an active condition on the patient. Without the stamp, "
-        "the per-(patient, condition) carry-forward short-circuits."
-    )
+    assert updated[0]["data"]["icd10_code"] is None
+    assert "condition_id" not in updated[0]["data"]
+    assert updated[0]["data"]["candidate_suggestions"][0]["formatted_code"] == "I10"
 
-    # Step 2: prefill — resolves the prior signed Assessment by (patient,
-    # condition_id) and writes its ``background`` onto the proposal.
+    # Step 2: with no condition_id on an uncoded proposal, background carry-forward is a
+    # no-op at generation (see note in the plan: never-auto-apply trades away the
+    # generation-time diagnose background prefill; picking the code clears background anyway).
     prefill_diagnose_backgrounds(updated, str(current_note.id))
-    assert updated[0]["data"]["background"] == "Diagnosed 2020-03-15; controlled on lisinopril 10mg", (
-        "prefill_diagnose_backgrounds must carry forward the prior "
-        "Assessment.background for the same (patient, condition). A typo in "
-        "the filter kwargs or a missing condition_id stamp would fail here "
-        "even though every mock-based unit test passes."
-    )
+    assert not updated[0]["data"].get("background")

--- a/tests/hyperscribe/scribe/commands/test_diagnose.py
+++ b/tests/hyperscribe/scribe/commands/test_diagnose.py
@@ -76,3 +76,17 @@ def test_command_type() -> None:
 def test_data_field_is_none() -> None:
     parser = DiagnoseParser()
     assert parser.data_field is None
+
+
+def test_validate_requires_icd10_code() -> None:
+    """Hard block: an uncoded diagnosis is rejected on the insert path."""
+    parser = DiagnoseParser()
+    assert "Diagnosis is missing an ICD-10 code" in parser.validate({"icd10_code": "", "today_assessment": "x"})
+    assert "Diagnosis is missing an ICD-10 code" in parser.validate({"today_assessment": "x"})
+    assert parser.validate({"icd10_code": "F33.1", "today_assessment": "x"}) == []
+
+
+def test_validate_flags_long_assessment() -> None:
+    parser = DiagnoseParser()
+    errors = parser.validate({"icd10_code": "F33.1", "today_assessment": "x" * 2049})
+    assert "Assessment text exceeds 2048 characters" in errors

--- a/tests/hyperscribe/scribe/commands/test_diagnosis_candidates.py
+++ b/tests/hyperscribe/scribe/commands/test_diagnosis_candidates.py
@@ -150,8 +150,9 @@ def test_provenance_labels() -> None:
     science = DiagnosisCandidate(code="F331", raw_code="F33.1", display="", source=CandidateSource.SCIENCE_SEARCH)
     more = DiagnosisCandidate(code="G4701", raw_code="G47.01", display="", source=CandidateSource.MORE_SPECIFIC)
     assert provenance_label(active) == "Active problem"
-    assert provenance_label(resolved) == "Resolved 2021"
-    assert provenance_label(remission) == "In remission"
+    # Every non-active status collapses to one catch-all tag.
+    assert provenance_label(resolved) == "Past condition"
+    assert provenance_label(remission) == "Past condition"
     assert provenance_label(nabla) == "Detected in note"
     assert provenance_label(science) == "ICD-10 search"
     assert provenance_label(more) == "More specific option"
@@ -294,19 +295,11 @@ def test_provenance_labels_full_status_matrix() -> None:
             code="F331", raw_code="F33.1", display="", source=CandidateSource.PRIOR_CONDITION, clinical_status=status
         )
 
-    assert provenance_label(prior("relapse")) == "Relapse"
-    assert provenance_label(prior("investigative")) == "Under investigation"
-    assert provenance_label(prior("")) == "Prior condition"
-    # Resolved with an unparseable date falls back to the bare label.
-    weird = DiagnosisCandidate(
-        code="F331",
-        raw_code="F33.1",
-        display="",
-        source=CandidateSource.PRIOR_CONDITION,
-        clinical_status="resolved",
-        resolution_date="unknown",
-    )
-    assert provenance_label(weird) == "Resolved"
+    # Every non-active clinical status maps to the single "Past condition" tag.
+    assert provenance_label(prior("relapse")) == "Past condition"
+    assert provenance_label(prior("investigative")) == "Past condition"
+    assert provenance_label(prior("resolved")) == "Past condition"
+    assert provenance_label(prior("")) == "Past condition"
     # Unknown source -> empty label.
     assert provenance_label(DiagnosisCandidate(code="F331", raw_code="F33.1", display="", source="mystery")) == ""
 

--- a/tests/hyperscribe/scribe/commands/test_diagnosis_candidates.py
+++ b/tests/hyperscribe/scribe/commands/test_diagnosis_candidates.py
@@ -181,12 +181,17 @@ def test_expand_unspecified_offers_specific_siblings() -> None:
             Icd10Condition(code="G4700", label="Insomnia, unspecified"),
             Icd10Condition(code="G4701", label="Insomnia due to medical condition"),
             Icd10Condition(code="G4709", label="Other insomnia"),
+            # Same 3-char family but a DIFFERENT sub-category — must be excluded
+            # (these are what showed up as noise in UAT).
+            Icd10Condition(code="G4733", label="Obstructive sleep apnea"),
+            Icd10Condition(code="G4763", label="Sleep related bruxism"),
         ]
 
     children = expand_unspecified(chosen, fake_search)
     codes = {child.code for child in children}
     assert "G4700" not in codes  # the unspecified bucket itself is excluded
-    assert {"G4701", "G4709"} <= codes
+    assert {"G4701", "G4709"} == codes  # only the G47.0x insomnia sub-category
+    assert "G4733" not in codes and "G4763" not in codes  # apnea/bruxism filtered out
     assert all(child.source == CandidateSource.MORE_SPECIFIC for child in children)
 
 
@@ -235,6 +240,52 @@ def test_rank_orders_definitive_above_symptom() -> None:
     ranked = rank_candidates(MDD_HEADER, candidates)
     assert ranked[0].code == "F331"
     assert ranked[-1].code == "R45851"
+
+
+def test_cross_family_chart_vs_note_conflict_is_ambiguous() -> None:
+    # UAT regression: the patient's stale active problem F32.1 ("single episode")
+    # must NOT auto-override the encounter's documented F33.1 ("recurrent"). Different
+    # ICD families + the note matches F33.1 better -> surface both, let provider pick.
+    nabla = _nabla_block(("F33.1", "Major depressive disorder, recurrent, moderate"))
+    chart = [
+        PatientConditionSnapshot(
+            condition_id="cond-mdd",
+            code="F32.1",
+            display="Major depressive disorder, single episode, moderate",
+            system="ICD-10",
+            clinical_status="active",
+            onset_date="2002-01-01",
+            resolution_date="",
+        )
+    ]
+    result = build_block_candidates("apblock-0", MDD_HEADER, nabla, chart=chart)
+    assert result.chosen is None
+    assert result.ambiguous is True
+    by_code = {c.code: c for c in result.candidates}
+    assert {"F321", "F331"} <= set(by_code)
+    assert provenance_label(by_code["F321"]) == "Active problem"
+    assert provenance_label(by_code["F331"]) == "Detected in note"
+
+
+def test_same_family_active_still_auto_applies() -> None:
+    # Guard against over-triggering: a same-family active code (more specific) still
+    # wins over Nabla's unspecified one — this is continuity, not a conflict.
+    nabla = _nabla_block(("E11.9", "Type 2 diabetes mellitus without complications"))
+    chart = [
+        PatientConditionSnapshot(
+            condition_id="cond-dm",
+            code="E11.65",
+            display="Type 2 diabetes mellitus with hyperglycemia",
+            system="ICD-10",
+            clinical_status="active",
+            onset_date="2018-01-01",
+            resolution_date="",
+        )
+    ]
+    result = build_block_candidates("apblock-0", "Type 2 diabetes mellitus", nabla, chart=chart)
+    assert result.chosen is not None
+    assert result.chosen.code == "E1165"
+    assert result.ambiguous is False
 
 
 def test_provenance_labels_full_status_matrix() -> None:

--- a/tests/hyperscribe/scribe/commands/test_diagnosis_candidates.py
+++ b/tests/hyperscribe/scribe/commands/test_diagnosis_candidates.py
@@ -14,6 +14,7 @@ callable returning ``Icd10Condition``-shaped objects.
 from __future__ import annotations
 
 from hyperscribe.scribe.commands.diagnosis_candidates import (
+    MAX_SURFACED_SUGGESTIONS,
     CandidateSource,
     DiagnosisCandidate,
     PatientConditionSnapshot,
@@ -24,6 +25,7 @@ from hyperscribe.scribe.commands.diagnosis_candidates import (
     is_unspecified_code,
     provenance_label,
     rank_candidates,
+    surface_candidates,
 )
 from hyperscribe.structures.icd10_condition import Icd10Condition
 
@@ -302,6 +304,28 @@ def test_provenance_labels_full_status_matrix() -> None:
     assert provenance_label(prior("")) == "Past condition"
     # Unknown source -> empty label.
     assert provenance_label(DiagnosisCandidate(code="F331", raw_code="F33.1", display="", source="mystery")) == ""
+
+
+def _cand(code: str, raw: str, display: str, source: str = CandidateSource.NABLA) -> DiagnosisCandidate:
+    return DiagnosisCandidate(code=code, raw_code=raw, display=display, source=source)
+
+
+def test_surface_candidates_drops_symptom_when_definitive_exists() -> None:
+    cands = [
+        _cand("F331", "F33.1", "MDD recurrent moderate"),
+        _cand("R45851", "R45.851", "Suicidal ideations"),
+    ]
+    # The incidental symptom code is not offered as a diagnosis to pick.
+    assert [c.code for c in surface_candidates(cands)] == ["F331"]
+
+
+def test_surface_candidates_keeps_symptom_when_it_is_the_only_option() -> None:
+    assert [c.code for c in surface_candidates([_cand("R197", "R19.7", "Diarrhea, unspecified")])] == ["R197"]
+
+
+def test_surface_candidates_caps_length() -> None:
+    cands = [_cand(f"E03{i}", f"E03.{i}", f"opt {i}", CandidateSource.MORE_SPECIFIC) for i in range(9)]
+    assert len(surface_candidates(cands)) == MAX_SURFACED_SUGGESTIONS
 
 
 def test_overlap_bucket_partial() -> None:

--- a/tests/hyperscribe/scribe/commands/test_diagnosis_candidates.py
+++ b/tests/hyperscribe/scribe/commands/test_diagnosis_candidates.py
@@ -161,16 +161,17 @@ def test_provenance_labels() -> None:
 
 
 def test_is_unspecified_code() -> None:
-    # Text-based (the reliable signal — numeric tail "00" is not distinguishable).
+    # Display text is the reliable signal.
     assert is_unspecified_code("G47.00", "Insomnia, unspecified") is True
-    assert is_unspecified_code("G4700") is False  # no display, numeric shape doesn't flag "00"
-    # Numeric backstop: bare root, root+9, root+9+digit.
+    assert is_unspecified_code("F33.9", "Major depressive disorder, recurrent, unspecified") is True
+    assert is_unspecified_code("G4700") is False  # no display -> numeric "00" not flagged
+    # Bare 3-char rubric (never independently billable).
     assert is_unspecified_code("E03") is True
-    assert is_unspecified_code("F33.9") is True
-    assert is_unspecified_code("E11.90") is True
-    # Specified codes are not unspecified.
+    # ".9"/"without X" default codes are NOT unspecified (display doesn't say so) — the
+    # relaxed rule avoids forcing needless refinement picks on these standard codes.
+    assert is_unspecified_code("E11.9", "Type 2 diabetes mellitus without complications") is False
+    assert is_unspecified_code("K21.9", "Gastro-esophageal reflux disease without esophagitis") is False
     assert is_unspecified_code("F33.1", "Major depressive disorder, recurrent, moderate") is False
-    assert is_unspecified_code("Z99.89", "Other dependence") is False
 
 
 def test_expand_unspecified_offers_specific_siblings() -> None:
@@ -196,6 +197,44 @@ def test_expand_unspecified_offers_specific_siblings() -> None:
     assert {"G4701", "G4709"} == codes  # only the G47.0x insomnia sub-category
     assert "G4733" not in codes and "G4763" not in codes  # apnea/bruxism filtered out
     assert all(child.source == CandidateSource.MORE_SPECIFIC for child in children)
+
+
+def test_expand_unspecified_drops_non_leaf_and_duplicate() -> None:
+    # E78.4 is a non-billable category parent of E78.41/E78.49 (and shares a display
+    # with E78.49) — it must not be offered as a selectable refinement.
+    chosen = DiagnosisCandidate(
+        code="E785", raw_code="E78.5", display="Hyperlipidemia, unspecified", source=CandidateSource.NABLA
+    )
+
+    def fake_search(_expressions: list[str]) -> list[Icd10Condition]:
+        return [
+            Icd10Condition(code="E784", label="Other hyperlipidemia"),
+            Icd10Condition(code="E7849", label="Other hyperlipidemia"),
+            Icd10Condition(code="E782", label="Mixed hyperlipidemia"),
+        ]
+
+    codes = {c.code for c in expand_unspecified(chosen, fake_search)}
+    assert "E784" not in codes  # non-leaf parent dropped
+    assert codes == {"E7849", "E782"}
+
+
+def test_science_fallback_recovers_code_via_body_synonym() -> None:
+    # Nabla emitted nothing for the block; the ICD display ("Impingement syndrome")
+    # doesn't match the header ("tendinitis") but the assessment body says "impingement".
+    header = "Right rotator cuff tendinitis"
+    context = f"{header}\nDiagnosis consistent with rotator cuff tendinitis or impingement."
+
+    def fake_search(expressions: list[str]) -> list[Icd10Condition]:
+        if any("impingement" in expression for expression in expressions):
+            return [Icd10Condition(code="M7541", label="Impingement syndrome of right shoulder")]
+        return []
+
+    result = build_block_candidates(
+        "apblock-0", header, nabla_for_block=[], chart=[], science_search=fake_search, context_text=context
+    )
+    codes = {c.code for c in result.candidates}
+    assert "M7541" in codes  # recovered via the body synonym
+    assert result.candidates[0].code == "M7541"  # ranked first by full-context overlap
 
 
 def test_expand_unspecified_scopes_four_char_code_to_family_root() -> None:

--- a/tests/hyperscribe/scribe/commands/test_diagnosis_candidates.py
+++ b/tests/hyperscribe/scribe/commands/test_diagnosis_candidates.py
@@ -198,6 +198,43 @@ def test_expand_unspecified_offers_specific_siblings() -> None:
     assert all(child.source == CandidateSource.MORE_SPECIFIC for child in children)
 
 
+def test_expand_unspecified_scopes_four_char_code_to_family_root() -> None:
+    # Fix: a 4-char unspecified code (E78.5 "Hyperlipidemia, unspecified") offers its
+    # 3-char-root siblings — previously the "E785" sub-bucket found nothing.
+    chosen = DiagnosisCandidate(
+        code="E785", raw_code="E78.5", display="Hyperlipidemia, unspecified", source=CandidateSource.NABLA
+    )
+
+    def fake_search(expressions: list[str]) -> list[Icd10Condition]:
+        assert expressions == ["E78"]
+        return [
+            Icd10Condition(code="E782", label="Mixed hyperlipidemia"),
+            Icd10Condition(code="E781", label="Pure hyperglyceridemia"),
+        ]
+
+    assert {c.code for c in expand_unspecified(chosen, fake_search)} == {"E782", "E781"}
+
+
+def test_expand_unspecified_ranks_by_note_context() -> None:
+    # The refinement the note documents ("moderate") leads over other siblings.
+    chosen = DiagnosisCandidate(
+        code="F329",
+        raw_code="F32.9",
+        display="Major depressive disorder, single episode, unspecified",
+        source=CandidateSource.NABLA,
+    )
+
+    def fake_search(_expressions: list[str]) -> list[Icd10Condition]:
+        return [
+            Icd10Condition(code="F320", label="Major depressive disorder, single episode, mild"),
+            Icd10Condition(code="F321", label="Major depressive disorder, single episode, moderate"),
+            Icd10Condition(code="F322", label="Major depressive disorder, single episode, severe"),
+        ]
+
+    children = expand_unspecified(chosen, fake_search, context_text="Moderate depression, PHQ-9 12.")
+    assert children[0].code == "F321"
+
+
 def test_science_search_only_is_never_auto_applied() -> None:
     # No chart, no Nabla coding -> science fallback fires but stays ambiguous.
     def fake_search(expressions: list[str]) -> list[Icd10Condition]:

--- a/tests/hyperscribe/scribe/commands/test_diagnosis_candidates.py
+++ b/tests/hyperscribe/scribe/commands/test_diagnosis_candidates.py
@@ -1,0 +1,317 @@
+"""Tests for the grounded ICD-10 candidate engine (``diagnosis_candidates``).
+
+The engine replaces the old first-match-wins code pick in the A&P belt. The
+canonical regression is the Jodie Foster note: Nabla emitted both ``R45.851``
+"Suicidal ideations" (a Chapter-18 symptom code, listed first) and ``F33.1`` for
+a single "Major depressive disorder, recurrent, moderate to severe" block. The
+old belt stamped R45.851 and orphaned F33.1; the engine must rank F33.1 first and
+never discard R45.851.
+
+These tests are pure — the only injected dependency is a fake ``science_search``
+callable returning ``Icd10Condition``-shaped objects.
+"""
+
+from __future__ import annotations
+
+from hyperscribe.scribe.commands.diagnosis_candidates import (
+    CandidateSource,
+    DiagnosisCandidate,
+    PatientConditionSnapshot,
+    _overlap_bucket,
+    assemble_block_candidates,
+    build_block_candidates,
+    expand_unspecified,
+    is_unspecified_code,
+    provenance_label,
+    rank_candidates,
+)
+from hyperscribe.structures.icd10_condition import Icd10Condition
+
+MDD_HEADER = "Major depressive disorder, recurrent, moderate to severe"
+
+
+def _nabla_block(*codings: tuple[str, str]) -> list[dict]:
+    """One Nabla condition dict whose ``coding`` is the given (code, display) pairs."""
+    return [{"display": "", "coding": [{"code": code, "display": display} for code, display in codings]}]
+
+
+# The Jodie Foster ordering: symptom code first, definitive code second.
+_JODIE_NABLA = _nabla_block(
+    ("R45.851", "Suicidal ideations"),
+    ("F33.1", "Major depressive disorder, recurrent, moderate"),
+)
+
+
+def test_f331_beats_r45851_no_chart() -> None:
+    result = build_block_candidates("apblock-0", MDD_HEADER, _JODIE_NABLA, chart=[])
+    assert result.chosen is not None
+    assert result.chosen.code == "F331"
+    assert result.ambiguous is False
+
+
+def test_f331_beats_r45851_with_active_f33() -> None:
+    chart = [
+        PatientConditionSnapshot(
+            condition_id="cond-1",
+            code="F33.1",
+            display="Major depressive disorder, recurrent, moderate",
+            system="ICD-10",
+            clinical_status="active",
+            onset_date="2010-01-01",
+            resolution_date="",
+        )
+    ]
+    result = build_block_candidates("apblock-0", MDD_HEADER, _JODIE_NABLA, chart=chart)
+    assert result.chosen is not None
+    assert result.chosen.code == "F331"
+    assert result.chosen.source == CandidateSource.ACTIVE_PROBLEM
+    # condition_id flows through so the diagnose->assess flip stays eligible.
+    assert result.chosen.condition_id == "cond-1"
+
+
+def test_no_orphan_symptom_code_survives_as_candidate() -> None:
+    result = build_block_candidates("apblock-0", MDD_HEADER, _JODIE_NABLA, chart=[])
+    codes = {candidate.code for candidate in result.candidates}
+    # F33.1 wins, but R45.851 is NOT discarded — it remains a (lower) candidate.
+    assert "F331" in codes
+    assert "R45851" in codes
+
+
+def test_ambiguous_two_definitive_codes_tie() -> None:
+    # Two genuinely different definitive codes, both overlapping the header equally.
+    nabla = _nabla_block(
+        ("G44.1", "Vascular headache"),
+        ("G44.209", "Tension-type headache"),
+    )
+    result = build_block_candidates("apblock-0", "Headache", nabla, chart=[])
+    assert result.chosen is None
+    assert result.ambiguous is True
+    # Both surfaced for the provider to choose.
+    codes = {candidate.code for candidate in result.candidates}
+    assert {"G441", "G44209"} <= codes
+
+
+def test_incidental_symptom_code_is_ambiguous() -> None:
+    # An R-code that does NOT match the header (incidental — the Jodie case where
+    # Nabla only emitted "Suicidal ideations" for a depression block) is surfaced,
+    # never auto-stamped as the diagnosis.
+    nabla = _nabla_block(("R45.851", "Suicidal ideations"))
+    result = build_block_candidates("apblock-0", MDD_HEADER, nabla, chart=[])
+    assert result.chosen is None
+    assert result.ambiguous is True
+
+
+def test_matching_symptom_code_is_applied() -> None:
+    # A symptom code that IS the documented problem (full header overlap) stays a
+    # legitimate primary diagnosis — auto-applied, not flagged.
+    nabla = _nabla_block(("R19.7", "Diarrhea, unspecified"))
+    result = build_block_candidates("apblock-0", "Diarrhea, unspecified", nabla, chart=[])
+    assert result.chosen is not None
+    assert result.chosen.code == "R197"
+    assert result.ambiguous is False
+
+
+def test_charted_specific_beats_nabla_unspecified() -> None:
+    # Nabla emits the unspecified parent; the patient's resolved-but-specific code wins.
+    nabla = _nabla_block(("E11.9", "Type 2 diabetes mellitus without complications"))
+    chart = [
+        PatientConditionSnapshot(
+            condition_id="cond-9",
+            code="E11.65",
+            display="Type 2 diabetes mellitus with hyperglycemia",
+            system="ICD-10",
+            clinical_status="resolved",
+            onset_date="2015-01-01",
+            resolution_date="2021-06-01",
+        )
+    ]
+    result = build_block_candidates("apblock-0", "Type 2 diabetes mellitus", nabla, chart=chart)
+    assert result.chosen is not None
+    assert result.chosen.code == "E1165"
+    assert result.chosen.source == CandidateSource.PRIOR_CONDITION
+    # Prior conditions never carry a flip-eligible condition_id (no SDK reactivation).
+    assert result.chosen.condition_id == ""
+
+
+def test_provenance_labels() -> None:
+    active = DiagnosisCandidate(code="F331", raw_code="F33.1", display="", source=CandidateSource.ACTIVE_PROBLEM)
+    resolved = DiagnosisCandidate(
+        code="F331",
+        raw_code="F33.1",
+        display="",
+        source=CandidateSource.PRIOR_CONDITION,
+        clinical_status="resolved",
+        resolution_date="2021-06-01",
+    )
+    remission = DiagnosisCandidate(
+        code="F331", raw_code="F33.1", display="", source=CandidateSource.PRIOR_CONDITION, clinical_status="remission"
+    )
+    nabla = DiagnosisCandidate(code="F331", raw_code="F33.1", display="", source=CandidateSource.NABLA)
+    science = DiagnosisCandidate(code="F331", raw_code="F33.1", display="", source=CandidateSource.SCIENCE_SEARCH)
+    more = DiagnosisCandidate(code="G4701", raw_code="G47.01", display="", source=CandidateSource.MORE_SPECIFIC)
+    assert provenance_label(active) == "Active problem"
+    assert provenance_label(resolved) == "Resolved 2021"
+    assert provenance_label(remission) == "In remission"
+    assert provenance_label(nabla) == "Detected in note"
+    assert provenance_label(science) == "ICD-10 search"
+    assert provenance_label(more) == "More specific option"
+
+
+def test_is_unspecified_code() -> None:
+    # Text-based (the reliable signal — numeric tail "00" is not distinguishable).
+    assert is_unspecified_code("G47.00", "Insomnia, unspecified") is True
+    assert is_unspecified_code("G4700") is False  # no display, numeric shape doesn't flag "00"
+    # Numeric backstop: bare root, root+9, root+9+digit.
+    assert is_unspecified_code("E03") is True
+    assert is_unspecified_code("F33.9") is True
+    assert is_unspecified_code("E11.90") is True
+    # Specified codes are not unspecified.
+    assert is_unspecified_code("F33.1", "Major depressive disorder, recurrent, moderate") is False
+    assert is_unspecified_code("Z99.89", "Other dependence") is False
+
+
+def test_expand_unspecified_offers_specific_siblings() -> None:
+    chosen = DiagnosisCandidate(
+        code="G4700", raw_code="G47.00", display="Insomnia, unspecified", source=CandidateSource.NABLA
+    )
+
+    def fake_search(expressions: list[str]) -> list[Icd10Condition]:
+        assert expressions == ["G47"]  # searched by family root
+        return [
+            Icd10Condition(code="G4700", label="Insomnia, unspecified"),
+            Icd10Condition(code="G4701", label="Insomnia due to medical condition"),
+            Icd10Condition(code="G4709", label="Other insomnia"),
+        ]
+
+    children = expand_unspecified(chosen, fake_search)
+    codes = {child.code for child in children}
+    assert "G4700" not in codes  # the unspecified bucket itself is excluded
+    assert {"G4701", "G4709"} <= codes
+    assert all(child.source == CandidateSource.MORE_SPECIFIC for child in children)
+
+
+def test_science_search_only_is_never_auto_applied() -> None:
+    # No chart, no Nabla coding -> science fallback fires but stays ambiguous.
+    def fake_search(expressions: list[str]) -> list[Icd10Condition]:
+        return [Icd10Condition(code="J069", label="Acute upper respiratory infection, unspecified")]
+
+    result = build_block_candidates(
+        "apblock-0", "Upper respiratory infection", nabla_for_block=[], chart=[], science_search=fake_search
+    )
+    assert result.chosen is None
+    assert result.ambiguous is True
+    assert any(c.source == CandidateSource.SCIENCE_SEARCH for c in result.candidates)
+
+
+def test_no_candidates_is_uncoded_not_ambiguous() -> None:
+    result = build_block_candidates("apblock-0", "Some freetext header", nabla_for_block=[], chart=[])
+    assert result.chosen is None
+    assert result.ambiguous is False
+    assert result.candidates == []
+
+
+def test_assemble_dedupes_to_highest_trust_source() -> None:
+    # Same code from Nabla and the active problem list -> keep the active one.
+    nabla = _nabla_block(("F33.1", "Major depressive disorder, recurrent, moderate"))
+    chart = [
+        PatientConditionSnapshot(
+            condition_id="cond-1",
+            code="F33.1",
+            display="Major depressive disorder, recurrent, moderate",
+            system="ICD-10",
+            clinical_status="active",
+            onset_date="",
+            resolution_date="",
+        )
+    ]
+    candidates = assemble_block_candidates(MDD_HEADER, nabla, chart)
+    f331 = [c for c in candidates if c.code == "F331"]
+    assert len(f331) == 1
+    assert f331[0].source == CandidateSource.ACTIVE_PROBLEM
+
+
+def test_rank_orders_definitive_above_symptom() -> None:
+    candidates = assemble_block_candidates(MDD_HEADER, _JODIE_NABLA, chart=[])
+    ranked = rank_candidates(MDD_HEADER, candidates)
+    assert ranked[0].code == "F331"
+    assert ranked[-1].code == "R45851"
+
+
+def test_provenance_labels_full_status_matrix() -> None:
+    def prior(status: str) -> DiagnosisCandidate:
+        return DiagnosisCandidate(
+            code="F331", raw_code="F33.1", display="", source=CandidateSource.PRIOR_CONDITION, clinical_status=status
+        )
+
+    assert provenance_label(prior("relapse")) == "Relapse"
+    assert provenance_label(prior("investigative")) == "Under investigation"
+    assert provenance_label(prior("")) == "Prior condition"
+    # Resolved with an unparseable date falls back to the bare label.
+    weird = DiagnosisCandidate(
+        code="F331",
+        raw_code="F33.1",
+        display="",
+        source=CandidateSource.PRIOR_CONDITION,
+        clinical_status="resolved",
+        resolution_date="unknown",
+    )
+    assert provenance_label(weird) == "Resolved"
+    # Unknown source -> empty label.
+    assert provenance_label(DiagnosisCandidate(code="F331", raw_code="F33.1", display="", source="mystery")) == ""
+
+
+def test_overlap_bucket_partial() -> None:
+    assert _overlap_bucket("left knee pain swelling", "knee pain stiffness") == 1
+    assert _overlap_bucket("Headache", "Headache") == 2
+    assert _overlap_bucket("Diabetes", "Suicidal ideations") == 0
+
+
+def test_assemble_skips_malformed_codings_and_snapshots() -> None:
+    nabla = [
+        {
+            "display": "",
+            "coding": [
+                {"code": "", "display": "blank code"},  # skipped: no code
+                {"display": "no code key"},  # skipped: no code
+                {"code": "F33.1", "display": "Major depressive disorder, recurrent, moderate"},
+            ],
+        }
+    ]
+    chart = [
+        PatientConditionSnapshot("c0", "", "Empty code", "ICD-10", "active", "", ""),  # skipped: no code
+        PatientConditionSnapshot("c1", "K21.9", "GERD", "ICD-10", "active", "", ""),  # skipped: no match
+    ]
+    candidates = assemble_block_candidates(MDD_HEADER, nabla, chart)
+    codes = {c.code for c in candidates}
+    assert codes == {"F331"}
+
+
+def test_assemble_survives_science_outage() -> None:
+    def boom(_expressions: list[str]) -> list:
+        raise RuntimeError("science down")
+
+    result = build_block_candidates("apblock-0", "Sciatica", nabla_for_block=[], chart=[], science_search=boom)
+    assert result.candidates == []
+    assert result.chosen is None
+    assert result.ambiguous is False
+
+
+def test_expand_unspecified_survives_science_outage_and_filters_family() -> None:
+    chosen = DiagnosisCandidate(
+        code="E039", raw_code="E03.9", display="Hypothyroidism, unspecified", source=CandidateSource.NABLA
+    )
+
+    def boom(_expressions: list[str]) -> list:
+        raise RuntimeError("science down")
+
+    assert expand_unspecified(chosen, boom) == []
+    assert expand_unspecified(chosen, None) == []
+
+    def cross_family(_expressions: list[str]) -> list[Icd10Condition]:
+        return [
+            Icd10Condition(code="E030", label="Postsurgical hypothyroidism"),  # same family, specific -> kept
+            Icd10Condition(code="E1165", label="Type 2 diabetes with hyperglycemia"),  # other family -> dropped
+        ]
+
+    children = expand_unspecified(chosen, cross_family)
+    assert {c.code for c in children} == {"E030"}

--- a/tests/hyperscribe/scribe/recommendations/test_diagnosis_llm_resolver.py
+++ b/tests/hyperscribe/scribe/recommendations/test_diagnosis_llm_resolver.py
@@ -1,0 +1,240 @@
+"""Tests for the grounded-LLM diagnosis resolver.
+
+The resolver is an oracle over a RETRIEVED set of real ICD-10 codes: it may only
+select codes present in the pool (belt suggestions + science-search hits), and it
+expands the search when nothing provided fits. These tests assert the anti-
+hallucination gate, the auto-apply-only-on-high-confidence policy, the adaptive
+expansion round, and best-effort failure handling — all with a fake LLM client and
+an injected fake science search (no network).
+"""
+
+from __future__ import annotations
+
+import json
+from http import HTTPStatus
+from typing import Any
+
+from hyperscribe.scribe.recommendations.diagnosis_llm_resolver import (
+    BlockContext,
+    resolve_uncoded_blocks,
+)
+from hyperscribe.structures.icd10_condition import Icd10Condition
+
+
+class _Resp:
+    def __init__(self, response: str, code: HTTPStatus = HTTPStatus.OK) -> None:
+        self.code = code
+        self.response = response
+
+
+class _FakeClient:
+    """Returns queued structured responses in order; optionally raises on request()."""
+
+    def __init__(self, responses: list[_Resp], raise_on_request: bool = False) -> None:
+        self._responses = list(responses)
+        self._raise = raise_on_request
+
+    def reset_prompts(self) -> None: ...
+    def set_system_prompt(self, _prompt: Any) -> None: ...
+    def set_user_prompt(self, _prompt: Any) -> None: ...
+    def set_schema(self, _schema: Any) -> None: ...
+
+    def request(self) -> _Resp:
+        if self._raise:
+            raise RuntimeError("boom")
+        assert self._responses, "no more queued responses"
+        return self._responses.pop(0)
+
+
+def _step(
+    selected: str | None = None,
+    confidence: str = "low",
+    ranked: list[str] | None = None,
+    terms: list[str] | None = None,
+    code: HTTPStatus = HTTPStatus.OK,
+) -> _Resp:
+    # BaseModelLlmJson camelCases field aliases (extra="forbid"), so the LLM's JSON —
+    # and therefore these fixtures — must use camelCase keys.
+    return _Resp(
+        json.dumps(
+            {
+                "selectedCode": selected,
+                "confidence": confidence,
+                "rankedCodes": ranked or [],
+                "moreSearchTerms": terms or [],
+            }
+        ),
+        code=code,
+    )
+
+
+def _candidate(code: str, formatted: str, display: str, provenance: str = "Detected in note") -> dict[str, str]:
+    return {"code": code, "formatted_code": formatted, "display": display, "provenance": provenance}
+
+
+def _factory(client: _FakeClient) -> Any:
+    return lambda: client
+
+
+def _no_science(_terms: list[str]) -> list[Icd10Condition]:
+    return []
+
+
+def test_selects_from_provided_high_confidence_auto_applies() -> None:
+    block = BlockContext(
+        block_id="apblock-1",
+        header="Edema in lower extremities",
+        body="Edema in legs may be exacerbated by high sodium intake.",
+        candidates=[_candidate("R60.0", "R60.0", "Localized edema")],
+    )
+    client = _FakeClient([_step(selected="R60.0", confidence="high", ranked=["R60.0"])])
+    out = resolve_uncoded_blocks([block], _factory(client), _no_science)
+
+    assert out["apblock-1"].chosen == ("R60.0", "Localized edema")
+    assert out["apblock-1"].confidence == "high"
+
+
+def test_expands_when_nothing_provided_then_selects() -> None:
+    # "Fluid overload" — belt found nothing; the LLM asks for a search, science grounds
+    # E87.70, and the LLM selects it. Demonstrates the no-code-when-one-exists fix.
+    block = BlockContext(
+        block_id="apblock-0",
+        header="Fluid overload and pulmonary symptoms",
+        body="Fluid overload with pulmonary symptoms, managed with oxygen therapy.",
+        candidates=[],
+    )
+    science_calls: list[list[str]] = []
+
+    def science(terms: list[str]) -> list[Icd10Condition]:
+        science_calls.append(terms)
+        return [Icd10Condition(code="E8770", label="Fluid overload, unspecified")]
+
+    client = _FakeClient(
+        [
+            _step(terms=["fluid overload", "pulmonary edema"]),  # round 1: expand
+            _step(selected="E87.70", confidence="high", ranked=["E87.70"]),  # round 2: select
+        ]
+    )
+    out = resolve_uncoded_blocks([block], _factory(client), science)
+
+    assert science_calls == [["fluid overload", "pulmonary edema"]]
+    assert out["apblock-0"].chosen == ("E87.70", "Fluid overload, unspecified")
+
+
+def test_rejects_clinically_wrong_provided_and_expands() -> None:
+    # "Protein intake" seeded with the inverted lexical hit E67.8 (hyperalimentation).
+    # The LLM must NOT select it; it expands to hypoalbuminemia and picks E88.09.
+    block = BlockContext(
+        block_id="apblock-2",
+        header="Protein intake",
+        body="Albumin is slightly low, indicating need for increased dietary protein.",
+        candidates=[_candidate("E678", "E67.8", "Other specified hyperalimentation", "ICD-10 search")],
+    )
+
+    def science(_terms: list[str]) -> list[Icd10Condition]:
+        return [Icd10Condition(code="E8809", label="Hypoalbuminemia")]
+
+    client = _FakeClient(
+        [
+            _step(terms=["hypoalbuminemia"]),  # rejects E67.8, expands
+            _step(selected="E88.09", confidence="high", ranked=["E88.09"]),
+        ]
+    )
+    out = resolve_uncoded_blocks([block], _factory(client), science)
+
+    assert out["apblock-2"].chosen == ("E88.09", "Hypoalbuminemia")
+    # The inverted code was never chosen.
+    assert out["apblock-2"].chosen != ("E67.8", "Other specified hyperalimentation")
+
+
+def test_wrong_family_refinement_expands_to_correct_family() -> None:
+    # "Anemia" seeded with D64.9 (unspecified). The LLM expands to iron-deficiency and
+    # picks D50.9 — the note-indicated family — instead of the D64 siblings.
+    block = BlockContext(
+        block_id="apblock-3",
+        header="Anemia",
+        body="Mild anemia present. Iron deficiency to be considered.",
+        candidates=[_candidate("D64.9", "D64.9", "Anemia, unspecified")],
+    )
+
+    def science(_terms: list[str]) -> list[Icd10Condition]:
+        return [Icd10Condition(code="D509", label="Iron deficiency anemia, unspecified")]
+
+    client = _FakeClient(
+        [
+            _step(terms=["iron deficiency anemia"]),
+            _step(selected="D50.9", confidence="high", ranked=["D50.9", "D64.9"]),
+        ]
+    )
+    out = resolve_uncoded_blocks([block], _factory(client), science)
+
+    assert out["apblock-3"].chosen == ("D50.9", "Iron deficiency anemia, unspecified")
+
+
+def test_hallucinated_code_is_rejected() -> None:
+    # The LLM returns a code that is NOT in the pool and offers no search terms.
+    # Nothing survives the gate -> no resolution (belt output preserved).
+    block = BlockContext(
+        block_id="apblock-9",
+        header="Some problem",
+        body="",
+        candidates=[_candidate("R60.0", "R60.0", "Localized edema")],
+    )
+    client = _FakeClient([_step(selected="Z99.9", confidence="high", ranked=["Z99.9"])])
+    out = resolve_uncoded_blocks([block], _factory(client), _no_science)
+
+    assert "apblock-9" not in out
+
+
+def test_medium_confidence_surfaces_not_auto_applied() -> None:
+    block = BlockContext(
+        block_id="apblock-4",
+        header="Anemia",
+        body="Mild anemia.",
+        candidates=[
+            _candidate("D64.9", "D64.9", "Anemia, unspecified"),
+            _candidate("D501", "D50.1", "Sideropenic dysphagia"),
+        ],
+    )
+    client = _FakeClient([_step(selected="D64.9", confidence="medium", ranked=["D64.9", "D50.1"])])
+    out = resolve_uncoded_blocks([block], _factory(client), _no_science)
+
+    res = out["apblock-4"]
+    assert res.chosen is None  # medium never auto-applies
+    assert [s["formatted_code"] for s in res.suggestions] == ["D64.9", "D50.1"]
+
+
+def test_suggestions_drop_out_of_pool_ranked_codes() -> None:
+    # A ranked code not in the pool is filtered out; the in-pool one survives.
+    block = BlockContext(
+        block_id="apblock-5",
+        header="Anemia",
+        body="",
+        candidates=[_candidate("D64.9", "D64.9", "Anemia, unspecified")],
+    )
+    client = _FakeClient([_step(selected="D64.9", confidence="medium", ranked=["D64.9", "FAKE99"])])
+    out = resolve_uncoded_blocks([block], _factory(client), _no_science)
+
+    codes = [s["formatted_code"] for s in out["apblock-5"].suggestions]
+    assert codes == ["D64.9"]
+
+
+def test_best_effort_on_client_error_yields_no_resolution() -> None:
+    block = BlockContext(block_id="apblock-6", header="X", body="", candidates=[])
+    client = _FakeClient([], raise_on_request=True)
+    out = resolve_uncoded_blocks([block], _factory(client), _no_science)
+
+    assert out == {}
+
+
+def test_no_selection_no_terms_gives_up() -> None:
+    block = BlockContext(
+        block_id="apblock-7",
+        header="Physical therapy access",
+        body="Difficulty accessing home health PT.",
+        candidates=[],
+    )
+    client = _FakeClient([_step(selected=None, confidence="low")])
+    out = resolve_uncoded_blocks([block], _factory(client), _no_science)
+
+    assert "apblock-7" not in out

--- a/tests/hyperscribe/scribe/recommendations/test_diagnosis_llm_resolver.py
+++ b/tests/hyperscribe/scribe/recommendations/test_diagnosis_llm_resolver.py
@@ -171,6 +171,32 @@ def test_wrong_family_refinement_expands_to_correct_family() -> None:
     assert out["apblock-3"].chosen == ("D50.9", "Iron deficiency anemia, unspecified")
 
 
+def test_managed_condition_codes_the_underlying_diagnosis() -> None:
+    # "Vitamin D supplementation" with a normal-on-treatment level is an actively managed
+    # deficiency, not "no diagnosis": the LLM expands to the underlying condition and codes
+    # E55.9 rather than leaving the block uncoded.
+    block = BlockContext(
+        block_id="apblock-4",
+        header="Vitamin D supplementation",
+        body="Vitamin D level is within normal range with current prescription regimen. "
+        "Continue weekly prescription-strength vitamin D supplementation.",
+        candidates=[],
+    )
+
+    def science(_terms: list[str]) -> list[Icd10Condition]:
+        return [Icd10Condition(code="E559", label="Vitamin D deficiency, unspecified")]
+
+    client = _FakeClient(
+        [
+            _step(terms=["vitamin D deficiency"]),
+            _step(selected="E55.9", confidence="high", ranked=["E55.9"]),
+        ]
+    )
+    out = resolve_uncoded_blocks([block], _factory(client), science)
+
+    assert out["apblock-4"].chosen == ("E55.9", "Vitamin D deficiency, unspecified")
+
+
 def test_hallucinated_code_is_rejected() -> None:
     # The LLM returns a code that is NOT in the pool and offers no search terms.
     # Nothing survives the gate -> no resolution (belt output preserved).

--- a/tests/hyperscribe/scribe/recommendations/test_diagnosis_llm_resolver.py
+++ b/tests/hyperscribe/scribe/recommendations/test_diagnosis_llm_resolver.py
@@ -197,6 +197,30 @@ def test_managed_condition_codes_the_underlying_diagnosis() -> None:
     assert out["apblock-4"].chosen == ("E55.9", "Vitamin D deficiency, unspecified")
 
 
+def test_high_confidence_z_code_is_surfaced_not_applied() -> None:
+    # A contextual Z-code (e.g. Z75.8 for a PT-access problem) must never auto-apply,
+    # even at high confidence — it's surfaced for the provider to confirm instead.
+    block = BlockContext(
+        block_id="apblock-6",
+        header="Physical therapy access",
+        body="Difficulty accessing home health physical therapy due to repeated cancellations.",
+        candidates=[
+            _candidate(
+                "Z758",
+                "Z75.8",
+                "Other problems related to medical facilities and other health care",
+                "ICD-10 search",
+            )
+        ],
+    )
+    client = _FakeClient([_step(selected="Z75.8", confidence="high", ranked=["Z75.8"])])
+    out = resolve_uncoded_blocks([block], _factory(client), _no_science)
+
+    res = out["apblock-6"]
+    assert res.chosen is None  # not auto-applied
+    assert [s["formatted_code"] for s in res.suggestions] == ["Z75.8"]  # but surfaced
+
+
 def test_hallucinated_code_is_rejected() -> None:
     # The LLM returns a code that is NOT in the pool and offers no search terms.
     # Nothing survives the gate -> no resolution (belt output preserved).

--- a/tests/hyperscribe/scribe/recommendations/test_diagnosis_llm_resolver.py
+++ b/tests/hyperscribe/scribe/recommendations/test_diagnosis_llm_resolver.py
@@ -80,7 +80,7 @@ def _no_science(_terms: list[str]) -> list[Icd10Condition]:
     return []
 
 
-def test_selects_from_provided_high_confidence_auto_applies() -> None:
+def test_selection_leads_suggestions_never_auto_applies() -> None:
     block = BlockContext(
         block_id="apblock-1",
         header="Edema in lower extremities",
@@ -90,8 +90,9 @@ def test_selects_from_provided_high_confidence_auto_applies() -> None:
     client = _FakeClient([_step(selected="R60.0", confidence="high", ranked=["R60.0"])])
     out = resolve_uncoded_blocks([block], _factory(client), _no_science)
 
-    assert out["apblock-1"].chosen == ("R60.0", "Localized edema")
-    assert out["apblock-1"].confidence == "high"
+    res = out["apblock-1"]
+    assert res.chosen is None  # never auto-applied — the provider always picks
+    assert res.suggestions[0]["formatted_code"] == "R60.0"  # the model's pick leads the list
 
 
 def test_expands_when_nothing_provided_then_selects() -> None:
@@ -118,7 +119,9 @@ def test_expands_when_nothing_provided_then_selects() -> None:
     out = resolve_uncoded_blocks([block], _factory(client), science)
 
     assert science_calls == [["fluid overload", "pulmonary edema"]]
-    assert out["apblock-0"].chosen == ("E87.70", "Fluid overload, unspecified")
+    res = out["apblock-0"]
+    assert res.chosen is None
+    assert res.suggestions[0]["formatted_code"] == "E87.70"  # grounded code leads the picker
 
 
 def test_rejects_clinically_wrong_provided_and_expands() -> None:
@@ -142,9 +145,11 @@ def test_rejects_clinically_wrong_provided_and_expands() -> None:
     )
     out = resolve_uncoded_blocks([block], _factory(client), science)
 
-    assert out["apblock-2"].chosen == ("E88.09", "Hypoalbuminemia")
-    # The inverted code was never chosen.
-    assert out["apblock-2"].chosen != ("E67.8", "Other specified hyperalimentation")
+    res = out["apblock-2"]
+    assert res.chosen is None
+    codes = [s["formatted_code"] for s in res.suggestions]
+    assert codes[0] == "E88.09"  # the correct code leads
+    assert "E67.8" not in codes  # the inverted lexical hit is not surfaced
 
 
 def test_wrong_family_refinement_expands_to_correct_family() -> None:
@@ -168,7 +173,9 @@ def test_wrong_family_refinement_expands_to_correct_family() -> None:
     )
     out = resolve_uncoded_blocks([block], _factory(client), science)
 
-    assert out["apblock-3"].chosen == ("D50.9", "Iron deficiency anemia, unspecified")
+    res = out["apblock-3"]
+    assert res.chosen is None
+    assert res.suggestions[0]["formatted_code"] == "D50.9"  # iron-deficiency leads over D64
 
 
 def test_managed_condition_codes_the_underlying_diagnosis() -> None:
@@ -194,7 +201,9 @@ def test_managed_condition_codes_the_underlying_diagnosis() -> None:
     )
     out = resolve_uncoded_blocks([block], _factory(client), science)
 
-    assert out["apblock-4"].chosen == ("E55.9", "Vitamin D deficiency, unspecified")
+    res = out["apblock-4"]
+    assert res.chosen is None
+    assert res.suggestions[0]["formatted_code"] == "E55.9"  # underlying deficiency leads
 
 
 def test_high_confidence_z_code_is_surfaced_not_applied() -> None:

--- a/tests/hyperscribe/scribe/recommendations/test_diagnosis_suggestion.py
+++ b/tests/hyperscribe/scribe/recommendations/test_diagnosis_suggestion.py
@@ -1,171 +1,64 @@
+"""Tests for the grounded ICD-10 suggester (``suggest_diagnoses``).
+
+The free-generation path (LLM emits codes, existence-checked only) is gone. The
+suggester now returns ONLY codes the Canvas science service actually returns for
+the condition text — so a code the ontology does not surface can never appear.
+These tests assert exactly that anti-hallucination property.
+"""
+
 from __future__ import annotations
 
-import json
-from http import HTTPStatus
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
-from canvas_sdk.clients.llms.structures import LlmResponse, LlmTokens
-
-from hyperscribe.scribe.recommendations.diagnosis_suggestion import (
-    _validate_code,
-    suggest_diagnoses,
-)
+from hyperscribe.scribe.recommendations.diagnosis_suggestion import suggest_diagnoses
+from hyperscribe.structures.icd10_condition import Icd10Condition
 
 
-def _make_science_response(results: list[dict[str, str]]) -> MagicMock:
-    resp = MagicMock()
-    resp.json.return_value = {"results": results}
-    return resp
-
-
-@patch("hyperscribe.scribe.recommendations.diagnosis_suggestion.science_http")
-def test_validate_code_found(mock_science: MagicMock) -> None:
-    mock_science.get_json.return_value = _make_science_response(
-        [{"icd10_code": "R519", "icd10_text": "Headache, unspecified", "score": 1.0}]
-    )
-    result = _validate_code("R519")
-    assert result is not None
-    assert result["code"] == "R519"
-    assert result["display"] == "Headache, unspecified"
-    assert result["formatted_code"] == "R51.9"
-
-
-@patch("hyperscribe.scribe.recommendations.diagnosis_suggestion.science_http")
-def test_validate_code_not_found(mock_science: MagicMock) -> None:
-    mock_science.get_json.return_value = _make_science_response(
-        [{"icd10_code": "Z999", "icd10_text": "Something else", "score": 0.5}]
-    )
-    result = _validate_code("R519")
-    assert result is None
-
-
-@patch("hyperscribe.scribe.recommendations.diagnosis_suggestion.science_http")
-def test_validate_code_exception(mock_science: MagicMock) -> None:
-    mock_science.get_json.side_effect = Exception("Network error")
-    result = _validate_code("R519")
-    assert result is None
-
-
-@patch("hyperscribe.scribe.recommendations.diagnosis_suggestion._validate_code")
-@patch("hyperscribe.scribe.recommendations.diagnosis_suggestion.LlmAnthropic")
-def test_suggest_diagnoses_success(mock_llm_cls: MagicMock, mock_validate: MagicMock) -> None:
-    mock_client = MagicMock()
-    mock_llm_cls.return_value = mock_client
-    mock_client.request.return_value = LlmResponse(
-        code=HTTPStatus.OK,
-        response=json.dumps(
-            {
-                "suggestions": [
-                    {"conditionText": "Right-sided headache", "icd10Codes": ["R519", "G43909"]},
-                ]
-            }
-        ),
-        tokens=LlmTokens(prompt=100, generated=50),
-    )
-
-    mock_validate.side_effect = [
-        {"code": "R519", "display": "Headache, unspecified", "formatted_code": "R51.9"},
-        {"code": "G43909", "display": "Migraine, unspecified", "formatted_code": "G43.909"},
+def test_suggest_diagnoses_returns_only_science_codes() -> None:
+    search_results = [
+        Icd10Condition(code="G43909", label="Migraine, unspecified, not intractable"),
+        Icd10Condition(code="G44209", label="Tension-type headache, unspecified"),
     ]
+    with patch(
+        "hyperscribe.scribe.recommendations.diagnosis_suggestion.CanvasScience.search_conditions",
+        return_value=search_results,
+    ):
+        result = suggest_diagnoses(["Headache"])
 
-    result = suggest_diagnoses(["Right-sided headache"], "test-api-key")
-
-    assert "Right-sided headache" in result
-    assert len(result["Right-sided headache"]) == 2
-    assert result["Right-sided headache"][0]["code"] == "R519"
-    assert result["Right-sided headache"][1]["code"] == "G43909"
-
-
-@patch("hyperscribe.scribe.recommendations.diagnosis_suggestion._validate_code")
-@patch("hyperscribe.scribe.recommendations.diagnosis_suggestion.LlmAnthropic")
-def test_suggest_diagnoses_code_not_validated(mock_llm_cls: MagicMock, mock_validate: MagicMock) -> None:
-    mock_client = MagicMock()
-    mock_llm_cls.return_value = mock_client
-    mock_client.request.return_value = LlmResponse(
-        code=HTTPStatus.OK,
-        response=json.dumps(
-            {
-                "suggestions": [
-                    {"conditionText": "Knee pain", "icd10Codes": ["M25561", "XXXXX"]},
-                ]
-            }
-        ),
-        tokens=LlmTokens(prompt=100, generated=50),
-    )
-
-    mock_validate.side_effect = [
-        {"code": "M25561", "display": "Pain in right knee", "formatted_code": "M25.561"},
-        None,  # second code doesn't validate
-    ]
-
-    result = suggest_diagnoses(["Knee pain"], "test-api-key")
-
-    assert len(result["Knee pain"]) == 1
-    assert result["Knee pain"][0]["code"] == "M25561"
+    options = result["Headache"]
+    returned_codes = {option["code"] for option in options}
+    science_codes = {c.code for c in search_results}
+    # Every surfaced code came from the science service — nothing invented.
+    assert returned_codes <= science_codes
+    assert returned_codes  # and we did surface the grounded options
+    assert all("provenance" in option for option in options)
 
 
-@patch("hyperscribe.scribe.recommendations.diagnosis_suggestion._validate_code")
-@patch("hyperscribe.scribe.recommendations.diagnosis_suggestion.LlmAnthropic")
-def test_suggest_diagnoses_all_codes_invalid(mock_llm_cls: MagicMock, mock_validate: MagicMock) -> None:
-    mock_client = MagicMock()
-    mock_llm_cls.return_value = mock_client
-    mock_client.request.return_value = LlmResponse(
-        code=HTTPStatus.OK,
-        response=json.dumps(
-            {
-                "suggestions": [
-                    {"conditionText": "Unknown condition", "icd10Codes": ["XXXXX"]},
-                ]
-            }
-        ),
-        tokens=LlmTokens(prompt=100, generated=50),
-    )
-    mock_validate.return_value = None
-
-    result = suggest_diagnoses(["Unknown condition"], "test-api-key")
-
-    # Condition with no valid codes is omitted from the result.
-    assert "Unknown condition" not in result
+def test_suggest_diagnoses_no_science_match_is_empty() -> None:
+    with patch(
+        "hyperscribe.scribe.recommendations.diagnosis_suggestion.CanvasScience.search_conditions",
+        return_value=[],
+    ):
+        result = suggest_diagnoses(["Some freetext with no ontology match"])
+    # No fabricated codes — the provider falls back to manual search.
+    assert result["Some freetext with no ontology match"] == []
 
 
-def test_suggest_diagnoses_empty_conditions() -> None:
-    result = suggest_diagnoses([], "test-api-key")
-    assert result == {}
+def test_suggest_diagnoses_empty_and_blank_conditions() -> None:
+    assert suggest_diagnoses([]) == {}
+    with patch(
+        "hyperscribe.scribe.recommendations.diagnosis_suggestion.CanvasScience.search_conditions",
+        return_value=[],
+    ):
+        assert suggest_diagnoses(["   "]) == {}
 
 
-@patch("hyperscribe.scribe.recommendations.diagnosis_suggestion.LlmAnthropic")
-def test_suggest_diagnoses_llm_error(mock_llm_cls: MagicMock) -> None:
-    mock_client = MagicMock()
-    mock_llm_cls.return_value = mock_client
-    mock_client.request.return_value = LlmResponse(
-        code=HTTPStatus.INTERNAL_SERVER_ERROR,
-        response="Server error",
-        tokens=LlmTokens(prompt=0, generated=0),
-    )
-
-    result = suggest_diagnoses(["Headache"], "test-api-key")
-    assert result == {}
-
-
-@patch("hyperscribe.scribe.recommendations.diagnosis_suggestion.LlmAnthropic")
-def test_suggest_diagnoses_llm_exception(mock_llm_cls: MagicMock) -> None:
-    mock_client = MagicMock()
-    mock_llm_cls.return_value = mock_client
-    mock_client.request.side_effect = Exception("Network error")
-
-    result = suggest_diagnoses(["Headache"], "test-api-key")
-    assert result == {}
-
-
-@patch("hyperscribe.scribe.recommendations.diagnosis_suggestion.LlmAnthropic")
-def test_suggest_diagnoses_malformed_response(mock_llm_cls: MagicMock) -> None:
-    mock_client = MagicMock()
-    mock_llm_cls.return_value = mock_client
-    mock_client.request.return_value = LlmResponse(
-        code=HTTPStatus.OK,
-        response="not valid json",
-        tokens=LlmTokens(prompt=100, generated=50),
-    )
-
-    result = suggest_diagnoses(["Headache"], "test-api-key")
-    assert result == {}
+def test_suggest_diagnoses_never_invents_off_list_code() -> None:
+    # Even if the science service returns one narrow result, the output is a strict
+    # subset of it — there is no path that adds a code the ontology didn't return.
+    with patch(
+        "hyperscribe.scribe.recommendations.diagnosis_suggestion.CanvasScience.search_conditions",
+        return_value=[Icd10Condition(code="E039", label="Hypothyroidism, unspecified")],
+    ):
+        result = suggest_diagnoses(["Hypothyroidism"])
+    assert [option["code"] for option in result["Hypothyroidism"]] == ["E039"]

--- a/tests/hyperscribe/scribe/recommendations/test_referral_diagnosis.py
+++ b/tests/hyperscribe/scribe/recommendations/test_referral_diagnosis.py
@@ -22,31 +22,31 @@ def _diagnose(header: str, code: str | None, display: str = "") -> dict[str, Any
 def test_links_code_from_diagnose_command() -> None:
     recs = [_refer("Shoulder muscle spasm")]
     commands = [_diagnose("Shoulder muscle spasm:", "M62.838", "Other muscle spasm")]
-    link_referral_diagnoses(recs, commands, [], {})
+    link_referral_diagnoses(recs, commands, [])
     assert recs[0]["data"]["diagnosis_codes"] == ["M62.838"]
     # the ICD-10 name is attached for display alongside the code
     assert recs[0]["data"]["diagnosis_displays"] == ["Other muscle spasm"]
     assert recs[0]["data"]["diagnosis_formatted"] == ["M62.838"]
 
 
-def test_diagnose_command_takes_priority_over_suggestions() -> None:
-    recs = [_refer("Hypertension")]
-    commands = [_diagnose("Hypertension:", "I10")]
-    suggestions = {"Hypertension:": [{"code": "I150", "formatted_code": "I15.0"}]}
-    link_referral_diagnoses(recs, commands, [], suggestions)
-    assert recs[0]["data"]["diagnosis_codes"] == ["I10"]
-
-
-def test_falls_back_to_suggestions_when_diagnose_uncoded() -> None:
+def test_uncoded_diagnose_does_not_link() -> None:
+    # A diagnose block that is still uncoded (only ranked candidate_suggestions, no
+    # provider-chosen code) must NOT link the referral: pre-stamping the top guess
+    # could stick a code the provider never picks. The frontend live-linker attaches
+    # the provider's FINAL code at reconciliation time instead.
     recs = [_refer("Shoulder muscle spasm")]
-    # diagnose command exists but has no code yet
-    commands = [_diagnose("Shoulder muscle spasm:", None)]
-    suggestions = {
-        "Shoulder muscle spasm:": [{"code": "M6281", "formatted_code": "M62.81", "display": "Muscle weakness"}]
-    }
-    link_referral_diagnoses(recs, commands, [], suggestions)
-    assert recs[0]["data"]["diagnosis_codes"] == ["M62.81"]
-    assert recs[0]["data"]["diagnosis_displays"] == ["Muscle weakness"]
+    commands = [
+        {
+            "command_type": "diagnose",
+            "data": {
+                "condition_header": "Shoulder muscle spasm:",
+                "icd10_code": None,
+                "candidate_suggestions": [{"code": "M6281", "formatted_code": "M62.81", "display": "Muscle weakness"}],
+            },
+        }
+    ]
+    link_referral_diagnoses(recs, commands, [])
+    assert "diagnosis_codes" not in recs[0]["data"]
 
 
 def test_falls_back_to_unmatched_conditions() -> None:
@@ -57,7 +57,7 @@ def test_falls_back_to_unmatched_conditions() -> None:
             "corresponding_note_problem": "Asthma",
         }
     ]
-    link_referral_diagnoses(recs, commands=[], unmatched_conditions=unmatched, diagnosis_suggestions={})
+    link_referral_diagnoses(recs, commands=[], unmatched_conditions=unmatched)
     assert recs[0]["data"]["diagnosis_codes"] == ["J45.909"]
     assert recs[0]["data"]["diagnosis_displays"] == ["Unspecified asthma, uncomplicated"]
 
@@ -66,7 +66,7 @@ def test_containment_match() -> None:
     # indication is a substring of the note's problem header (minor wording drift)
     recs = [_refer("muscle spasm")]
     commands = [_diagnose("Shoulder muscle spasm:", "M62.838")]
-    link_referral_diagnoses(recs, commands, [], {})
+    link_referral_diagnoses(recs, commands, [])
     assert recs[0]["data"]["diagnosis_codes"] == ["M62.838"]
 
 
@@ -75,28 +75,28 @@ def test_partial_word_overlap_does_not_match() -> None:
     # so no code is linked (avoids guessing a wrong indication)
     recs = [_refer("shoulder spasm")]
     commands = [_diagnose("Shoulder muscle spasm:", "M62.838")]
-    link_referral_diagnoses(recs, commands, [], {})
+    link_referral_diagnoses(recs, commands, [])
     assert "diagnosis_codes" not in recs[0]["data"]
 
 
 def test_no_match_leaves_codes_absent() -> None:
     recs = [_refer("Cardiology consult")]
     commands = [_diagnose("Diabetes:", "E11.9")]
-    link_referral_diagnoses(recs, commands, [], {})
+    link_referral_diagnoses(recs, commands, [])
     assert "diagnosis_codes" not in recs[0]["data"]
 
 
 def test_no_indication_is_skipped() -> None:
     recs = [_refer(None)]
     commands = [_diagnose("Hypertension:", "I10")]
-    link_referral_diagnoses(recs, commands, [], {})
+    link_referral_diagnoses(recs, commands, [])
     assert "diagnosis_codes" not in recs[0]["data"]
 
 
 def test_existing_codes_preserved() -> None:
     recs = [_refer("Hypertension", diagnosis_codes=["I11.9"])]
     commands = [_diagnose("Hypertension:", "I10")]
-    link_referral_diagnoses(recs, commands, [], {})
+    link_referral_diagnoses(recs, commands, [])
     # not overwritten
     assert recs[0]["data"]["diagnosis_codes"] == ["I11.9"]
 
@@ -105,5 +105,5 @@ def test_non_refer_proposals_untouched() -> None:
     med = {"command_type": "medication_statement", "data": {"indication": "Hypertension"}}
     recs = [med]
     commands = [_diagnose("Hypertension:", "I10")]
-    link_referral_diagnoses(recs, commands, [], {})
+    link_referral_diagnoses(recs, commands, [])
     assert "diagnosis_codes" not in med["data"]


### PR DESCRIPTION
Jira: [PLUGIN-333](https://canvasmedical.atlassian.net/browse/PLUGIN-333)

## The problem this fixes

The prior pipeline took the **first** Nabla code for an A&P problem with no clinical ranking, so wrong codes attached to diagnoses — e.g. the symptom code **R45.851 "Suicidal ideations"** replaced the real depression diagnosis **F33.1** — and an LLM could free-generate (hallucinate) codes. Provider control over the final code was minimal.

This PR overhauls the Canvas Scribe ICD-10 diagnosis-coding pipeline: grounded (no-hallucination) candidates, **the provider picks every code**, a "Wrap Up" destination for non-diagnosis A&P items, and a grounded-LLM fallback for hard-to-code blocks.

Branched from `canvas-scribe`; its recent fixes (KOALA-6055, KOALA-5930) are merged in so this is up to date.

## What changed, by area

### 1. Grounded, no-hallucination ranking (new engine)
- New `diagnosis_candidates.py` builds a candidate set from the patient's **active AND inactive** chart conditions + Nabla codings + a science-service search, then ranks by clinical priority (active-problem › prior condition › note-text overlap › definitive-over-R/Z-symptom › specificity).
- Codes are only ever **retrieved**, never generated. Incidental symptom (R) / contextual (Z) codes are dropped when a definitive code exists.
- Belt (`ap_split.py`) rewritten to use it; `session_view` loads full chart history; `diagnosis_suggestion.py` de-LLM'd to a grounded science lookup.

### 2. Provider always picks — never auto-apply (headline behavior)
- Every A&P diagnosis is surfaced **UNCODED** with a ranked picker; the most-recommended code leads. Nothing is auto-stamped.
- Picker shows the **top 4** recommendations with a **"More options"** expander revealing the rest and the move-to-Wrap-Up action.
- A **hard block** (client + server) prevents note approval until each diagnosis is coded, rejected, or moved.
- Active-problem matches lead the list and flip to `assess` at insert time via code match — continuity of care preserved without silent coding.

### 3. Grounded-LLM resolver (suggestions only)
- For blocks the deterministic path can't ground, an LLM does retrieval-augmented selection (propose clinical search terms → CanvasScience → pick from the real results) with a hard gate that rejects any code not in the retrieved set. It curates the suggestion list; it never auto-applies.

### 4. "Move to the wrap up section"
- Non-diagnosis A&P items (e.g. "Physical therapy access", "Ear cleaning") can be reclassified from the picker into a persistent, always-rendered, editable **Wrap Up** component instead of being forced a code. Two-click inline confirm; multiple moved items consolidate into one box.

### 5. Referrals
- Backend links a referral's indication to a coded diagnosis / active-chart condition; the frontend **live-links** a referral to the provider's final code during reconciliation (self-correcting; never overrides a provider edit). Removed the stale block_id-keyed suggestion source.

### 6. Persistence & misc
- Persist the raw Nabla normalized-data response (`ScribeSummary.raw_normalized_response`) for analysis/regression (nullable-no-default field; safe on existing rows).
- A&P diagnoses subsection renamed **"Conditions"**; the original Nabla headline is baked into the editable "Today's assessment"; **assess (existing-condition) cards can be re-coded via "Change"**; server-side uncoded-diagnosis guard in `DiagnoseParser`.

### 7. Merged from canvas-scribe (kept up to date)
- fix(scribe): reopen lab/imaging diagnosis dropdown after each pick (KOALA-6055)
- fix(scribe): resolve medications to the correct strength/product (KOALA-5930)

## Files (representative)
- **Backend:** `commands/ap_split.py`, `commands/diagnosis_candidates.py`, `commands/diagnose.py`, `recommendations/diagnosis_llm_resolver.py`, `recommendations/diagnosis_suggestion.py`, `recommendations/_referral_diagnosis.py`, `recommendations/schemas.py`, `recommendations/__init__.py`, `api/session_view.py`, `clients/nabla/backend.py`, `models/scribe.py`
- **Frontend:** `static/diagnose-row.js`, `static/soap-group.js`, `static/summary.js`, `static/styles.css`, `static/debug.js`
- **Tests:** broad updates across `tests/hyperscribe/scribe/**`

## Testing
- `pytest tests/hyperscribe/scribe` — **1470 passing**; `mypy` and `ruff` clean; JS `node --check` clean.
- Extensive manual UAT on `scribeqa-playground` (now running v0.4.35).

## Known follow-ups (not in this PR)
- Generation-time diagnosis **background carry-forward** is intentionally dropped — it depended on the auto-applied `condition_id`, and picking a code clears carried background anyway.
- **KOALA-6188** (grounded-LLM fallback for synonym gaps) is largely addressed; **belt-level Z-code auto-apply** (e.g. Z95.0 on a "cardiac follow-up" header) and **non-leaf code filtering** (E78.01-class) remain.
- Optional: a provider allowlist feature flag (the planned `SECRET_SCRIBE_ICD10_STAFFERS` gate was not implemented — this ships on for everyone).

🤖 Generated with [Claude Code](https://claude.com/claude-code)



[PLUGIN-333]: https://canvasmedical.atlassian.net/browse/PLUGIN-333?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ