### PR TITLE
feat(scribe): conversation/dictation capture mode (KOALA-5513)

### DIFF
--- a/hyperscribe/CANVAS_MANIFEST.json
+++ b/hyperscribe/CANVAS_MANIFEST.json
@@ -307,6 +307,7 @@
     "ScribeBackend",
     "ScribeDebugStaffers",
     "ScribeDictationEnabled",
+    "ScribeCaptureDictationEnabled",
     "ScribeManualModeOnly",
     "ScribeNoteTypes",
     "ScribePilotStaffers",

--- a/hyperscribe/scribe/api/scribe_view.py
+++ b/hyperscribe/scribe/api/scribe_view.py
@@ -74,6 +74,11 @@ class ScribeView(StaffSessionAuthMixin, SimpleAPI):
         # "true" match so setting the secret to "false" disables it (unlike the
         # truthy-if-present secrets, where any value would enable).
         dictation_enabled = str(self.secrets.get("ScribeDictationEnabled", "")).strip().lower() == "true"
+        # Whole-visit dictation capture mode (the Conversation | Dictation toggle,
+        # KOALA-5513) is gated independently from field dictation so it can be
+        # enabled/disabled on its own while the broader note-gen fix is worked out.
+        # Same strict "true" match so setting it to "false" disables it.
+        capture_dictation_enabled = str(self.secrets.get("ScribeCaptureDictationEnabled", "")).strip().lower() == "true"
 
         html = render_to_string(
             "scribe/static/index.html",
@@ -94,6 +99,7 @@ class ScribeView(StaffSessionAuthMixin, SimpleAPI):
                 "alert_facility_enabled": "true" if self.secrets.get("AlertFacilityEnabled") else "",
                 "manual_mode_only": "true" if self.secrets.get("ScribeManualModeOnly") else "",
                 "dictation_enabled": "true" if dictation_enabled else "",
+                "capture_dictation_enabled": "true" if capture_dictation_enabled else "",
                 "initial_data": _safe_json(initial_data),
             },
         )

--- a/hyperscribe/scribe/static/app.js
+++ b/hyperscribe/scribe/static/app.js
@@ -6,7 +6,7 @@ import { Audit } from '/plugin-io/api/hyperscribe/scribe/static/audit.js';
 
 const html = htm.bind(h);
 
-export function App({ noteId, view, providerName, providerPhotoUrl, patientName, patientBirthDate, patientGender, patientId, staffId, staffName, debugMode, noteEditable, isAuthor, alertFacilityEnabled, manualModeOnly, dictationEnabled, initialData }) {
+export function App({ noteId, view, providerName, providerPhotoUrl, patientName, patientBirthDate, patientGender, patientId, staffId, staffName, debugMode, noteEditable, isAuthor, alertFacilityEnabled, manualModeOnly, dictationEnabled, captureDictationEnabled, initialData }) {
   if (view === 'audit') {
     return html`<${Audit} noteId=${noteId} />`;
   }
@@ -32,6 +32,7 @@ export function App({ noteId, view, providerName, providerPhotoUrl, patientName,
       alertFacilityEnabled=${alertFacilityEnabled}
       manualModeOnly=${manualModeOnly}
       dictationEnabled=${dictationEnabled}
+      captureDictationEnabled=${captureDictationEnabled}
       initialData=${initialData}
     />`;
   }

--- a/hyperscribe/scribe/static/index.html
+++ b/hyperscribe/scribe/static/index.html
@@ -71,6 +71,7 @@
       alertFacilityEnabled: '{{ alert_facility_enabled }}' === 'true',
       manualModeOnly: '{{ manual_mode_only }}' === 'true',
       dictationEnabled: '{{ dictation_enabled }}' === 'true',
+      captureDictationEnabled: '{{ capture_dictation_enabled }}' === 'true',
       initialData: initialData,
     };
     render(h(App, config), document.getElementById('app'));

--- a/hyperscribe/scribe/static/recording-hook.js
+++ b/hyperscribe/scribe/static/recording-hook.js
@@ -9,7 +9,7 @@ import {
   reconnectSessionOffset,
   drainResolution,
   finishDrainDecision,
-  buildDictationEntry,
+  appendDictatedText,
 } from './transcript-merge.js';
 import { logEvent } from '/plugin-io/api/hyperscribe/scribe/static/audit-log.js';
 
@@ -322,12 +322,15 @@ export function useRecording(noteId, initialTranscript, { mode = 'conversation' 
       // conversation onTranscriptItem path above).
       client.onDictatedText = (text) => {
         if (!text) return;
-        // Mirror finalizePartials: write entriesRef.current inline (not React
-        // state alone) so the finish-time save (which reads entriesRef.current)
-        // captures the last dictated unit even when it arrives during the END
-        // flush, without depending on a render landing before finalizePartials.
-        // Computing from the ref also keeps same-tick bursts in order.
-        const next = [...entriesRef.current, buildDictationEntry(entriesRef.current.length, text)];
+        // dictate-ws streams verbatim append-only deltas (often a single word
+        // or lone punctuation), not whole utterances. appendDictatedText folds
+        // them into ONE running entry so the transcript (and the generate-note
+        // payload) reads as one coherent monologue, not a row per word.
+        // Write entriesRef.current inline (not React state alone), mirroring
+        // finalizePartials, so the finish-time save (which reads
+        // entriesRef.current) captures the last delta even when it arrives
+        // during the END flush, without depending on a render landing first.
+        const next = appendDictatedText(entriesRef.current, text);
         entriesRef.current = next;
         setEntries(next);
       };

--- a/hyperscribe/scribe/static/recording-hook.js
+++ b/hyperscribe/scribe/static/recording-hook.js
@@ -9,6 +9,7 @@ import {
   reconnectSessionOffset,
   drainResolution,
   finishDrainDecision,
+  buildDictationEntry,
 } from './transcript-merge.js';
 import { logEvent } from '/plugin-io/api/hyperscribe/scribe/static/audit-log.js';
 
@@ -321,14 +322,7 @@ export function useRecording(noteId, initialTranscript, { mode = 'conversation' 
       // conversation onTranscriptItem path above).
       client.onDictatedText = (text) => {
         if (!text) return;
-        setEntries(prev => [...prev, {
-          item_id: `__dict_${prev.length}`,
-          text,
-          speaker: 'DOCTOR',
-          start_offset_ms: 0,
-          end_offset_ms: 0,
-          is_final: true,
-        }]);
+        setEntries(prev => [...prev, buildDictationEntry(prev.length, text)]);
       };
       client.onError = (msg, code) => {
         if (code === 83011) {

--- a/hyperscribe/scribe/static/recording-hook.js
+++ b/hyperscribe/scribe/static/recording-hook.js
@@ -322,7 +322,14 @@ export function useRecording(noteId, initialTranscript, { mode = 'conversation' 
       // conversation onTranscriptItem path above).
       client.onDictatedText = (text) => {
         if (!text) return;
-        setEntries(prev => [...prev, buildDictationEntry(prev.length, text)]);
+        // Mirror finalizePartials: write entriesRef.current inline (not React
+        // state alone) so the finish-time save (which reads entriesRef.current)
+        // captures the last dictated unit even when it arrives during the END
+        // flush, without depending on a render landing before finalizePartials.
+        // Computing from the ref also keeps same-tick bursts in order.
+        const next = [...entriesRef.current, buildDictationEntry(entriesRef.current.length, text)];
+        entriesRef.current = next;
+        setEntries(next);
       };
       client.onError = (msg, code) => {
         if (code === 83011) {

--- a/hyperscribe/scribe/static/recording-hook.js
+++ b/hyperscribe/scribe/static/recording-hook.js
@@ -59,7 +59,7 @@ const DING_URL = 'data:audio/wav;base64,UklGRmhWAABXQVZFZm10IBAAAAABAAEAIlYAAESs
  *            startRecording, pauseRecording, resumeRecording, finishRecording }
  */
 
-export function useRecording(noteId, initialTranscript) {
+export function useRecording(noteId, initialTranscript, { mode = 'conversation' } = {}) {
   const [status, setStatus] = useState(() => {
     if (initialTranscript?.started && !initialTranscript.finalized) return 'paused';
     return 'idle';
@@ -289,9 +289,10 @@ export function useRecording(noteId, initialTranscript) {
     // reconnects extend it by acked-audio time rather than recomputing
     // wall-clock, so replayed audio keeps its true timeline position.
     const sessionStartBaseMs = sessionOffsetHolder.current;
+    const configPath = mode === 'dictation' ? '/dictation-config' : '/config';
     let config;
     try {
-      const res = await fetch(`${API_BASE}/config`, { cache: 'no-store' });
+      const res = await fetch(`${API_BASE}${configPath}`, { cache: 'no-store' });
       config = await res.json();
       if (config.error) {
         setError(config.error);
@@ -303,18 +304,32 @@ export function useRecording(noteId, initialTranscript) {
     }
 
     const refreshConfig = async () => {
-      const res = await fetch(`${API_BASE}/config`, { cache: 'no-store' });
+      const res = await fetch(`${API_BASE}${configPath}`, { cache: 'no-store' });
       return res.json();
     };
 
     let client;
     try {
-      client = createScribeClient({ ...config, refreshConfig });
+      client = createScribeClient({ ...config, mode, refreshConfig });
       // Bind THIS client's session-offset holder into its handler closure.
       // Reading holder.current at delivery time (not at bind time) means
       // when onReconnect bumps the offset for a fresh Nabla session, the
       // very next item this client processes already uses the new value.
       client.onTranscriptItem = (item) => handleTranscriptItem(item, sessionOffsetHolder.current);
+      // Dictation is a monologue with no offsets/ids and is never revised —
+      // append-only, verbatim, no mergeEntry/offset-rebasing (unlike the
+      // conversation onTranscriptItem path above).
+      client.onDictatedText = (text) => {
+        if (!text) return;
+        setEntries(prev => [...prev, {
+          item_id: `__dict_${prev.length}`,
+          text,
+          speaker: 'DOCTOR',
+          start_offset_ms: 0,
+          end_offset_ms: 0,
+          is_final: true,
+        }]);
+      };
       client.onError = (msg, code) => {
         if (code === 83011) {
           // Stream timeout — Nabla closes the connection if a stream receives
@@ -427,7 +442,7 @@ export function useRecording(noteId, initialTranscript) {
     }
 
     return true;
-  }, [handleTranscriptItem]);
+  }, [handleTranscriptItem, mode]);
 
   const disconnectAll = useCallback(async ({ force = false } = {}) => {
     cleanupAudio(audioCtxRef, streamRef, workletNodeRef);

--- a/hyperscribe/scribe/static/scribeClient.js
+++ b/hyperscribe/scribe/static/scribeClient.js
@@ -11,7 +11,7 @@
  * See: https://docs.nabla.com/guides/best-practices/transcription-network-resilience
  */
 
-import { samplesToMs } from './transcript-merge.js';
+import { samplesToMs, buildConfigFrame } from './transcript-merge.js';
 
 /**
  * Convert Int16Array to base64 string.
@@ -50,6 +50,9 @@ class NablaScribeClient {
    * @param {string} config.encoding
    * @param {string[]} config.speech_locales
    * @param {string} config.stream_id
+   * @param {string} [config.mode] — 'conversation' (default, transcribe-ws) or
+   *   'dictation' (dictate-ws). Switches the subprotocol, CONFIG frame,
+   *   AUDIO_CHUNK shape, and routes DICTATED_TEXT to onDictatedText.
    * @param {function(): Promise<object>} [config.refreshConfig] — async callback
    *   that returns a fresh config object (with a new access_token) when the
    *   current token has expired. Called before each reconnect attempt.
@@ -96,6 +99,8 @@ class NablaScribeClient {
     this.onDisconnect = () => {};
     /** @type {function(): void} */
     this.onReconnect = () => {};
+    /** @type {function(string): void} */
+    this.onDictatedText = () => {};
   }
 
   /**
@@ -231,7 +236,7 @@ class NablaScribeClient {
     const { ws_url, access_token } = this._config;
     let ws;
     try {
-      ws = new WebSocket(ws_url, ['transcribe-protocol', `jwt-${access_token}`]);
+      ws = new WebSocket(ws_url, [this._config.mode === 'dictation' ? 'dictate-protocol' : 'transcribe-protocol', `jwt-${access_token}`]);
     } catch {
       this._handleConnectFailure();
       return;
@@ -436,8 +441,8 @@ class NablaScribeClient {
       this._ws.send(JSON.stringify({
         type: 'AUDIO_CHUNK',
         payload: chunk.base64,
-        stream_id: chunk.streamId,
         seq_id: chunk.seqId,
+        ...(this._config.mode !== 'dictation' ? { stream_id: chunk.streamId } : {}),
       }));
       chunk.sent = true;
       this._inflightSamples += chunk.sampleCount;
@@ -474,6 +479,9 @@ class NablaScribeClient {
         break;
       case 'AUDIO_CHUNK_ACK':
         this._handleAck(msg);
+        break;
+      case 'DICTATED_TEXT':
+        this.onDictatedText(msg.text || '');
         break;
       case 'END':
         this._intentionalClose = true;
@@ -528,15 +536,7 @@ class NablaScribeClient {
   /** @private */
   _sendConfig() {
     if (!this._ws) return;
-    const config = {
-      type: 'CONFIG',
-      encoding: this._config.encoding,
-      sample_rate: this._config.sample_rate,
-      speech_locales: this._config.speech_locales,
-      streams: [{ id: this._config.stream_id, speaker_type: 'unspecified' }],
-      enable_audio_chunk_ack: true,
-    };
-    this._ws.send(JSON.stringify(config));
+    this._ws.send(JSON.stringify(buildConfigFrame(this._config.mode || 'conversation', this._config)));
   }
 
   /** @private */

--- a/hyperscribe/scribe/static/scribeClient.test.js
+++ b/hyperscribe/scribe/static/scribeClient.test.js
@@ -306,3 +306,80 @@ test('transcript items are forwarded to onTranscriptItem', (t) => {
   assert.equal(items[0].text, 'hello');
   assert.equal(items[0].speaker, 'PATIENT');
 });
+
+// --- Dictation mode ---------------------------------------------------------
+
+test('dictation mode opens with the dictate-protocol subprotocol', (t) => {
+  t.mock.timers.enable({ apis: ['setTimeout', 'setInterval', 'Date'] });
+  const { sockets } = makeClient({ mode: 'dictation' });
+
+  assert.ok(
+    sockets[0].protocols.includes('dictate-protocol'),
+    'dictation mode must open with dictate-protocol, not transcribe-protocol',
+  );
+  assert.ok(!sockets[0].protocols.includes('transcribe-protocol'));
+});
+
+test('dictation mode sends the dictation CONFIG frame (no streams)', (t) => {
+  t.mock.timers.enable({ apis: ['setTimeout', 'setInterval', 'Date'] });
+  const { sockets } = makeClient({
+    mode: 'dictation',
+    dictation_locale: 'ENGLISH_US',
+    punctuation_mode: 'EXPLICIT',
+    text_field_context: { text: '', selection_start: 0, selection_length: 0 },
+  });
+
+  sockets[0].fireOpen();
+  const config = sockets[0].sent.map((raw) => JSON.parse(raw)).find((m) => m.type === 'CONFIG');
+  assert.equal(config.dictation_locale, 'ENGLISH_US');
+  assert.equal(config.punctuation_mode, 'EXPLICIT');
+  assert.ok(!('streams' in config), 'dictation CONFIG must not include streams');
+  assert.ok(!('speech_locales' in config), 'dictation CONFIG must not include speech_locales');
+});
+
+test('dictation mode sends AUDIO_CHUNK without stream_id', (t) => {
+  t.mock.timers.enable({ apis: ['setTimeout', 'setInterval', 'Date'] });
+  const { client, sockets } = makeClient({ mode: 'dictation' });
+
+  sockets[0].fireOpen();
+  client.sendAudio(pcm(1600));
+  const chunk = sockets[0].sent.map((raw) => JSON.parse(raw)).find((m) => m.type === 'AUDIO_CHUNK');
+  assert.equal(chunk.seq_id, 0);
+  assert.ok(!('stream_id' in chunk), 'dictation AUDIO_CHUNK must not include stream_id');
+});
+
+test('dictation mode routes DICTATED_TEXT to onDictatedText', (t) => {
+  t.mock.timers.enable({ apis: ['setTimeout', 'setInterval', 'Date'] });
+  const { client, sockets } = makeClient({ mode: 'dictation' });
+  const texts = [];
+  client.onDictatedText = (text) => texts.push(text);
+
+  sockets[0].fireOpen();
+  sockets[0].fireMessage({ type: 'DICTATED_TEXT', text: 'hello world' });
+
+  assert.deepEqual(texts, ['hello world']);
+});
+
+test('dictation mode still reconnects and replays un-acked audio', (t) => {
+  t.mock.timers.enable({ apis: ['setTimeout', 'setInterval', 'Date'] });
+  const { client, sockets } = makeClient({ mode: 'dictation' });
+
+  sockets[0].fireOpen();
+  client.sendAudio(pcm(1600)); // seq 0
+  client.sendAudio(pcm(1600)); // seq 1
+  client.sendAudio(pcm(1600)); // seq 2
+  assert.deepEqual(sentSeqIds(sockets[0]), [0, 1, 2], 'all chunks sent on first connection');
+
+  sockets[0].fireMessage({ type: 'AUDIO_CHUNK_ACK', ack_id: 1 });
+
+  sockets[0].fireClose(); // network drop
+  t.mock.timers.tick(1000); // backoff timer -> reconnect
+  assert.equal(sockets.length, 2, 'reconnect opened a fresh socket');
+
+  sockets[1].fireOpen();
+  assert.deepEqual(
+    sentSeqIds(sockets[1]),
+    [2],
+    'only the un-acked chunk is replayed — acked audio must NOT be re-transcribed',
+  );
+});

--- a/hyperscribe/scribe/static/summary.js
+++ b/hyperscribe/scribe/static/summary.js
@@ -559,7 +559,7 @@ function renderSoapGroups(sections, commandBySectionKey, onEditCommand, onDelete
     .filter(Boolean);
 }
 
-export function Scribe({ noteId, patientId, staffId, staffName, providerName, providerPhotoUrl, patientName, patientBirthDate, patientGender, debugMode, noteEditable = true, isAuthor = false, alertFacilityEnabled = false, manualModeOnly = false, dictationEnabled = false, initialData = null }) {
+export function Scribe({ noteId, patientId, staffId, staffName, providerName, providerPhotoUrl, patientName, patientBirthDate, patientGender, debugMode, noteEditable = true, isAuthor = false, alertFacilityEnabled = false, manualModeOnly = false, dictationEnabled = false, captureDictationEnabled = false, initialData = null }) {
   const initSummary = initialData?.summary ?? null;
   const [noteData, setNoteData] = useState(initSummary?.note ?? null);
   const [generating, setGenerating] = useState(false);
@@ -3397,7 +3397,7 @@ export function Scribe({ noteId, patientId, staffId, staffName, providerName, pr
             </select>
           `}
           ${showTopControls && html`
-            ${dictationEnabled && !manualModeOnly && html`
+            ${captureDictationEnabled && !manualModeOnly && html`
               <div class="refer-priority" style="max-width: 220px;" role="group" aria-label="Capture mode">
                 <button
                   type="button"
@@ -3423,7 +3423,7 @@ export function Scribe({ noteId, patientId, staffId, staffName, providerName, pr
               Manual
             </button>
           `}
-          ${mode === 'ai' && dictationEnabled && html`
+          ${mode === 'ai' && captureDictationEnabled && html`
             <span class="capture-mode-locked" style="font-size: 12px; font-weight: 600; color: #6b7280; white-space: nowrap;" title="Capture transport is locked for this session">
               Capture: ${captureMode === 'dictation' ? 'Dictation' : 'Conversation'}
             </span>

--- a/hyperscribe/scribe/static/summary.js
+++ b/hyperscribe/scribe/static/summary.js
@@ -599,6 +599,16 @@ export function Scribe({ noteId, patientId, staffId, staffName, providerName, pr
     }
     return cached;
   });
+  // Capture-mode toggle (KOALA-5513 spike): which live-audio transport backs
+  // the recording — 'conversation' (default; existing Nabla transcribe-ws,
+  // multi-speaker) or 'dictation' (Nabla dictate-ws, verbatim single-speaker
+  // monologue). This is intentionally named `captureMode`, NOT `mode` — the
+  // `mode` state above is the unrelated note-generation workflow mode
+  // ('ai'|'manual'|null). Not persisted across reload (spike scope); local
+  // component state only. Locked once the AI Scribe session starts (see
+  // `mode === 'ai'` gate at the top-bar render) since the transport can't
+  // change mid-session.
+  const [captureMode, setCaptureMode] = useState('conversation');
   const [transcriptCollapsed, setTranscriptCollapsed] = useState(false);
   // Auto-scroll the transcript body to the latest entry whenever live capture
   // is producing or refining content. We deliberately don't try to "respect"
@@ -930,8 +940,10 @@ export function Scribe({ noteId, patientId, staffId, staffName, providerName, pr
   }, [wasFinalized, approved]);
   // --- End charge matrix ---
 
-  // Recording hook.
-  const recording = useRecording(noteId, initialData?.transcript);
+  // Recording hook. captureMode is fixed at whatever it was when AI Scribe
+  // started (see the `mode === 'ai'` lock in the top-bar render below) — the
+  // hook re-reads it on every render, but nothing changes it after that point.
+  const recording = useRecording(noteId, initialData?.transcript, { mode: captureMode });
 
   // Keep the transcript pinned to the latest entry as new ones stream in or
   // get refined (in-place partial updates, speaker-attribution flips, etc.).
@@ -3385,6 +3397,22 @@ export function Scribe({ noteId, patientId, staffId, staffName, providerName, pr
             </select>
           `}
           ${showTopControls && html`
+            ${dictationEnabled && !manualModeOnly && html`
+              <div class="refer-priority" style="max-width: 220px;" role="group" aria-label="Capture mode">
+                <button
+                  type="button"
+                  class="refer-pill${captureMode === 'conversation' ? ' active' : ''}"
+                  onClick=${() => setCaptureMode('conversation')}
+                  title="Multi-speaker conversation, transcribed live"
+                >Conversation</button>
+                <button
+                  type="button"
+                  class="refer-pill${captureMode === 'dictation' ? ' active' : ''}"
+                  onClick=${() => setCaptureMode('dictation')}
+                  title="Single-speaker dictated monologue"
+                >Dictation</button>
+              </div>
+            `}
             ${!manualModeOnly && html`
               <button class="start-ai-btn" onClick=${handleStartAI} disabled=${!canEdit || !selectedTemplate}>
                 <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><circle cx="12" cy="12" r="8" /></svg>
@@ -3394,6 +3422,11 @@ export function Scribe({ noteId, patientId, staffId, staffName, providerName, pr
             <button class="start-manual-btn" onClick=${handleStartManual} disabled=${!canEdit || !selectedTemplate}>
               Manual
             </button>
+          `}
+          ${mode === 'ai' && dictationEnabled && html`
+            <span class="capture-mode-locked" style="font-size: 12px; font-weight: 600; color: #6b7280; white-space: nowrap;" title="Capture transport is locked for this session">
+              Capture: ${captureMode === 'dictation' ? 'Dictation' : 'Conversation'}
+            </span>
           `}
           ${isRecording && html`
             <div class="recording-controls-inline">

--- a/hyperscribe/scribe/static/transcript-merge.js
+++ b/hyperscribe/scribe/static/transcript-merge.js
@@ -26,24 +26,37 @@ export function sortEntries(items) {
   });
 }
 
-// Build a dictation transcript entry. Dictation has no real audio-time (it's
-// a single append-only monologue, no offsets from Nabla), but sortEntries
-// still runs on every rehydration (mount useState initializer, load-on-mount
-// /transcript effect) and sorts by start_offset_ms first, item_id only as a
-// tiebreak. If every dictation entry shared offset 0, ordering would fall to
-// item_id.localeCompare, and "__dict_10" sorts before "__dict_2" — scrambling
-// a paused-and-reloaded session with >=10 chunks. Using the monotonic append
-// index as the offset keeps append order stable through sortEntries at any
-// count, independent of item_id string comparison.
-export function buildDictationEntry(index, text) {
-  return {
-    item_id: `__dict_${index}`,
-    text,
-    speaker: 'DOCTOR',
-    start_offset_ms: index,
-    end_offset_ms: index,
-    is_final: true,
-  };
+// The single transcript entry that holds a dictated monologue. Dictation is
+// one continuous single-speaker block, unlike conversation's multi-speaker
+// utterances — so all dictated text lives under one stable id.
+export const DICTATION_ENTRY_ID = '__dictation';
+
+// Append one DICTATED_TEXT delta to the transcript. dictate-ws streams
+// verbatim, append-only, immutable deltas (often a single word or a lone
+// punctuation mark like "-", not whole utterances), and Nabla owns spacing
+// and punctuation. So we concatenate every delta into ONE running entry
+// rather than rendering a row per word — mirroring how KOALA-6233 field
+// dictation folds the same stream into one text field (summary.js
+// handleDictatedText). This also feeds generate-note one coherent DOCTOR
+// item (backend.py transcript_items) instead of dozens of near-zero-offset
+// fragments. A single fixed-id entry makes any sort-ordering ambiguity
+// structurally impossible. Pure so the accumulation is unit-tested.
+export function appendDictatedText(entries, text) {
+  const last = entries.length ? entries[entries.length - 1] : null;
+  if (last && last.item_id === DICTATION_ENTRY_ID) {
+    return [...entries.slice(0, -1), { ...last, text: last.text + text }];
+  }
+  return [
+    ...entries,
+    {
+      item_id: DICTATION_ENTRY_ID,
+      text,
+      speaker: 'DOCTOR',
+      start_offset_ms: 0,
+      end_offset_ms: 0,
+      is_final: true,
+    },
+  ];
 }
 
 // A partial entry is "stuck" when at least one final entry has a later

--- a/hyperscribe/scribe/static/transcript-merge.js
+++ b/hyperscribe/scribe/static/transcript-merge.js
@@ -26,6 +26,26 @@ export function sortEntries(items) {
   });
 }
 
+// Build a dictation transcript entry. Dictation has no real audio-time (it's
+// a single append-only monologue, no offsets from Nabla), but sortEntries
+// still runs on every rehydration (mount useState initializer, load-on-mount
+// /transcript effect) and sorts by start_offset_ms first, item_id only as a
+// tiebreak. If every dictation entry shared offset 0, ordering would fall to
+// item_id.localeCompare, and "__dict_10" sorts before "__dict_2" — scrambling
+// a paused-and-reloaded session with >=10 chunks. Using the monotonic append
+// index as the offset keeps append order stable through sortEntries at any
+// count, independent of item_id string comparison.
+export function buildDictationEntry(index, text) {
+  return {
+    item_id: `__dict_${index}`,
+    text,
+    speaker: 'DOCTOR',
+    start_offset_ms: index,
+    end_offset_ms: index,
+    is_final: true,
+  };
+}
+
 // A partial entry is "stuck" when at least one final entry has a later
 // start_offset_ms — Nabla has moved on past this segment without ever
 // finalizing it, so the row stays partial forever and accumulates text

--- a/hyperscribe/scribe/static/transcript-merge.js
+++ b/hyperscribe/scribe/static/transcript-merge.js
@@ -115,6 +115,30 @@ export function mergeEntry(entries, incoming, { offsetWindowMs = 1500 } = {}) {
   return [...entries, incoming];
 }
 
+// Per-mode Nabla CONFIG frame. Conversation = transcribe-ws (speaker streams);
+// dictation = dictate-ws (single locale + punctuation + caret context). Pure so
+// the mode branching is unit-tested rather than buried in the ws client.
+export function buildConfigFrame(mode, config) {
+  if (mode === 'dictation') {
+    return {
+      type: 'CONFIG',
+      encoding: config.encoding,
+      sample_rate: config.sample_rate,
+      dictation_locale: config.dictation_locale,
+      punctuation_mode: config.punctuation_mode,
+      text_field_context: config.text_field_context || { text: '', selection_start: 0, selection_length: 0 },
+    };
+  }
+  return {
+    type: 'CONFIG',
+    encoding: config.encoding,
+    sample_rate: config.sample_rate,
+    speech_locales: config.speech_locales,
+    streams: [{ id: config.stream_id, speaker_type: 'unspecified' }],
+    enable_audio_chunk_ack: true,
+  };
+}
+
 // Convert a PCM sample count to milliseconds of audio. Guards a zero/absent
 // sample rate rather than returning Infinity/NaN.
 export function samplesToMs(samples, sampleRate) {

--- a/hyperscribe/scribe/static/transcript-merge.test.js
+++ b/hyperscribe/scribe/static/transcript-merge.test.js
@@ -9,7 +9,25 @@ import {
   reconnectSessionOffset,
   drainResolution,
   finishDrainDecision,
+  buildConfigFrame,
 } from './transcript-merge.js';
+
+test('buildConfigFrame conversation mode keeps the transcribe shape', () => {
+  const f = buildConfigFrame('conversation', { encoding: 'PCM_S16LE', sample_rate: 16000, speech_locales: ['ENGLISH_US'], stream_id: 'stream1' });
+  assert.equal(f.type, 'CONFIG');
+  assert.deepEqual(f.speech_locales, ['ENGLISH_US']);
+  assert.equal(f.streams[0].id, 'stream1');
+  assert.equal(f.enable_audio_chunk_ack, true);
+});
+
+test('buildConfigFrame dictation mode emits the dictate shape', () => {
+  const f = buildConfigFrame('dictation', { encoding: 'PCM_S16LE', sample_rate: 16000, dictation_locale: 'ENGLISH_US', punctuation_mode: 'EXPLICIT', text_field_context: { text: '', selection_start: 0, selection_length: 0 } });
+  assert.equal(f.type, 'CONFIG');
+  assert.equal(f.dictation_locale, 'ENGLISH_US');
+  assert.equal(f.punctuation_mode, 'EXPLICIT');
+  assert.deepEqual(f.text_field_context, { text: '', selection_start: 0, selection_length: 0 });
+  assert.ok(!('streams' in f));
+});
 
 test('finishDrainDecision returns drained the moment the buffer empties', () => {
   assert.equal(finishDrainDecision({ pendingMs: 0, accepted: false }), 'drained');

--- a/hyperscribe/scribe/static/transcript-merge.test.js
+++ b/hyperscribe/scribe/static/transcript-merge.test.js
@@ -10,7 +10,8 @@ import {
   drainResolution,
   finishDrainDecision,
   buildConfigFrame,
-  buildDictationEntry,
+  appendDictatedText,
+  DICTATION_ENTRY_ID,
 } from './transcript-merge.js';
 
 test('buildConfigFrame conversation mode keeps the transcribe shape', () => {
@@ -135,28 +136,39 @@ test('drainResolution prefers stalled over cap when both trip', () => {
   assert.equal(drainResolution({ pending: 5000, msSinceProgress: 40000, msSinceStart: 400000, stallMs: 30000, capMs: 300000 }), 'stalled');
 });
 
-// Regression guard: dictation entries used to all share start_offset_ms: 0,
-// so sortEntries fell back to item_id.localeCompare and "__dict_10" sorted
-// before "__dict_2" on any reload (pause -> reload re-runs sortEntries).
-// buildDictationEntry keys the primary sort field on the append index so
-// order survives sortEntries past 10 entries.
-test('sortEntries preserves append order for 12+ sequential dictation entries', () => {
-  const appended = [];
-  for (let i = 0; i < 12; i++) {
-    appended.push(buildDictationEntry(i, `chunk ${i}`));
+test('appendDictatedText seeds a single dictation entry from the first delta', () => {
+  const out = appendDictatedText([], 'One');
+  assert.equal(out.length, 1);
+  assert.equal(out[0].item_id, DICTATION_ENTRY_ID);
+  assert.equal(out[0].text, 'One');
+  assert.equal(out[0].speaker, 'DOCTOR');
+  assert.equal(out[0].is_final, true);
+});
+
+test('appendDictatedText concatenates every delta into ONE entry, verbatim', () => {
+  // dictate-ws deltas carry their own leading spaces / sub-word splits; Nabla
+  // owns spacing, so plain concatenation must reconstruct the monologue.
+  let out = [];
+  for (const delta of ['One', ' follow', '-', 'up', ' visit']) {
+    out = appendDictatedText(out, delta);
   }
-  const sorted = sortEntries(appended);
-  assert.deepEqual(
-    sorted.map(e => e.item_id),
-    appended.map(e => e.item_id),
-    'dictation entries must stay in append order after sortEntries, even past 10 entries',
-  );
-  // Specifically: __dict_10 and __dict_11 must land after __dict_9, not
-  // lexicographically between __dict_1 and __dict_2 as they would under the
-  // old offset-0-for-everyone shape.
-  const ids = sorted.map(e => e.item_id);
-  assert.ok(ids.indexOf('__dict_9') < ids.indexOf('__dict_10'));
-  assert.ok(ids.indexOf('__dict_10') < ids.indexOf('__dict_11'));
+  assert.equal(out.length, 1, 'a monologue is one row, not a row per word');
+  assert.equal(out[0].text, 'One follow-up visit');
+  assert.equal(out[0].item_id, DICTATION_ENTRY_ID);
+});
+
+test('appendDictatedText past 12 deltas is still a single entry (no ordering ambiguity)', () => {
+  let out = [];
+  for (let i = 0; i < 15; i++) out = appendDictatedText(out, ` w${i}`);
+  assert.equal(out.length, 1);
+  // A single fixed-id entry cannot be reordered by sortEntries on reload.
+  assert.deepEqual(sortEntries(out).map(e => e.item_id), [DICTATION_ENTRY_ID]);
+});
+
+test('appendDictatedText ignores empty deltas is the callers job; here it appends what it is given', () => {
+  // The hook guards empty text before calling; the pure fn appends verbatim.
+  const out = appendDictatedText([{ item_id: DICTATION_ENTRY_ID, text: 'hi', speaker: 'DOCTOR', start_offset_ms: 0, end_offset_ms: 0, is_final: true }], ' there');
+  assert.equal(out[0].text, 'hi there');
 });
 
 // Integration guard for the actual KOALA-5934 fix: an item Nabla emitted but

--- a/hyperscribe/scribe/static/transcript-merge.test.js
+++ b/hyperscribe/scribe/static/transcript-merge.test.js
@@ -10,6 +10,7 @@ import {
   drainResolution,
   finishDrainDecision,
   buildConfigFrame,
+  buildDictationEntry,
 } from './transcript-merge.js';
 
 test('buildConfigFrame conversation mode keeps the transcribe shape', () => {
@@ -132,6 +133,30 @@ test('drainResolution reports cap when the hard cap is exceeded', () => {
 
 test('drainResolution prefers stalled over cap when both trip', () => {
   assert.equal(drainResolution({ pending: 5000, msSinceProgress: 40000, msSinceStart: 400000, stallMs: 30000, capMs: 300000 }), 'stalled');
+});
+
+// Regression guard: dictation entries used to all share start_offset_ms: 0,
+// so sortEntries fell back to item_id.localeCompare and "__dict_10" sorted
+// before "__dict_2" on any reload (pause -> reload re-runs sortEntries).
+// buildDictationEntry keys the primary sort field on the append index so
+// order survives sortEntries past 10 entries.
+test('sortEntries preserves append order for 12+ sequential dictation entries', () => {
+  const appended = [];
+  for (let i = 0; i < 12; i++) {
+    appended.push(buildDictationEntry(i, `chunk ${i}`));
+  }
+  const sorted = sortEntries(appended);
+  assert.deepEqual(
+    sorted.map(e => e.item_id),
+    appended.map(e => e.item_id),
+    'dictation entries must stay in append order after sortEntries, even past 10 entries',
+  );
+  // Specifically: __dict_10 and __dict_11 must land after __dict_9, not
+  // lexicographically between __dict_1 and __dict_2 as they would under the
+  // old offset-0-for-everyone shape.
+  const ids = sorted.map(e => e.item_id);
+  assert.ok(ids.indexOf('__dict_9') < ids.indexOf('__dict_10'));
+  assert.ok(ids.indexOf('__dict_10') < ids.indexOf('__dict_11'));
 });
 
 // Integration guard for the actual KOALA-5934 fix: an item Nabla emitted but


### PR DESCRIPTION
Linked ticket: https://canvasmedical.atlassian.net/browse/KOALA-5513

Provider monologues (bedside summaries, SNF visits, dictated recaps) produce thin HPIs today because the ambient `transcribe-ws` endpoint is tuned for multi-speaker dialogue: it mangles single-speaker speech (wrong words, spurious diarization) and note generation receives a degraded transcript. This adds a **Conversation | Dictation** capture toggle on the pre-recording screen, gated by its own `ScribeCaptureDictationEnabled` secret (separate from the KOALA-6233 `ScribeDictationEnabled` field-dictation flag, so it can be enabled/disabled independently — per Kevin's request on the ticket). Dictation routes capture through Nabla's `dictate-ws` endpoint — verbatim, punctuated, single-speaker — so the transcript feeding note generation is clean. Note generation itself is unchanged (fork A): dictation simply produces a better input to the same pipeline.

Implementation: the WebSocket transport client and the recording hook became mode-aware. Dictation uses the `dictate-ws` subprotocol/CONFIG and folds the endpoint's append-only `DICTATED_TEXT` deltas into a single continuous transcript entry (mirroring the KOALA-6233 field-dictation concat) rather than one row per word — which also hands note generation one coherent utterance instead of dozens of near-zero-offset fragments. Both modes share the resilient, lossless finish/drain handling from #325 unchanged. The toggle locks to a read-only badge once recording starts, since the transport can't change mid-session.

Stacked on #325 (`koala-5934-scribe-connectivity`) and depends on its lossless drain — merge after #325.

Known follow-ups (spike-accepted): a mid-dictation reconnect can duplicate dictated words (no offset/id to dedup on — needs a committed-audio watermark at ingestion); capture mode isn't persisted across reload; optional sentence/paragraph splitting of the dictation block.
