### PR TITLE
feat: capture supplemental oxygen in scribe vitals

### DIFF
--- a/hyperscribe/scribe/commands/vitals.py
+++ b/hyperscribe/scribe/commands/vitals.py
@@ -633,6 +633,18 @@ class VitalsParser(CommandParser):
     def build(self, data: dict[str, Any], note_uuid: str, command_uuid: str) -> _BaseCommand:
         bp_site_raw = data.get("blood_pressure_position_and_site")
         bp_site = VitalsCommand.BloodPressureSite(bp_site_raw) if bp_site_raw is not None else None
+        # supplemental_oxygen comes only from the controlled review-UI <select>, so an
+        # unrecognized value (e.g. a stale cached asset posting an old index against the
+        # current code-valued enum) is dropped rather than failing the whole command.
+        supplemental_oxygen_raw = data.get("supplemental_oxygen")
+        try:
+            supplemental_oxygen = (
+                VitalsCommand.SupplementalOxygen(supplemental_oxygen_raw)
+                if supplemental_oxygen_raw is not None
+                else None
+            )
+        except ValueError:
+            supplemental_oxygen = None
         return VitalsCommand(
             height=data.get("height"),
             weight_lbs=data.get("weight_lbs"),
@@ -643,6 +655,7 @@ class VitalsParser(CommandParser):
             respiration_rate=data.get("respiration_rate"),
             oxygen_saturation=data.get("oxygen_saturation"),
             blood_pressure_position_and_site=bp_site,
+            supplemental_oxygen=supplemental_oxygen,
             note=data.get("note"),
             note_uuid=note_uuid,
             command_uuid=command_uuid,

--- a/hyperscribe/scribe/print/command_display.py
+++ b/hyperscribe/scribe/print/command_display.py
@@ -140,6 +140,13 @@ BP_SITE_LABELS: dict[int, str] = {
     11: "Supine, Left Lower Arm",
 }
 
+# LOINC LL4908-1 answers for "Use of supplemental oxygen" (88658-0), keyed by answer code.
+SUPPLEMENTAL_OXYGEN_LABELS: dict[str, str] = {
+    "LA28684-1": "Continuously depending on high oxygen flow",
+    "LA28685-8": "Continuously depending on low oxygen flow",
+    "LA28686-6": "Intermittent oxygen consumption",
+}
+
 
 def _schema_key_to_label(schema_key: str) -> str:
     if schema_key in SCHEMA_KEY_LABELS:
@@ -593,6 +600,10 @@ def extract_command_display(schema_key: str, data: dict[str, Any], command_displ
         if bp_site is not None:
             site_label = BP_SITE_LABELS.get(bp_site, str(bp_site))
             vitals_parts.append({"label": "Site", "value": site_label, "unit": ""})
+        supplemental_oxygen = data.get("supplemental_oxygen")
+        if supplemental_oxygen is not None:
+            supplemental_oxygen_label = SUPPLEMENTAL_OXYGEN_LABELS.get(supplemental_oxygen, str(supplemental_oxygen))
+            vitals_parts.append({"label": "Supplemental Oxygen", "value": supplemental_oxygen_label, "unit": ""})
         note_val = data.get("note")
         if note_val:
             vitals_parts.append({"label": "Note", "value": str(note_val), "unit": ""})

--- a/hyperscribe/scribe/static/summary.js
+++ b/hyperscribe/scribe/static/summary.js
@@ -1591,6 +1591,15 @@ export function Scribe({ noteId, patientId, staffId, staffName, providerName, pr
             const label = siteLabels[newData.blood_pressure_position_and_site];
             if (label) vParts.push(`Site: ${label}`);
           }
+          if (newData.supplemental_oxygen != null) {
+            const supplementalOxygenLabels = {
+              'LA28684-1': 'Continuously depending on high oxygen flow',
+              'LA28685-8': 'Continuously depending on low oxygen flow',
+              'LA28686-6': 'Intermittent oxygen consumption',
+            };
+            const label = supplementalOxygenLabels[newData.supplemental_oxygen];
+            if (label) vParts.push(`Supplemental O2: ${label}`);
+          }
           if (newData.note) vParts.push(`Note: ${newData.note}`);
           next = { ...cmd, data: newData, display: vParts.join(', ') || 'Vitals' };
         } else if (type === 'medication_statement') {

--- a/hyperscribe/scribe/static/vitals-row.js
+++ b/hyperscribe/scribe/static/vitals-row.js
@@ -41,6 +41,21 @@ function bpSiteLabel(value) {
 
 export { bpSiteLabel };
 
+// LOINC LL4908-1 answers for "Use of supplemental oxygen" (88658-0). Values are the LOINC
+// answer codes, matching the canvas_core / canvas_sdk SupplementalOxygen enum values.
+const SUPPLEMENTAL_OXYGEN_OPTIONS = [
+  { value: 'LA28684-1', label: 'Continuously depending on high oxygen flow' },
+  { value: 'LA28685-8', label: 'Continuously depending on low oxygen flow' },
+  { value: 'LA28686-6', label: 'Intermittent oxygen consumption' },
+];
+
+function supplementalOxygenLabel(value) {
+  const opt = SUPPLEMENTAL_OXYGEN_OPTIONS.find(o => o.value === value);
+  return opt ? opt.label : '';
+}
+
+export { supplementalOxygenLabel };
+
 function formatVitalsDisplay(data) {
   const parts = [];
   VITALS_FIELDS.forEach(f => {
@@ -58,6 +73,10 @@ function formatVitalsDisplay(data) {
   if (data.blood_pressure_position_and_site != null) {
     const label = bpSiteLabel(data.blood_pressure_position_and_site);
     if (label) parts.push(`Site: ${label}`);
+  }
+  if (data.supplemental_oxygen != null) {
+    const label = supplementalOxygenLabel(data.supplemental_oxygen);
+    if (label) parts.push(`Supplemental O2: ${label}`);
   }
   if (data.note) parts.push(`Note: ${data.note}`);
   return parts.join(', ');
@@ -89,6 +108,7 @@ export function VitalsRow({ command, commandIndex, onEdit, readOnly, onEditingCh
   const [draft, setDraft] = useState({ ...command.data });
   const [tempRaw, setTempRaw] = useState(command.data.body_temperature != null ? String(command.data.body_temperature) : '');
   const [bpSite, setBpSite] = useState(command.data.blood_pressure_position_and_site != null ? String(command.data.blood_pressure_position_and_site) : '');
+  const [supplementalOxygen, setSupplementalOxygen] = useState(command.data.supplemental_oxygen || '');
   const [note, setNote] = useState(command.data.note || '');
   const [errors, setErrors] = useState({});
 
@@ -138,8 +158,10 @@ export function VitalsRow({ command, commandIndex, onEdit, readOnly, onEditingCh
     }
 
     delete data.blood_pressure_position_and_site;
+    delete data.supplemental_oxygen;
     delete data.note;
     if (bpSite !== '') data.blood_pressure_position_and_site = parseInt(bpSite, 10);
+    if (supplementalOxygen !== '') data.supplemental_oxygen = supplementalOxygen;
     if (note.trim()) data.note = note.trim();
     onEdit(commandIndex, data);
     setEditing(false);
@@ -150,6 +172,7 @@ export function VitalsRow({ command, commandIndex, onEdit, readOnly, onEditingCh
     setErrors({});
     setTempRaw(command.data.body_temperature != null ? String(command.data.body_temperature) : '');
     setBpSite(command.data.blood_pressure_position_and_site != null ? String(command.data.blood_pressure_position_and_site) : '');
+    setSupplementalOxygen(command.data.supplemental_oxygen || '');
     setNote(command.data.note || '');
     setEditing(false);
   };
@@ -240,6 +263,15 @@ export function VitalsRow({ command, commandIndex, onEdit, readOnly, onEditingCh
             </select>
           </div>
           <div class="history-form-field">
+            <label class="history-form-label">Supplemental Oxygen</label>
+            <select class="history-form-input" value=${supplementalOxygen} onChange=${(e) => setSupplementalOxygen(e.target.value)}>
+              <option value="">None</option>
+              ${SUPPLEMENTAL_OXYGEN_OPTIONS.map(o => html`
+                <option key=${o.value} value=${o.value}>${o.label}</option>
+              `)}
+            </select>
+          </div>
+          <div class="history-form-field">
             <label class="history-form-label">Comment</label>
             <input
               type="text"
@@ -287,6 +319,10 @@ export function VitalsRow({ command, commandIndex, onEdit, readOnly, onEditingCh
   if (command.data.blood_pressure_position_and_site != null) {
     const label = bpSiteLabel(command.data.blood_pressure_position_and_site);
     if (label) items.push(html`<span class="vitals-item" key="bp_site"><strong>Site</strong> ${label}</span>`);
+  }
+  if (command.data.supplemental_oxygen != null) {
+    const label = supplementalOxygenLabel(command.data.supplemental_oxygen);
+    if (label) items.push(html`<span class="vitals-item" key="supplemental_oxygen"><strong>Supplemental O2</strong> ${label}</span>`);
   }
   if (command.data.note) {
     items.push(html`<span class="vitals-item" key="note"><strong>Note</strong> ${command.data.note}</span>`);

--- a/tests/hyperscribe/scribe/commands/test_vitals.py
+++ b/tests/hyperscribe/scribe/commands/test_vitals.py
@@ -478,10 +478,38 @@ def test_build() -> None:
         respiration_rate=16,
         oxygen_saturation=98,
         blood_pressure_position_and_site=mock_cmd.BloodPressureSite.return_value,
+        supplemental_oxygen=None,
         note="Patient was anxious",
         note_uuid="note-uuid-789",
         command_uuid="cmd-uuid",
     )
+    mock_cmd.SupplementalOxygen.assert_not_called()
+
+
+def test_build_with_supplemental_oxygen() -> None:
+    parser = VitalsParser()
+    data = {"pulse": 72, "supplemental_oxygen": "LA28684-1"}
+    with patch("hyperscribe.scribe.commands.vitals.VitalsCommand") as mock_cmd:
+        mock_cmd.return_value = MagicMock()
+        parser.build(data, "note-uuid", "cmd-uuid")
+
+    mock_cmd.SupplementalOxygen.assert_called_once_with("LA28684-1")
+    _, kwargs = mock_cmd.call_args
+    assert kwargs["supplemental_oxygen"] == mock_cmd.SupplementalOxygen.return_value
+
+
+def test_build_drops_unknown_supplemental_oxygen() -> None:
+    """An unrecognized value (e.g. a stale index) is dropped, not raised as a build error."""
+    parser = VitalsParser()
+    data = {"pulse": 72, "supplemental_oxygen": "0"}
+    with patch("hyperscribe.scribe.commands.vitals.VitalsCommand") as mock_cmd:
+        mock_cmd.return_value = MagicMock()
+        mock_cmd.SupplementalOxygen.side_effect = ValueError("not a valid SupplementalOxygen")
+        parser.build(data, "note-uuid", "cmd-uuid")
+
+    mock_cmd.SupplementalOxygen.assert_called_once_with("0")
+    _, kwargs = mock_cmd.call_args
+    assert kwargs["supplemental_oxygen"] is None
 
 
 def test_parse_vitals_respiratory_rate_phrasing() -> None:
@@ -548,6 +576,7 @@ def test_build_without_new_fields() -> None:
         respiration_rate=None,
         oxygen_saturation=None,
         blood_pressure_position_and_site=None,
+        supplemental_oxygen=None,
         note=None,
         note_uuid="note-uuid",
         command_uuid="cmd-uuid",


### PR DESCRIPTION
https://canvasmedical.atlassian.net/browse/KOALA-6235



Adds a Supplemental Oxygen `<select>` to the vitals review card. The selected
LOINC answer code flows into the Vitals command build, the collapsed summary
display, and the scribe printout. `build()` coerces the code defensively so an
unrecognized value (e.g. a stale cached asset) is dropped rather than failing
command creation.

- `hyperscribe/scribe/commands/vitals.py` (build + defensive coercion)
- `hyperscribe/scribe/static/vitals-row.js` (selector + display)
- `hyperscribe/scribe/static/summary.js` (summary display)
- `hyperscribe/scribe/print/command_display.py` (printout)

Depends on the SDK change being released and pinned (the plugin-runner SDK
must include the supplemental oxygen field on the Vitals command).

Tests: `tests/hyperscribe/scribe/commands/test_vitals.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
