### PR TITLE
feat(scribe): enter amend edit mode in one action (KOALA-6315)

### DIFF
--- a/hyperscribe/scribe/static/summary.js
+++ b/hyperscribe/scribe/static/summary.js
@@ -768,6 +768,9 @@ export function Scribe({ noteId, patientId, staffId, staffName, providerName, pr
     const cleanup = connectScribeWS(noteId, (msg) => {
       if (msg.type === 'NOTE_STATE_CHANGED') {
         setNoteEditable(msg.editable);
+        // KOALA-6315: note becoming editable = the "Amend" click → enter edit
+        // mode directly. applyMakeChanges no-ops unless finalized + author.
+        if (msg.editable) applyMakeChangesRef.current();
       }
     });
     return cleanup;
@@ -818,8 +821,12 @@ export function Scribe({ noteId, patientId, staffId, staffName, providerName, pr
     if (isNoteEditable) saveBlockedRef.current = false;
   }, [isNoteEditable, noteId]);
 
-  const handleMakeChanges = useCallback(() => {
-    if (!isAuthor || !isNoteEditable || !approved) return;
+  // Core amend transition: drop un-inserted AI recs and flip back to editable.
+  // No `isNoteEditable` guard on purpose — it runs off the NOTE_STATE_CHANGED
+  // event, where `editable` is the proof and that state hasn't committed yet.
+  // The "Make changes" button gates on `isNoteEditable` via handleMakeChanges.
+  const applyMakeChanges = useCallback(() => {
+    if (!isAuthor || !approved) return;
     // Either `already_documented` OR `command_uuid` means "already on the note"
     // — same predicate as the `insertable` filter (see 8ea1df36 back-compat
     // fix). Pre-existing finalized notes (signed before the explicit
@@ -860,7 +867,23 @@ export function Scribe({ noteId, patientId, staffId, staffName, providerName, pr
     // already, but ensure the React state matches without waiting for the
     // /summary refetch.
     setWasFinalized(true);
-  }, [isAuthor, isNoteEditable, approved, commands, recommendations]);
+  }, [isAuthor, approved, commands, recommendations]);
+
+  // "Make changes" button: editable-note guard, then the shared transition.
+  const handleMakeChanges = useCallback(() => {
+    if (!isNoteEditable) return;
+    applyMakeChanges();
+  }, [isNoteEditable, applyMakeChanges]);
+
+  // Latest applyMakeChanges for the WS callback (bound once per noteId, so it
+  // would otherwise capture stale state). Reacting to the note-state EVENT
+  // rather than a derived-state effect is deliberate: a "Save changes"
+  // re-approve emits no note-state event, so it can't bounce us back into edit
+  // mode — the note just re-locks.
+  const applyMakeChangesRef = useRef(applyMakeChanges);
+  useEffect(() => {
+    applyMakeChangesRef.current = applyMakeChanges;
+  }, [applyMakeChanges]);
 
   // Keep the recommendations ref in lockstep with state so syncNoteCommands
   // (a stable callback that intentionally avoids `recommendations` in its deps)

--- a/tests/hyperscribe/scribe/api/test_session_view.py
+++ b/tests/hyperscribe/scribe/api/test_session_view.py
@@ -2112,20 +2112,23 @@ def test_summary_js_make_changes_preserves_on_note_recommendations() -> None:
     prescribe) live in the `recommendations` array with command_uuid +
     already_documented and carry NO section_key — syncNoteCommands keeps them
     out of the from_the_note bucket only via `recommendationUuids` (built from
-    recommendationsRef). A blanket `setRecommendations([])` in handleMakeChanges
-    emptied that guard, so the next sync re-appended these still-on-chart
-    commands as ADDITIONAL COMMANDS. handleMakeChanges must instead keep the
+    recommendationsRef). A blanket `setRecommendations([])` in the amend
+    transition emptied that guard, so the next sync re-appended these still-on
+    -chart commands as ADDITIONAL COMMANDS. The transition must instead keep the
     on-note recommendations (filter by the same `onNote` predicate it uses for
     commands) and prime the ref so the guard survives the amend.
+
+    The transition lives in `applyMakeChanges` (KOALA-6315); `handleMakeChanges`
+    (the button) and the NOTE_STATE_CHANGED handler both delegate to it.
     """
     from pathlib import Path
 
     summary_js = Path(__file__).resolve().parents[4] / "hyperscribe" / "scribe" / "static" / "summary.js"
     src = summary_js.read_text()
 
-    decl = "const handleMakeChanges = useCallback("
+    decl = "const applyMakeChanges = useCallback("
     start = src.find(decl)
-    assert start != -1, "Expected `const handleMakeChanges = useCallback(` in summary.js."
+    assert start != -1, "Expected `const applyMakeChanges = useCallback(` in summary.js."
     open_brace_pos = src.find("{", start)
     depth = 0
     end = -1
@@ -2137,22 +2140,22 @@ def test_summary_js_make_changes_preserves_on_note_recommendations() -> None:
             if depth == 0:
                 end = i
                 break
-    assert end != -1, "Could not find handleMakeChanges body."
+    assert end != -1, "Could not find applyMakeChanges body."
     body = src[start:end]
 
     assert "setRecommendations([])" not in body, (
-        "handleMakeChanges must NOT blanket-clear recommendations — that drops "
+        "applyMakeChanges must NOT blanket-clear recommendations — that drops "
         "accepted/inserted recs from the array, emptying the recommendationUuids "
         "guard so the next sync reshuffles them into ADDITIONAL COMMANDS "
         "(KOALA-5687)."
     )
     assert "recommendations.filter(onNote)" in body, (
-        "handleMakeChanges must keep on-note recommendations via "
+        "applyMakeChanges must keep on-note recommendations via "
         "`recommendations.filter(onNote)` (same predicate as commands), so "
         "accepted recs stay in their SOAP section through the amend (KOALA-5687)."
     )
     assert "commitRecommendations(keptRecommendations)" in body, (
-        "handleMakeChanges must commit the kept recommendations via "
+        "applyMakeChanges must commit the kept recommendations via "
         "`commitRecommendations(...)` so recommendationsRef is primed "
         "synchronously for the next syncNoteCommands (KOALA_5634_RECOMMENDATIONS_REF)."
     )


### PR DESCRIPTION
https://canvasmedical.atlassian.net/browse/KOALA-6315

## What & why

KOALA-6315. Amending a finalized Scribe note took several steps — click **Amend** in the note header, open the Scribe tab, scroll to the top, and click **Make changes**. This removes the redundant last step: clicking **Amend** now drops the Scribe tab straight into the amendment edit state.

## How

- The note-header **Amend** unlocks a signed note (`locked → editable`), which reaches the tab as a `NOTE_STATE_CHANGED{editable:true}` WebSocket message. The handler now fires the amend transition directly instead of waiting for a manual **Make changes** click.
- The transition is split into `applyMakeChanges` (core — drops un-inserted AI recs, re-enters the editable amendment state; guards on `isAuthor && approved` only) and a thin `handleMakeChanges` button wrapper that keeps the `isNoteEditable` guard. `applyMakeChanges` intentionally omits the `isNoteEditable` guard because it runs off the event, where the `editable` flag is the proof of editability and the React state hasn't committed yet.
- **Reacting to the note-state event, not a derived-state effect, is deliberate:** a "Save changes" re-approve flips `approved` back to `true` but emits no note-state event, so it can't bounce the provider back into edit mode — the note re-locks correctly.
- The **Make changes** button is kept as the manual affordance (e.g. the approved-but-not-signed reopen still uses it).

## Scope

Frontend-only, `hyperscribe/scribe/static/summary.js`. No backend/migration/protobuf/doc changes. The KOALA-5687 source-guard test is repointed from `handleMakeChanges` to `applyMakeChanges` (invariant unchanged, just relocated).

## Testing

- `ruff` / `ruff format` / `mypy` / `pytest` all green via pre-commit (full scribe suite).
- ESM `node --check` clean; no single-line Django-template `{{}}`/`{%%}` in the served JS.
- Manual QA in scribe-qa (no JS test harness in old hyperscribe): (a) sign → **Amend** → open tab → already in edit mode; (b) edit → **Save changes** → tab re-locks to "Charting finalized"; (c) **Amend** again → re-enters edit mode; (d) non-author / still-signed note → unchanged read-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
