### PR TITLE
fix(scribe): reset dispense type when adjust Rx swaps medication

### DIFF
--- a/hyperscribe/scribe/static/order-row.js
+++ b/hyperscribe/scribe/static/order-row.js
@@ -362,6 +362,14 @@ export function OrderRow({ command, commandIndex, onEdit, onDelete, readOnly, pa
     setChangeToQuery(r.description);
     setChangeToResults([]);
     setChangeToSearched(false);
+    // The dispense-type options belong to the medication being dispensed, so
+    // swapping to a new med must rebuild them from the new med's quantities and
+    // drop the previous selection — otherwise the saved type_to_dispense /
+    // representative_ndc would still reference the old medication. Mirrors
+    // handleMedSelect.
+    const options = buildTypeToDispenseOptions(r.quantities || []);
+    setMedQuantities(options);
+    setTypeToDispense(options.length === 1 ? options[0].value : '');
   };
 
   const snapshotCurrentRx = () => ({


### PR DESCRIPTION
https://canvasmedical.atlassian.net/browse/KOALA-5620

This pull request makes an important fix to the medication selection logic in `order-row.js`. When swapping to a new medication, the code now ensures that the dispense-type options are rebuilt from the new medication's quantities, and the previous selection is cleared. This prevents the dispense-type or representative NDC from referencing the old medication.

Medication selection logic:

* In `OrderRow`, after selecting a new medication, the dispense-type options are rebuilt using `buildTypeToDispenseOptions` based on the new medication's quantities, and the previous selection is dropped to avoid referencing the old medication.