### PR TITLE
feat(scribe): post-generation field dictation (KOALA-6233)

### DIFF
--- a/hyperscribe/CANVAS_MANIFEST.json
+++ b/hyperscribe/CANVAS_MANIFEST.json
@@ -288,6 +288,7 @@
     "NotionFeedbackDatabaseId",
     "ScribeBackend",
     "ScribeDebugStaffers",
+    "ScribeDictationEnabled",
     "ScribeManualModeOnly",
     "ScribeNoteTypes",
     "ScribePilotStaffers",

--- a/hyperscribe/scribe/api/scribe_view.py
+++ b/hyperscribe/scribe/api/scribe_view.py
@@ -70,6 +70,10 @@ class ScribeView(StaffSessionAuthMixin, SimpleAPI):
             provider_photo_url = ""
 
         initial_data = _load_initial_data(note_id, self.secrets)
+        # Field dictation is gated behind a true/false secret (KOALA-6233). Strict
+        # "true" match so setting the secret to "false" disables it (unlike the
+        # truthy-if-present secrets, where any value would enable).
+        dictation_enabled = str(self.secrets.get("ScribeDictationEnabled", "")).strip().lower() == "true"
 
         html = render_to_string(
             "scribe/static/index.html",
@@ -89,6 +93,7 @@ class ScribeView(StaffSessionAuthMixin, SimpleAPI):
                 "is_author": "true" if is_author else "",
                 "alert_facility_enabled": "true" if self.secrets.get("AlertFacilityEnabled") else "",
                 "manual_mode_only": "true" if self.secrets.get("ScribeManualModeOnly") else "",
+                "dictation_enabled": "true" if dictation_enabled else "",
                 "initial_data": _safe_json(initial_data),
             },
         )

--- a/hyperscribe/scribe/api/session_view.py
+++ b/hyperscribe/scribe/api/session_view.py
@@ -955,6 +955,26 @@ class ScribeSessionView(StaffSessionAuthMixin, SimpleAPI):
             return [JSONResponse({"error": str(exc)}, status_code=HTTPStatus.INTERNAL_SERVER_ERROR)]
         return [JSONResponse(config, status_code=HTTPStatus.OK)]
 
+    @api.get("/dictation-config")
+    def get_dictation_config(self) -> list[Union[Response, Effect]]:
+        """Return the Nabla dictate-ws config for talking into a single field post-generation.
+
+        Mirrors ``/config`` but for the separate dictation endpoint. Provides the
+        same per-user Nabla WS credentials; a backend that does not support
+        dictation raises ScribeError (→ 500). The field text/caret is supplied
+        client-side, so no note_id is needed here.
+        """
+        try:
+            backend = get_backend_from_secrets(self.secrets)
+        except ScribeError as exc:
+            return [JSONResponse({"error": str(exc)}, status_code=HTTPStatus.BAD_REQUEST)]
+        try:
+            staff_id = self.request.headers.get("canvas-logged-in-user-id")
+            config = backend.get_dictation_config(user_external_id=staff_id)
+        except ScribeError as exc:
+            return [JSONResponse({"error": str(exc)}, status_code=HTTPStatus.INTERNAL_SERVER_ERROR)]
+        return [JSONResponse(config, status_code=HTTPStatus.OK)]
+
     @api.get("/transcript")
     def get_transcript(self) -> list[Union[Response, Effect]]:
         note_id = self.request.query_params.get("note_id", "")

--- a/hyperscribe/scribe/backend/base.py
+++ b/hyperscribe/scribe/backend/base.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import Any
 
+from hyperscribe.scribe.backend.errors import ScribeError
 from hyperscribe.scribe.backend.models import (
     ClinicalNote,
     NormalizedData,
@@ -18,6 +19,17 @@ class ScribeBackend(ABC):
     def get_transcription_config(self, *, user_external_id: str = "") -> dict[str, Any]:
         """Return config for the JS client: vendor, ws_url, access_token, sample_rate, encoding, etc."""
         ...
+
+    def get_dictation_config(self, *, user_external_id: str = "") -> dict[str, Any]:
+        """Return dictation config for the JS client: ws_url, access_token, dictation_locale, punctuation_mode.
+
+        Dictation (talking into a single field post-generation) is an *optional*
+        capability. Unlike ``get_transcription_config`` — which is abstract, so
+        every scribe backend must support ambient transcription — a backend that
+        cannot dictate simply inherits this default. It raises to signal the
+        ``/dictation-config`` endpoint that dictation is unsupported.
+        """
+        raise ScribeError("This scribe backend does not support dictation")
 
     @abstractmethod
     def generate_note(

--- a/hyperscribe/scribe/clients/nabla/backend.py
+++ b/hyperscribe/scribe/clients/nabla/backend.py
@@ -22,6 +22,10 @@ from hyperscribe.scribe.clients.nabla.client import NablaClient
 
 _NABLA_API_VERSION = "2026-06-12"
 _NOTE_LOCALE = "ENGLISH_US"
+# Dictation (dictate-ws) takes a single locale, not the transcribe-ws speech_locales
+# array, and EXPLICIT punctuation means the provider dictates punctuation out loud.
+_DICTATION_LOCALE = "ENGLISH_US"
+_DICTATION_PUNCTUATION_MODE = "EXPLICIT"
 _NOTE_TEMPLATE = "GENERIC_MULTIPLE_SECTIONS_AP_MERGED"
 _PSYCHIATRY_NOTE_TEMPLATE = "PSYCHIATRY_MULTIPLE_SECTIONS_AP_MERGED"
 
@@ -138,6 +142,31 @@ class NablaBackend(ScribeBackend):
             "speech_locales": ["ENGLISH_US"],
             "stream_id": "stream1",
             "split_by_sentence": True,
+        }
+
+    def get_dictation_config(self, *, user_external_id: str = "") -> dict[str, Any]:
+        """Return config for the JS dictation client (Nabla ``dictate-ws``).
+
+        Post-generation field dictation (talk into one field) uses a *separate*
+        Nabla endpoint from ambient transcription. It differs from
+        ``get_transcription_config``: a single ``dictation_locale`` (not the
+        ``speech_locales`` array), ``punctuation_mode`` EXPLICIT (the provider
+        dictates punctuation out loud), and no ``stream_id``. The JS client adds
+        the per-field ``text_field_context`` (current text + caret) when it sends
+        CONFIG, so dictated words are inserted at the caret. Reuses the same
+        per-user Nabla token as transcription.
+        """
+        access_token, refresh_token = self._auth.get_user_tokens(user_external_id)
+        hostname = self._auth.base_url.split("://", 1)[-1].split("/", 1)[0]
+        return {
+            "vendor": "nabla",
+            "ws_url": f"wss://{hostname}/v1/core/user/dictate-ws?nabla-api-version={_NABLA_API_VERSION}",
+            "access_token": access_token,
+            "refresh_token": refresh_token,
+            "sample_rate": 16000,
+            "encoding": "PCM_S16LE",
+            "dictation_locale": _DICTATION_LOCALE,
+            "punctuation_mode": _DICTATION_PUNCTUATION_MODE,
         }
 
     def generate_note(

--- a/hyperscribe/scribe/static/app.js
+++ b/hyperscribe/scribe/static/app.js
@@ -6,7 +6,7 @@ import { Audit } from '/plugin-io/api/hyperscribe/scribe/static/audit.js';
 
 const html = htm.bind(h);
 
-export function App({ noteId, view, providerName, providerPhotoUrl, patientName, patientBirthDate, patientGender, patientId, staffId, staffName, debugMode, noteEditable, isAuthor, alertFacilityEnabled, manualModeOnly, initialData }) {
+export function App({ noteId, view, providerName, providerPhotoUrl, patientName, patientBirthDate, patientGender, patientId, staffId, staffName, debugMode, noteEditable, isAuthor, alertFacilityEnabled, manualModeOnly, dictationEnabled, initialData }) {
   if (view === 'audit') {
     return html`<${Audit} noteId=${noteId} />`;
   }
@@ -31,6 +31,7 @@ export function App({ noteId, view, providerName, providerPhotoUrl, patientName,
       isAuthor=${isAuthor}
       alertFacilityEnabled=${alertFacilityEnabled}
       manualModeOnly=${manualModeOnly}
+      dictationEnabled=${dictationEnabled}
       initialData=${initialData}
     />`;
   }

--- a/hyperscribe/scribe/static/command-row.js
+++ b/hyperscribe/scribe/static/command-row.js
@@ -1,4 +1,4 @@
-import { h } from 'https://esm.sh/preact@10.25.4';
+import { h, Fragment } from 'https://esm.sh/preact@10.25.4';
 import { useState, useRef, useEffect } from 'https://esm.sh/preact@10.25.4/hooks';
 import htm from 'https://esm.sh/htm@3.1.1';
 
@@ -6,6 +6,8 @@ const html = htm.bind(h);
 
 const ICON_X = html`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><line x1="6" y1="6" x2="18" y2="18"/><line x1="6" y1="18" x2="18" y2="6"/></svg>`;
 const ICON_CHECK = html`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="4 12 10 18 20 6"/></svg>`;
+const ICON_MIC = html`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 1a3 3 0 0 0-3 3v8a3 3 0 0 0 6 0V4a3 3 0 0 0-3-3z"/><path d="M19 10v2a7 7 0 0 1-14 0v-2"/><line x1="12" y1="19" x2="12" y2="23"/><line x1="8" y1="23" x2="16" y2="23"/></svg>`;
+const ICON_STOP = html`<svg viewBox="0 0 24 24" fill="currentColor"><rect x="6" y="6" width="12" height="12" rx="2"/></svg>`;
 
 const DATA_FIELD = {
   rfv: 'comment',
@@ -15,10 +17,32 @@ const DATA_FIELD = {
   imaging_results: 'narrative',
 };
 
-export function CommandRow({ command, commandIndex, onEdit, onDelete, readOnly, onEditingChange }) {
+// Fields a provider can dictate into (talk-to-fill, post-generation). Kept
+// narrower than DATA_FIELD on purpose: lab/imaging narratives are not dictation
+// targets. KOALA-6233.
+const DICTATABLE = new Set(['rfv', 'hpi', 'plan']);
+// Some sections are plan-typed narratives but not free-text prose targets — the
+// Appointments section is a follow-up list, so no dictation mic there. Scoped by
+// section_key (not command_type, which is 'plan' for these too).
+const NON_DICTATABLE_SECTIONS = new Set(['appointments']);
+
+export function CommandRow({ command, commandIndex, onEdit, onDelete, readOnly, onEditingChange, dictation }) {
   const field = DATA_FIELD[command.command_type];
-  const isNew = onDelete && !command.display;
+  // Dictatable narratives (CC / HPI / Plan) start in READ mode even when freshly
+  // added and empty, so the dictation mic + "Tap to enter text" both show. Other
+  // ad-hoc rows keep auto-opening their editor. KOALA-6233.
+  const isNew = onDelete && !command.display && !DICTATABLE.has(command.command_type);
   const [editing, setEditing] = useState(isNew);
+  // Dictation (KOALA-6233): a mic on the read view of CC / HPI / Plan streams
+  // spoken text straight into the field. Only offered when the parent says it's
+  // available (author, editable, not mid-ambient-recording). Kept out of the
+  // edit view so live dictation never fights the textarea's local draft.
+  const canDictate = Boolean(
+    dictation && dictation.available
+    && DICTATABLE.has(command.command_type)
+    && !NON_DICTATABLE_SECTIONS.has(command.section_key),
+  );
+  const dictating = canDictate && dictation.activeField === commandIndex;
   useEffect(() => {
     onEditingChange?.(commandIndex, editing);
     return () => onEditingChange?.(commandIndex, false);
@@ -71,12 +95,38 @@ export function CommandRow({ command, commandIndex, onEdit, onDelete, readOnly, 
     `;
   }
 
+  // Dictation status shown as a small line BELOW the field so it's visible whether
+  // or not the field already has text (the placeholder only shows when empty).
+  const dictationMsg = !dictating
+    ? null
+    : dictation.silent
+      ? 'No audio detected — check your microphone'
+      : dictation.status === 'connecting'
+        ? 'Connecting…'
+        : 'Listening…';
+
   return html`
-    <div class="command-row" onClick=${() => !readOnly && setEditing(true)}>
-      ${command.display
-        ? html`<span class="command-row-text">${command.display}</span>`
-        : !readOnly && html`<span class="command-row-placeholder">Tap to enter text</span>`
-      }
-    </div>
+    <${Fragment}>
+      <div
+        class="command-row${dictating ? ' dictating' : ''}"
+        onClick=${() => !readOnly && !dictating && setEditing(true)}
+      >
+        ${command.display
+          ? html`<span class="command-row-text">${command.display}</span>`
+          : !readOnly && html`<span class="command-row-placeholder">Tap to enter text</span>`
+        }
+        ${canDictate && html`
+          <button
+            type="button"
+            class="command-row-mic${dictating ? ' recording' : ''}${dictating && dictation.silent ? ' silent' : ''}${dictation.error && dictating ? ' error' : ''}"
+            title=${dictating ? (dictation.silent ? 'No audio detected — check your microphone' : 'Stop dictation') : (dictation.micBlocked ? 'Microphone blocked — allow mic access' : 'Dictate into this field')}
+            aria-label=${dictating ? 'Stop dictation' : 'Dictate into this field'}
+            aria-pressed=${dictating}
+            onClick=${(e) => { e.stopPropagation(); dictation.onToggle(commandIndex); }}
+          >${dictating ? ICON_STOP : ICON_MIC}</button>
+        `}
+      </div>
+      ${dictationMsg && html`<div class="command-row-dictation-status${dictation.silent ? ' warning' : ''}">${dictationMsg}</div>`}
+    </${Fragment}>
   `;
 }

--- a/hyperscribe/scribe/static/dictation-hook.js
+++ b/hyperscribe/scribe/static/dictation-hook.js
@@ -1,0 +1,235 @@
+import { useState, useRef, useCallback, useEffect } from 'https://esm.sh/preact@10.25.4/hooks';
+import { createDictationClient } from './dictationClient.js';
+
+const API_BASE = '/plugin-io/api/hyperscribe/scribe-session';
+const TARGET_SAMPLE_RATE = 16000;
+// Silence detection (mirrors recording-hook): RMS below this counts as silence.
+// If the mic stays silent this long while listening, surface a "no audio" hint —
+// the common muted-mic / wrong-input-device failure. Seeded at listening-start so
+// a mic that is dead from the very first frame is caught too.
+const SILENCE_RMS_THRESHOLD = 0.005;
+const SILENCE_TIMEOUT_MS = 4000;
+
+/**
+ * Tear down the mic capture graph. Mirrors recording-hook's cleanupAudio but
+ * kept local so dictation shares no capture state with ambient recording.
+ */
+function cleanupAudio(audioCtxRef, streamRef, workletNodeRef) {
+  if (workletNodeRef.current) {
+    workletNodeRef.current.disconnect();
+    workletNodeRef.current = null;
+  }
+  if (audioCtxRef.current) {
+    audioCtxRef.current.close().catch(() => {});
+    audioCtxRef.current = null;
+  }
+  if (streamRef.current) {
+    streamRef.current.getTracks().forEach((t) => t.stop());
+    streamRef.current = null;
+  }
+}
+
+/**
+ * useFieldDictation — dictate into ONE note field at a time via Nabla dictate-ws.
+ *
+ * Deliberately independent of useRecording: its own client, its own mic capture,
+ * and it never writes to the transcript / note-generation pipeline. Dictated
+ * text is delivered incrementally through `onDictatedText(fieldId, text)` so the
+ * caller can append it to the field live; on stop() the field already holds the
+ * final text.
+ *
+ * The browser can only capture one microphone at a time, so the CALLER must not
+ * start dictation while ambient recording is active (gate the mic affordance on
+ * the recording status).
+ *
+ * @param {function(string, string): void} onDictatedText — (fieldId, textUnit)
+ * @returns {object} controls — activeField, status ('idle'|'connecting'|'listening'|'stopping'),
+ *   error, micBlocked, silent (no audio detected while listening), start(fieldId, currentText), stop().
+ */
+export function useFieldDictation(onDictatedText) {
+  const [activeField, setActiveField] = useState(null);
+  const [status, setStatus] = useState('idle');
+  const [error, setError] = useState(null);
+  const [micBlocked, setMicBlocked] = useState(false);
+  const [silent, setSilent] = useState(false);
+
+  const clientRef = useRef(null);
+  const audioCtxRef = useRef(null);
+  const streamRef = useRef(null);
+  const workletNodeRef = useRef(null);
+  const activeFieldRef = useRef(null);
+  // Silence tracking (refs so audio frames never trigger re-renders; `silent`
+  // state flips only on transition).
+  const lastAudioTimeRef = useRef(0);
+  const silentRef = useRef(false);
+  // Keep the latest callback without re-creating start().
+  const onTextRef = useRef(onDictatedText);
+  onTextRef.current = onDictatedText;
+
+  const resetState = useCallback(() => {
+    setStatus('idle');
+    setActiveField(null);
+    activeFieldRef.current = null;
+    silentRef.current = false;
+    setSilent(false);
+    // (no audio-level meter state — dictation shows a CSS-only pulse, so we avoid
+    // re-rendering the summary on every audio frame; only `silent` flips, and only
+    // on transition.)
+  }, []);
+
+  const stop = useCallback(async () => {
+    if (!clientRef.current) {
+      resetState();
+      return;
+    }
+    setStatus('stopping');
+    // Stop capturing first so no more audio is queued, then drain + END.
+    cleanupAudio(audioCtxRef, streamRef, workletNodeRef);
+    const client = clientRef.current;
+    clientRef.current = null;
+    client.onDictatedText = () => {};
+    client.onError = () => {};
+    try {
+      await client.end();
+    } catch {
+      // best-effort teardown
+    }
+    resetState();
+  }, [resetState]);
+
+  const start = useCallback(async (fieldId, currentText = '') => {
+    // One field at a time — finish any in-flight session first.
+    if (clientRef.current) {
+      await stop();
+    }
+    setError(null);
+    setMicBlocked(false);
+    setActiveField(fieldId);
+    activeFieldRef.current = fieldId;
+    setStatus('connecting');
+
+    const fail = (message) => {
+      if (message) setError(message);
+      resetState();
+      return false;
+    };
+
+    let config;
+    try {
+      const res = await fetch(`${API_BASE}/dictation-config`, { cache: 'no-store' });
+      config = await res.json();
+      if (config.error) return fail(config.error);
+    } catch {
+      return fail('Failed to get dictation config');
+    }
+
+    let client;
+    try {
+      client = createDictationClient(config);
+    } catch (err) {
+      return fail(err.message || 'Failed to start dictation');
+    }
+    client.onDictatedText = (text) => {
+      const fid = activeFieldRef.current;
+      if (fid != null && onTextRef.current) onTextRef.current(fid, text);
+    };
+    client.onError = (msg, code) => {
+      // 83011 = Nabla silence timeout; the server closes the socket, which the
+      // client already surfaces via its close handling — not user-actionable.
+      if (code === 83011) return;
+      setError(code ? `${msg} (${code})` : msg);
+    };
+    clientRef.current = client;
+
+    // Acquire the mic and start capturing BEFORE opening the socket, so buffered
+    // audio drains as soon as CONFIG is sent (avoids Nabla's silence timeout) and
+    // no leading speech is lost while connecting.
+    let stream;
+    try {
+      stream = await navigator.mediaDevices.getUserMedia({
+        audio: { sampleRate: TARGET_SAMPLE_RATE, channelCount: 1, echoCancellation: true },
+      });
+    } catch {
+      client.forceEnd();
+      clientRef.current = null;
+      setMicBlocked(true);
+      return fail(null);
+    }
+    streamRef.current = stream;
+
+    try {
+      const audioCtx = new AudioContext({ sampleRate: TARGET_SAMPLE_RATE });
+      audioCtxRef.current = audioCtx;
+
+      const processorUrl = new URL('./rawPcm16Processor.js', import.meta.url).href;
+      await audioCtx.audioWorklet.addModule(processorUrl);
+
+      const source = audioCtx.createMediaStreamSource(stream);
+      const workletNode = new AudioWorkletNode(audioCtx, 'raw-pcm16-processor');
+      workletNodeRef.current = workletNode;
+
+      workletNode.port.onmessage = (event) => {
+        const { pcm16, rms } = event.data;
+        if (rms >= SILENCE_RMS_THRESHOLD) {
+          lastAudioTimeRef.current = Date.now();
+          if (silentRef.current) {
+            silentRef.current = false;
+            setSilent(false);
+          }
+        }
+        if (clientRef.current) clientRef.current.sendAudio(pcm16);
+      };
+
+      source.connect(workletNode);
+      workletNode.connect(audioCtx.destination);
+    } catch (err) {
+      client.forceEnd();
+      clientRef.current = null;
+      cleanupAudio(audioCtxRef, streamRef, workletNodeRef);
+      return fail('Audio setup failed: ' + err.message);
+    }
+
+    // Open the socket last. sendAudio() has been buffering into the client, so
+    // the queued audio flushes the moment CONFIG is sent.
+    try {
+      const caret = currentText.length;
+      await client.connect({ text: currentText, selection_start: caret, selection_length: 0 });
+    } catch {
+      client.forceEnd();
+      clientRef.current = null;
+      cleanupAudio(audioCtxRef, streamRef, workletNodeRef);
+      return fail('Failed to connect to dictation service');
+    }
+
+    lastAudioTimeRef.current = Date.now();
+    silentRef.current = false;
+    setSilent(false);
+    setStatus('listening');
+    return true;
+  }, [stop, resetState]);
+
+  // Flip `silent` on while listening if no above-threshold audio has arrived for
+  // SILENCE_TIMEOUT_MS. Only touches state on transition, so no per-frame churn.
+  useEffect(() => {
+    if (status !== 'listening') return undefined;
+    const timer = setInterval(() => {
+      const last = lastAudioTimeRef.current || Date.now();
+      if (Date.now() - last >= SILENCE_TIMEOUT_MS && !silentRef.current) {
+        silentRef.current = true;
+        setSilent(true);
+      }
+    }, 1000);
+    return () => clearInterval(timer);
+  }, [status]);
+
+  // Tear everything down if the component unmounts mid-dictation.
+  useEffect(() => () => {
+    cleanupAudio(audioCtxRef, streamRef, workletNodeRef);
+    if (clientRef.current) {
+      clientRef.current.forceEnd();
+      clientRef.current = null;
+    }
+  }, []);
+
+  return { activeField, status, error, micBlocked, silent, start, stop };
+}

--- a/hyperscribe/scribe/static/dictationClient.js
+++ b/hyperscribe/scribe/static/dictationClient.js
@@ -1,0 +1,296 @@
+/**
+ * Vendor-abstracted WebSocket client for real-time single-field DICTATION.
+ *
+ * This is deliberately SEPARATE from scribeClient.js (ambient transcription):
+ * dictation talks into one note field post-generation and must never feed the
+ * note-generation transcript. It targets Nabla's `dictate-ws` endpoint, which
+ * differs from `transcribe-ws`:
+ *  - a single `dictation_locale` (not a `speech_locales` array), no `stream_id`
+ *  - `punctuation_mode: "EXPLICIT"` — the provider dictates punctuation aloud
+ *  - a `text_field_context` (current field text + caret) so dictated words are
+ *    inserted at the caret (caret at end ⇒ append, first word capitalised)
+ *  - the server replies with append-only DICTATED_TEXT units (immutable, in
+ *    order, no partial/final revision) that the client appends verbatim
+ *
+ * See: https://docs.nabla.com/server/dictate-ws
+ */
+
+/**
+ * Convert Int16Array to base64 string.
+ * @param {Int16Array} int16Array
+ * @returns {string}
+ */
+function int16ArrayToBase64(int16Array) {
+  const bytes = new Uint8Array(int16Array.buffer, int16Array.byteOffset, int16Array.byteLength);
+  let binary = '';
+  for (let i = 0; i < bytes.length; i++) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  return btoa(binary);
+}
+
+// Fallback drain window after END before we force-close (dictation sessions are
+// short, so a generous but bounded wait is enough for the server to flush).
+const END_TIMEOUT_MS = 15000;
+
+class NablaDictationClient {
+  /**
+   * @param {object} config — from the /dictation-config endpoint
+   * @param {string} config.ws_url
+   * @param {string} config.access_token
+   * @param {number} config.sample_rate
+   * @param {string} config.encoding
+   * @param {string} config.dictation_locale
+   * @param {string} config.punctuation_mode
+   */
+  constructor(config) {
+    this._config = config;
+    this._ws = null;
+    this._textFieldContext = null;
+
+    // Audio buffer — FIFO queue. Each entry: { seqId, base64, sampleCount, sent }.
+    // dictate-ws acks audio chunks and errors past ~10s of un-acked audio, so we
+    // cap in-flight (sent-but-unacked) audio at ~9s and drain as ACKs arrive.
+    this._buffer = [];
+    this._nextSeqId = 0;
+    this._lastAckedSeqId = -1;
+    this._inflightSamples = 0;
+    this._maxInflightSamples = 9 * (config.sample_rate || 16000);
+
+    // End-of-session state.
+    this._ending = false;
+    this._endSent = false;
+    this._intentionalClose = false;
+    this._ended = false;
+    this._endResolve = null;
+    this._endTimeout = null;
+
+    /** @type {function(string): void} — one appended DICTATED_TEXT unit */
+    this.onDictatedText = () => {};
+    /** @type {function(string, number=): void} */
+    this.onError = () => {};
+    /** @type {function(): void} — fired once the session is fully torn down */
+    this.onEnd = () => {};
+  }
+
+  /**
+   * Open the dictate WebSocket, send CONFIG (with the field's text/caret), and
+   * resolve once connected. Rejects if the initial connection fails.
+   * @param {object} textFieldContext - has text, selection_start, selection_length
+   * @returns {Promise<void>}
+   */
+  connect(textFieldContext) {
+    this._textFieldContext = textFieldContext || { text: '', selection_start: 0, selection_length: 0 };
+    return new Promise((resolve, reject) => {
+      let opened = false;
+      let ws;
+      try {
+        ws = new WebSocket(this._config.ws_url, ['dictate-protocol', `jwt-${this._config.access_token}`]);
+      } catch {
+        reject(new Error('WebSocket connection error'));
+        return;
+      }
+
+      ws.onopen = () => {
+        opened = true;
+        this._ws = ws;
+        this._sendConfig();
+        this._flush();
+        resolve();
+      };
+
+      ws.onerror = () => {
+        // Surfaced via onclose.
+      };
+
+      ws.onmessage = (event) => this._handleMessage(event.data);
+
+      ws.onclose = () => {
+        if (this._ws === ws) this._ws = null;
+        if (!opened) {
+          reject(new Error('WebSocket connection error'));
+          return;
+        }
+        // Opened, then closed. A clean close after END means the server flushed
+        // all dictated text. An unexpected close (e.g. silence timeout 83011)
+        // ends the session too — dictation does not auto-reconnect.
+        if (!this._intentionalClose && !this._endSent) {
+          this.onError('Dictation connection lost');
+        }
+        this._resolveEnd();
+      };
+    });
+  }
+
+  /**
+   * Buffer PCM16 audio and flush to the WebSocket when possible. Safe to call
+   * before connect() resolves — audio buffers until the socket opens.
+   * @param {Int16Array} pcm16Int16Array
+   */
+  sendAudio(pcm16Int16Array) {
+    if (this._ending) return;
+    const seqId = this._nextSeqId++;
+    this._buffer.push({
+      seqId,
+      base64: int16ArrayToBase64(pcm16Int16Array),
+      sampleCount: pcm16Int16Array.length,
+      sent: false,
+    });
+    this._flush();
+  }
+
+  /**
+   * Signal end of dictation: drain the buffer, send END, and wait for the server
+   * to flush remaining DICTATED_TEXT and close the socket (up to END_TIMEOUT_MS).
+   * @returns {Promise<void>}
+   */
+  async end() {
+    if (this._ending) return;
+    this._ending = true;
+    this._flush();
+
+    if (!this._ws) {
+      this._resolveEnd();
+      return;
+    }
+
+    return new Promise((resolve) => {
+      this._endResolve = resolve;
+      this._endTimeout = setTimeout(() => {
+        this._intentionalClose = true;
+        if (this._ws) {
+          this._ws.close();
+          this._ws = null;
+        }
+        this._resolveEnd();
+      }, END_TIMEOUT_MS);
+    });
+  }
+
+  /** Force-close immediately without draining the buffer. */
+  forceEnd() {
+    this._intentionalClose = true;
+    this._ending = true;
+    if (this._ws) {
+      this._ws.close();
+      this._ws = null;
+    }
+    this._resolveEnd();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Internal
+  // ---------------------------------------------------------------------------
+
+  /** @private */
+  _sendConfig() {
+    if (!this._ws) return;
+    this._ws.send(JSON.stringify({
+      type: 'CONFIG',
+      encoding: this._config.encoding,
+      sample_rate: this._config.sample_rate,
+      dictation_locale: this._config.dictation_locale,
+      punctuation_mode: this._config.punctuation_mode,
+      text_field_context: this._textFieldContext,
+    }));
+  }
+
+  /**
+   * @private
+   * Send queued chunks up to the backpressure limit. When ending and the buffer
+   * is fully acknowledged, send the END frame.
+   */
+  _flush() {
+    if (!this._ws || this._ws.readyState !== WebSocket.OPEN) return;
+    if (this._endSent) return;
+
+    for (const chunk of this._buffer) {
+      if (chunk.sent) continue;
+      if (this._inflightSamples + chunk.sampleCount > this._maxInflightSamples) break;
+
+      this._ws.send(JSON.stringify({
+        type: 'AUDIO_CHUNK',
+        seq_id: chunk.seqId,
+        payload: chunk.base64,
+      }));
+      chunk.sent = true;
+      this._inflightSamples += chunk.sampleCount;
+    }
+
+    if (this._ending && this._buffer.length === 0 && !this._endSent) {
+      this._endSent = true;
+      this._ws.send(JSON.stringify({ type: 'END' }));
+    }
+  }
+
+  /** @private */
+  _handleMessage(raw) {
+    let msg;
+    try {
+      msg = JSON.parse(raw);
+    } catch {
+      return;
+    }
+
+    switch (msg.type) {
+      case 'DICTATED_TEXT':
+        this.onDictatedText(msg.text || '');
+        break;
+      case 'AUDIO_CHUNK_ACK':
+        this._handleAck(msg);
+        break;
+      case 'ERROR':
+      case 'ERROR_MESSAGE':
+        this.onError(msg.message || 'Unknown error', msg.code);
+        break;
+    }
+  }
+
+  /**
+   * @private
+   * Discard acknowledged chunks and flush more now that backpressure has eased.
+   */
+  _handleAck(msg) {
+    const ackId = msg.ack_id;
+    if (ackId <= this._lastAckedSeqId) return;
+    this._lastAckedSeqId = ackId;
+
+    while (this._buffer.length > 0 && this._buffer[0].seqId <= ackId) {
+      const chunk = this._buffer.shift();
+      if (chunk.sent) {
+        this._inflightSamples -= chunk.sampleCount;
+      }
+    }
+
+    this._flush();
+  }
+
+  /** @private */
+  _resolveEnd() {
+    if (this._endTimeout) {
+      clearTimeout(this._endTimeout);
+      this._endTimeout = null;
+    }
+    const resolve = this._endResolve;
+    this._endResolve = null;
+    if (!this._ended) {
+      this._ended = true;
+      this.onEnd();
+    }
+    if (resolve) resolve();
+  }
+}
+
+/**
+ * Factory for a vendor-specific dictation client.
+ * @param {object} config - Config object from /dictation-config
+ * @returns {NablaDictationClient}
+ */
+export function createDictationClient(config) {
+  switch (config.vendor) {
+    case 'nabla':
+      return new NablaDictationClient(config);
+    default:
+      throw new Error(`Unknown dictation vendor: ${config.vendor}`);
+  }
+}

--- a/hyperscribe/scribe/static/index.html
+++ b/hyperscribe/scribe/static/index.html
@@ -70,6 +70,7 @@
       isAuthor: '{{ is_author }}' === 'true',
       alertFacilityEnabled: '{{ alert_facility_enabled }}' === 'true',
       manualModeOnly: '{{ manual_mode_only }}' === 'true',
+      dictationEnabled: '{{ dictation_enabled }}' === 'true',
       initialData: initialData,
     };
     render(h(App, config), document.getElementById('app'));

--- a/hyperscribe/scribe/static/soap-group.js
+++ b/hyperscribe/scribe/static/soap-group.js
@@ -714,7 +714,7 @@ function AddConditionSearch({ onAdd, patientId }) {
   `;
 }
 
-export function SoapGroup({ title, groupColor, sections, commandBySectionKey, onEditCommand, onDeleteCommand, adHocCommands, assignees, onAddTask, onAddOrder, onAddPlan, onAddVitals, onAddPhysicalExam, onAddMentalStatusExam, onAddMedication, onAddAllergy, onAddStopMedication, onAddRemoveAllergy, onAddResolveCondition, onAddHistory, onAddQuestionnaire, onAddCharge, readOnly, isAmending = false, sectionConditions, patientId, noteId, staffId, staffName, recommendations, onEditRecommendation, onDeleteRecommendation, onAcceptRecommendation, onRejectRecommendation, onAddCondition, unmatchedConditions, diagnosisSuggestions, noteDiagnoses = [], onAddNow, hideRejected, alertFacilityEnabled, onEditingChange, questionnaireScores, chargeMatrixDiagnoses = [], chargeMatrixCharges = [], searchCharges = () => {}, suggestedCharges = [], onToggleChargePointer = () => {}, onReorderDiagnoses = () => {}, onAddChargeModifier = () => {}, onRemoveChargeModifier = () => {}, onSetChargeComment = () => {}, onClearChargeComment = () => {}, onRemoveChargeByUuid = () => {}, examTemplates, onCarryForwardExam, isPsychiatry = false }) {
+export function SoapGroup({ title, groupColor, sections, commandBySectionKey, onEditCommand, onDeleteCommand, adHocCommands, assignees, onAddTask, onAddOrder, onAddPlan, onAddVitals, onAddPhysicalExam, onAddMentalStatusExam, onAddMedication, onAddAllergy, onAddStopMedication, onAddRemoveAllergy, onAddResolveCondition, onAddHistory, onAddQuestionnaire, onAddCharge, readOnly, isAmending = false, sectionConditions, patientId, noteId, staffId, staffName, recommendations, onEditRecommendation, onDeleteRecommendation, onAcceptRecommendation, onRejectRecommendation, onAddCondition, unmatchedConditions, diagnosisSuggestions, noteDiagnoses = [], onAddNow, hideRejected, alertFacilityEnabled, onEditingChange, questionnaireScores, chargeMatrixDiagnoses = [], chargeMatrixCharges = [], searchCharges = () => {}, suggestedCharges = [], onToggleChargePointer = () => {}, onReorderDiagnoses = () => {}, onAddChargeModifier = () => {}, onRemoveChargeModifier = () => {}, onSetChargeComment = () => {}, onClearChargeComment = () => {}, onRemoveChargeByUuid = () => {}, examTemplates, onCarryForwardExam, isPsychiatry = false, dictation }) {
   const isCharges = title === 'CHARGES';
   const coveredKeys = getCoveredKeys(commandBySectionKey);
 
@@ -932,6 +932,7 @@ export function SoapGroup({ title, groupColor, sections, commandBySectionKey, on
                     onEdit=${onEditCommand}
                     readOnly=${narrativeRowReadOnly}
                     onEditingChange=${onEditingChange}
+                    dictation=${dictation}
                   />
                 </div>
                 ${planResolves.map(re => {
@@ -1553,6 +1554,7 @@ export function SoapGroup({ title, groupColor, sections, commandBySectionKey, on
                     onDelete=${onDeleteCommand}
                     readOnly=${planRowReadOnly}
                     onEditingChange=${onEditingChange}
+                    dictation=${dictation}
                   />
                 </div>
                 ${!readOnly && !entry.command.already_documented && !entry.command._adding && html`<div class="recommendation-actions"><button type="button" class="rec-remove-x" onClick=${() => onDeleteCommand(entry.index)} title="Remove">${ICON_X}</button></div>`}

--- a/hyperscribe/scribe/static/styles.css
+++ b/hyperscribe/scribe/static/styles.css
@@ -762,6 +762,20 @@ h2 { margin-bottom: 4px; }
 .vitals-bp-slash { font-weight: 600; color: #888; }
 .command-row-placeholder { font-size: 14px; color: #aaa; font-style: italic; }
 .vitals-placeholder { font-size: 14px; color: #aaa; font-style: italic; }
+
+/* Field dictation mic (KOALA-6233) — sits on the right of CC / HPI / Plan rows. */
+.command-row-mic { flex: 0 0 auto; margin-left: auto; display: inline-flex; align-items: center; justify-content: center; width: 30px; height: 30px; padding: 0; border: none; border-radius: 50%; background: transparent; color: #667085; cursor: pointer; transition: background 0.15s, color 0.15s; }
+.command-row-mic svg { width: 17px; height: 17px; }
+.command-row-mic:hover { background: #eef1f4; color: #052B49; }
+.command-row-mic.recording { background: #fde8e8; color: #d92d20; animation: command-row-mic-pulse 1.3s ease-in-out infinite; }
+/* No audio detected: amber, no pulse (pulsing implies live capture). */
+.command-row-mic.recording.silent { background: #fef3c7; color: #b45309; animation: none; }
+.command-row-mic.error { color: #d92d20; }
+.command-row.dictating { outline: 2px solid rgba(217, 45, 32, 0.35); outline-offset: 1px; }
+@keyframes command-row-mic-pulse { 0%, 100% { box-shadow: 0 0 0 0 rgba(217, 45, 32, 0.35); } 50% { box-shadow: 0 0 0 6px rgba(217, 45, 32, 0); } }
+/* Dictation status line under the field (visible even when the field has text). */
+.command-row-dictation-status { font-size: 12px; line-height: 1.4; color: #d92d20; padding: 3px 4px 0; }
+.command-row-dictation-status.warning { font-weight: 600; }
 .vitals-input-error { border-color: #dc2626; }
 .vitals-input-error:focus { border-color: #dc2626; }
 .vitals-error { font-size: 11px; color: #dc2626; font-weight: 600; white-space: nowrap; }

--- a/hyperscribe/scribe/static/summary.js
+++ b/hyperscribe/scribe/static/summary.js
@@ -4,6 +4,7 @@ import htm from 'https://esm.sh/htm@3.1.1';
 import { SoapGroup, parseAPBlocks, matchCondition } from '/plugin-io/api/hyperscribe/scribe/static/soap-group.js';
 import { collectQuestionnaireScores } from '/plugin-io/api/hyperscribe/scribe/static/questionnaire-score.js';
 import { useRecording } from '/plugin-io/api/hyperscribe/scribe/static/recording-hook.js';
+import { useFieldDictation } from '/plugin-io/api/hyperscribe/scribe/static/dictation-hook.js';
 import { initAuditLog, logEvent } from '/plugin-io/api/hyperscribe/scribe/static/audit-log.js';
 import { connectScribeWS } from '/plugin-io/api/hyperscribe/scribe/static/scribe-ws.js';
 import { FinishRecordingButton } from '/plugin-io/api/hyperscribe/scribe/static/finish-button.js';
@@ -350,7 +351,7 @@ function buildCommandBySectionKey(commands) {
   return map;
 }
 
-function renderSoapGroups(sections, commandBySectionKey, onEditCommand, onDeleteCommand, { adHocCommands, objectiveAdHocCommands, historyAdHocCommands, subjectiveAdHocCommands, chargeAdHocCommands, assignees, onAddTask, onAddOrder, onAddPlan, onAddMedication, onAddAllergy, onAddStopMedication, onAddRemoveAllergy, onAddResolveCondition, onAddHistory, onAddQuestionnaire, onAddCharge, onAddTemplateCharge, onRemoveChargeByCpt, templateCharges, readOnly, isAmending, sectionConditions, patientId, noteId, staffId, staffName, recommendations, onEditRecommendation, onDeleteRecommendation, onAcceptRecommendation, onRejectRecommendation, onAddCondition, unmatchedConditions, diagnosisSuggestions, onAddNow, onAddVitals, onAddPhysicalExam, onAddMentalStatusExam, hideRejected, alertFacilityEnabled, onEditingChange, questionnaireScores, chargeMatrixDiagnoses, chargeMatrixCharges, searchCharges, suggestedCharges, onToggleChargePointer, onReorderDiagnoses, onAddChargeModifier, onRemoveChargeModifier, onSetChargeComment, onClearChargeComment, onRemoveChargeByUuid, examTemplates, onCarryForwardExam, noteDiagnoses, isPsychiatry } = {}) {
+function renderSoapGroups(sections, commandBySectionKey, onEditCommand, onDeleteCommand, { adHocCommands, objectiveAdHocCommands, historyAdHocCommands, subjectiveAdHocCommands, chargeAdHocCommands, assignees, onAddTask, onAddOrder, onAddPlan, onAddMedication, onAddAllergy, onAddStopMedication, onAddRemoveAllergy, onAddResolveCondition, onAddHistory, onAddQuestionnaire, onAddCharge, onAddTemplateCharge, onRemoveChargeByCpt, templateCharges, readOnly, isAmending, sectionConditions, patientId, noteId, staffId, staffName, recommendations, onEditRecommendation, onDeleteRecommendation, onAcceptRecommendation, onRejectRecommendation, onAddCondition, unmatchedConditions, diagnosisSuggestions, onAddNow, onAddVitals, onAddPhysicalExam, onAddMentalStatusExam, hideRejected, alertFacilityEnabled, onEditingChange, questionnaireScores, chargeMatrixDiagnoses, chargeMatrixCharges, searchCharges, suggestedCharges, onToggleChargePointer, onReorderDiagnoses, onAddChargeModifier, onRemoveChargeModifier, onSetChargeComment, onClearChargeComment, onRemoveChargeByUuid, examTemplates, onCarryForwardExam, noteDiagnoses, isPsychiatry, dictation } = {}) {
   return SOAP_GROUPS
     .map(group => {
       const matching = sections.filter(s => group.keys.has(s.key.toLowerCase()));
@@ -421,12 +422,13 @@ function renderSoapGroups(sections, commandBySectionKey, onEditCommand, onDelete
         examTemplates=${(isObjective || isSubjective) ? examTemplates : null}
         onCarryForwardExam=${(isObjective || isSubjective) ? onCarryForwardExam : null}
         isPsychiatry=${isObjective ? isPsychiatry : false}
+        dictation=${dictation}
       />`;
     })
     .filter(Boolean);
 }
 
-export function Scribe({ noteId, patientId, staffId, staffName, providerName, providerPhotoUrl, patientName, patientBirthDate, patientGender, debugMode, noteEditable = true, isAuthor = false, alertFacilityEnabled = false, manualModeOnly = false, initialData = null }) {
+export function Scribe({ noteId, patientId, staffId, staffName, providerName, providerPhotoUrl, patientName, patientBirthDate, patientGender, debugMode, noteEditable = true, isAuthor = false, alertFacilityEnabled = false, manualModeOnly = false, dictationEnabled = false, initialData = null }) {
   const initSummary = initialData?.summary ?? null;
   const [noteData, setNoteData] = useState(initSummary?.note ?? null);
   const [generating, setGenerating] = useState(false);
@@ -1599,6 +1601,62 @@ export function Scribe({ noteId, patientId, staffId, staffName, providerName, pr
       return updated;
     });
   }, [canEdit, noteData, saveSummaryToCache, recommendations, unmatchedConditions, diagnosisSuggestions]);
+
+  // --- Field dictation (KOALA-6233) ---
+  // Talk into a single field (CC / HPI / Plan) after generation, before approval.
+  // Runs on Nabla's separate dictate-ws endpoint and never touches the ambient
+  // transcript / note-generation pipeline. Text streams into the command's live
+  // value (read view updates as you speak); the field is persisted once on stop.
+  const commandsRef = useRef(commands);
+  commandsRef.current = commands;
+
+  // Append one dictated unit verbatim (Nabla owns spacing/punctuation). No save
+  // here — a single save happens on stop, so a stream of words is not a stream
+  // of POSTs.
+  const handleDictatedText = useCallback((index, chunk) => {
+    if (!chunk) return;
+    setCommands(prev => prev.map((cmd, i) => {
+      if (i !== index) return cmd;
+      const dictField = cmd.command_type === 'rfv' ? 'comment' : 'narrative';
+      const nextText = (cmd.data?.[dictField] || '') + chunk;
+      return { ...cmd, data: { ...cmd.data, [dictField]: nextText }, display: nextText };
+    }));
+  }, []);
+
+  const dictation = useFieldDictation(handleDictatedText);
+
+  const toggleDictation = useCallback(async (index) => {
+    if (dictation.activeField === index) {
+      logEvent('DICTATION_STOP', { index });
+      await dictation.stop();
+      // Persist the final text once. Done inside the updater so it always sees
+      // the last streamed chunk (state may not have re-rendered yet after stop),
+      // and it applies the amend tag when amending — mirroring handleEdit's save.
+      setCommands(prev => {
+        const cmd = prev[index];
+        if (!cmd) return prev;
+        const dictField = cmd.command_type === 'rfv' ? 'comment' : 'narrative';
+        const display = cmd.data?.[dictField] || '';
+        let next = { ...cmd, display };
+        if (isAmendingSectionEditable(cmd, wasFinalized && !approved)) {
+          next = { ...next, _amend_edited: true };
+        }
+        const updated = prev.map((c, i) => (i === index ? next : c));
+        saveSummaryToCache(noteData, updated, false, { recommendations, unmatched_conditions: unmatchedConditions, diagnosis_suggestions: diagnosisSuggestions });
+        return updated;
+      });
+      return;
+    }
+    const cmd = commandsRef.current[index];
+    if (!cmd) return;
+    const dictField = cmd.command_type === 'rfv' ? 'comment' : 'narrative';
+    logEvent('DICTATION_START', { index, commandType: cmd.command_type });
+    dictation.start(index, cmd.data?.[dictField] || '');
+  }, [dictation, wasFinalized, approved, noteData, saveSummaryToCache, recommendations, unmatchedConditions, diagnosisSuggestions]);
+
+  useEffect(() => {
+    if (dictation.error) logEvent('DICTATION_ERROR', { error: dictation.error });
+  }, [dictation.error]);
 
   const handleAddTask = useCallback(() => {
     logEvent('ADD_TASK');
@@ -3171,6 +3229,18 @@ export function Scribe({ noteId, patientId, staffId, staffName, providerName, pr
           examTemplates: templates,
           onCarryForwardExam: handleCarryForwardExam,
           isPsychiatry,
+          dictation: {
+            // Gated behind the ScribeDictationEnabled secret. A single physical
+            // mic: also only offered when editable and NOT while ambient recording
+            // (or paused) owns the mic.
+            available: dictationEnabled && canEdit && !isRecording,
+            activeField: dictation.activeField,
+            status: dictation.status,
+            micBlocked: dictation.micBlocked,
+            silent: dictation.silent,
+            error: dictation.error,
+            onToggle: toggleDictation,
+          },
         })}
         ${fromTheNoteCommands.length > 0 && html`
           <div class="summary-section from-the-note-section">

--- a/tests/hyperscribe/scribe/api/test_session_view.py
+++ b/tests/hyperscribe/scribe/api/test_session_view.py
@@ -125,6 +125,70 @@ def test_get_config_auth_error(get_backend: MagicMock) -> None:
     assert result == expected
 
 
+# --- /dictation-config ---
+
+
+@patch("hyperscribe.scribe.api.session_view.get_backend_from_secrets")
+def test_get_dictation_config_success(get_backend: MagicMock) -> None:
+    mock_backend = MagicMock()
+    mock_backend.get_dictation_config.return_value = {
+        "vendor": "nabla",
+        "ws_url": "wss://example.com/dictate-ws",
+        "access_token": "tok",
+        "dictation_locale": "ENGLISH_US",
+        "punctuation_mode": "EXPLICIT",
+    }
+    get_backend.return_value = mock_backend
+
+    view = _helper_instance(staff_id="staff-key-abc")
+    result = view.get_dictation_config()
+
+    expected = [
+        JSONResponse(
+            {
+                "vendor": "nabla",
+                "ws_url": "wss://example.com/dictate-ws",
+                "access_token": "tok",
+                "dictation_locale": "ENGLISH_US",
+                "punctuation_mode": "EXPLICIT",
+            },
+            status_code=HTTPStatus.OK,
+        )
+    ]
+    assert result == expected
+    mock_backend.get_dictation_config.assert_called_once_with(user_external_id="staff-key-abc")
+
+
+@patch("hyperscribe.scribe.api.session_view.get_backend_from_secrets")
+def test_get_dictation_config_unknown_vendor(get_backend: MagicMock) -> None:
+    get_backend.side_effect = ScribeError("Unknown scribe vendor: 'bad'")
+
+    view = _helper_instance()
+    result = view.get_dictation_config()
+
+    expected = [JSONResponse({"error": "Unknown scribe vendor: 'bad'"}, status_code=HTTPStatus.BAD_REQUEST)]
+    assert result == expected
+
+
+@patch("hyperscribe.scribe.api.session_view.get_backend_from_secrets")
+def test_get_dictation_config_unsupported(get_backend: MagicMock) -> None:
+    """A backend that does not support dictation surfaces the ScribeError as a 500."""
+    mock_backend = MagicMock()
+    mock_backend.get_dictation_config.side_effect = ScribeError("This scribe backend does not support dictation")
+    get_backend.return_value = mock_backend
+
+    view = _helper_instance()
+    result = view.get_dictation_config()
+
+    expected = [
+        JSONResponse(
+            {"error": "This scribe backend does not support dictation"},
+            status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
+        )
+    ]
+    assert result == expected
+
+
 # --- /transcript ---
 
 

--- a/tests/hyperscribe/scribe/backend/test_base.py
+++ b/tests/hyperscribe/scribe/backend/test_base.py
@@ -7,6 +7,7 @@ from hyperscribe.scribe.backend import (
     NormalizedData,
     PatientContext,
     ScribeBackend,
+    ScribeError,
     Transcript,
 )
 
@@ -53,6 +54,31 @@ def test_complete_implementation_works() -> None:
 
     normalized = backend.generate_normalized_data(note)
     assert isinstance(normalized, NormalizedData)
+
+
+def test_get_dictation_config_defaults_to_unsupported() -> None:
+    """Dictation is optional: a backend implementing only the three required
+    methods inherits the base default, which raises to tell the
+    /dictation-config endpoint that dictation is unsupported."""
+
+    class NoDictation(ScribeBackend):
+        def get_transcription_config(self) -> dict[str, Any]:
+            return {}
+
+        def generate_note(
+            self,
+            transcript: Transcript,
+            *,
+            patient_context: PatientContext | None = None,
+        ) -> ClinicalNote:
+            return ClinicalNote(title="test")
+
+        def generate_normalized_data(self, note: ClinicalNote) -> NormalizedData:
+            return NormalizedData()
+
+    backend = NoDictation()
+    with pytest.raises(ScribeError, match="does not support dictation"):
+        backend.get_dictation_config()
 
 
 def test_generate_note_accepts_patient_context() -> None:

--- a/tests/hyperscribe/scribe/clients/nabla/test_backend.py
+++ b/tests/hyperscribe/scribe/clients/nabla/test_backend.py
@@ -53,6 +53,30 @@ def test_get_transcription_config_calls_user_tokens() -> None:
     backend._auth.get_user_tokens.assert_called_once_with("staff-key")
 
 
+def test_get_dictation_config() -> None:
+    backend, _ = _make_backend()
+    config = backend.get_dictation_config(user_external_id="staff-key")
+
+    assert config["vendor"] == "nabla"
+    assert config["ws_url"] == "wss://us.api.nabla.com/v1/core/user/dictate-ws?nabla-api-version=2026-06-12"
+    assert config["access_token"] == "user-access-token"
+    assert config["refresh_token"] == "user-refresh-token"
+    assert config["sample_rate"] == 16000
+    assert config["encoding"] == "PCM_S16LE"
+    assert config["dictation_locale"] == "ENGLISH_US"
+    assert config["punctuation_mode"] == "EXPLICIT"
+    # dictate-ws is single-locale and single-stream — the transcribe-only keys are absent.
+    assert "speech_locales" not in config
+    assert "stream_id" not in config
+
+
+def test_get_dictation_config_calls_user_tokens() -> None:
+    backend, _ = _make_backend()
+    backend.get_dictation_config(user_external_id="staff-key")
+
+    backend._auth.get_user_tokens.assert_called_once_with("staff-key")
+
+
 def test_generate_note() -> None:
     backend, mock_rest_client = _make_backend()
     mock_rest_client.generate_note.return_value = {


### PR DESCRIPTION
https://canvasmedical.atlassian.net/browse/KOALA-6233


## Summary
Adds post-generation field dictation to Canvas Scribe (KOALA-6233): a mic on the **Chief Complaint, HPI, and Plan** fields lets a provider dictate free text into a field after the note is generated (or in manual mode), before it's approved. Runs on Nabla's dedicated `dictate-ws` endpoint and is **fully independent of the ambient recording / note-generation transcript** — dictated text goes only into the targeted field.

## What's included
- **Backend** — `get_dictation_config` on the scribe backend (Nabla `dictate-ws`: single `dictation_locale`, `EXPLICIT` punctuation, reuses the per-user token) + `GET /scribe-session/dictation-config`. Dictation is an optional backend capability, so the base `ScribeBackend` raises when unsupported.
- **Client + hook** — `dictationClient.js` (CONFIG with `text_field_context`, audio-chunk backpressure, append-only `DICTATED_TEXT`) and `useFieldDictation` (`dictation-hook.js`), a self-contained mic session with silence detection, independent of the ambient recorder.
- **UI + gate** — a mic on the CC/HPI/Plan read rows streams dictation into the field live, with a status line (connecting / listening / no-audio) below the input. The Appointments section is excluded. Gated behind the `ScribeDictationEnabled` true/false secret.

## Behavior
- Mic shows only when: `ScribeDictationEnabled` is `true`, viewer is the note author, note is editable and not approved, and no ambient recording is active (single physical mic).
- EXPLICIT punctuation — the provider dictates "period", "new line", etc.; Nabla inserts at the field caret, so text appends onto existing AI content.
- Text streams into the field live; on stop the field is persisted once (amend-tagged when amending).

## Testing
- Backend: 6 new tests; full scribe suite green (**1433 passing**); ruff + mypy + format clean.
- Frontend: `node --check` on all touched modules; client framing/backpressure smoke-tested against a fake socket. Verified end-to-end on scribe-qa — conversation → generate → dictate into all three fields, manual mode, and secret on/off.
- Nabla `dictate-ws` protocol taken from Nabla's official sample app + docs.

## Enabling
Set the `ScribeDictationEnabled` secret to `true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)