### PR TITLE
feat(scribe): extend Alert Facility to prescribe, adjust prescription, refill

### DIFF
--- a/hyperscribe/CANVAS_MANIFEST.json
+++ b/hyperscribe/CANVAS_MANIFEST.json
@@ -260,7 +260,7 @@
     "views": []
   },
   "secrets": [
-    "AlertFacilityEnabled",
+    "AlertFacilityCommands",
     "AnthropicAPIKey",
     "APISigningKey",
     "AudioHost",

--- a/hyperscribe/libraries/constants.py
+++ b/hyperscribe/libraries/constants.py
@@ -127,7 +127,7 @@ class Constants:
     SECRET_NOTION_FEEDBACK_DATABASE_ID = "NotionFeedbackDatabaseId"
     SECRET_SCRIBE_BACKEND = "ScribeBackend"  # JSON: {"vendor": "nabla", "region": "us", ...}
     SECRET_SCRIBE_NOTE_TYPES = "ScribeNoteTypes"  # Comma-separated note type names
-    SECRET_ALERT_FACILITY_ENABLED = "AlertFacilityEnabled"
+    SECRET_ALERT_FACILITY_COMMANDS = "AlertFacilityCommands"  # Comma-separated command types
     SECRET_SCRIBE_DEBUG_STAFFERS = "ScribeDebugStaffers"  # Comma-separated staff keys for debug apps
     SECRET_VISIT_TEMPLATES = "VisitTemplates"  # JSON: {"templates": [...]}
     SECRET_NOTION_API_KEY = "NotionAPIKey"

--- a/hyperscribe/scribe/api/scribe_view.py
+++ b/hyperscribe/scribe/api/scribe_view.py
@@ -12,6 +12,7 @@ from canvas_sdk.v1.data.staff import Staff
 from hyperscribe.libraries.helper import Helper
 from hyperscribe.models.scribe import ScribeTranscript
 from hyperscribe.scribe.api.session_view import _load_initial_data
+from hyperscribe.scribe.commands._alert_facility import parse_alert_facility_commands
 
 
 def _safe_json(data: Any) -> str:
@@ -91,7 +92,9 @@ class ScribeView(StaffSessionAuthMixin, SimpleAPI):
                 "debug_mode": "true" if self.secrets.get("ScribeDebugStaffers") else "",
                 "note_editable": "true" if note_editable else "",
                 "is_author": "true" if is_author else "",
-                "alert_facility_enabled": "true" if self.secrets.get("AlertFacilityEnabled") else "",
+                "alert_facility_commands": ",".join(
+                    sorted(parse_alert_facility_commands(self.secrets.get("AlertFacilityCommands")))
+                ),
                 "manual_mode_only": "true" if self.secrets.get("ScribeManualModeOnly") else "",
                 "dictation_enabled": "true" if dictation_enabled else "",
                 "initial_data": _safe_json(initial_data),

--- a/hyperscribe/scribe/api/session_view.py
+++ b/hyperscribe/scribe/api/session_view.py
@@ -251,6 +251,38 @@ ALERT_FACILITY_SCHEMA_KEYS = frozenset(
     {"prescribe", "adjustPrescription", "refill", "medicationStatement", "stopMedication"}
 )
 
+# Per-command-type default for the Alert Facility flag, keyed by the frontend
+# command_type (snake_case). Prescribe and adjust prescription default on; the
+# rest default off. Applied only to freshly generated cards (see
+# _inject_alert_facility_defaults) so a new card shows its default without being
+# opened, while historical commands are left untouched.
+ALERT_FACILITY_DEFAULT_BY_COMMAND_TYPE = {
+    "prescribe": True,
+    "adjust_prescription": True,
+    "refill": False,
+    "medication_statement": False,
+    "stop_medication": False,
+}
+
+
+def _inject_alert_facility_defaults(proposals: list[dict[str, Any]], enabled: bool) -> None:
+    """Materialize the per-type Alert Facility default onto freshly generated
+    command/recommendation proposals so a new card displays its default without
+    being opened. ``setdefault`` means an explicit, already-chosen value always
+    wins. No-op when the feature flag is off. Only ever called on the current
+    generation's proposals — never on historical/committed commands."""
+    if not enabled:
+        return
+    for proposal in proposals:
+        command_type = proposal.get("command_type")
+        if not isinstance(command_type, str):
+            continue
+        default_on = ALERT_FACILITY_DEFAULT_BY_COMMAND_TYPE.get(command_type)
+        data = proposal.get("data")
+        if default_on is not None and isinstance(data, dict):
+            data.setdefault("alert_facility", default_on)
+
+
 _CAMEL_BOUNDARY_RE = re.compile(r"([a-z0-9])([A-Z])")
 
 # Canonical labels for schema_keys whose humanized form would look wrong
@@ -1454,6 +1486,14 @@ class ScribeSessionView(StaffSessionAuthMixin, SimpleAPI):
             except Exception:
                 log.exception("link_referral_diagnoses failed (non-critical)")
 
+        # ── Alert Facility: stamp per-type defaults onto freshly generated cards ──
+        # So a new command/recommendation shows its default without being opened.
+        # Runs only on fresh generation (never on cache reload or /note-commands),
+        # and setdefault leaves any explicit value untouched.
+        alert_facility_enabled = bool(self.secrets.get("AlertFacilityEnabled"))
+        _inject_alert_facility_defaults(commands_list, alert_facility_enabled)
+        _inject_alert_facility_defaults(recommendations_list, alert_facility_enabled)
+
         # ── Save to database ──
         # `mode` and `selected_template_name` are owned by the session lifecycle
         # (Start AI / Start Manual, template picker) — generate-summary only
@@ -2404,12 +2444,13 @@ class ScribeSessionView(StaffSessionAuthMixin, SimpleAPI):
             data = row.get("data") or {}
             details = _details_for_command(data)
             if alert_facility_enabled and schema_key in ALERT_FACILITY_SCHEMA_KEYS:
-                # Post-feature commands always carry an explicit alert_facility metadata
-                # row (build_effects writes one via pending_metadata). Missing metadata
-                # therefore means a pre-feature (or non-Scribe) command — default it to
-                # "Yes" so historical cards are shown unaltered.
-                value = alert_facility_by_command.get(str(row["id"]), "Yes")
-                details.append({"label": "Alert Facility", "value": value})
+                # Show the flag only when the command actually recorded one. Post-feature
+                # commands always carry an explicit alert_facility metadata row (build_effects
+                # writes one via pending_metadata); a missing row means a pre-feature (or
+                # non-Scribe) command, which we leave blank so historical cards are unaltered.
+                command_id = str(row["id"])
+                if command_id in alert_facility_by_command:
+                    details.append({"label": "Alert Facility", "value": alert_facility_by_command[command_id]})
             commands.append(
                 {
                     "command_uuid": str(row["id"]),

--- a/hyperscribe/scribe/api/session_view.py
+++ b/hyperscribe/scribe/api/session_view.py
@@ -251,17 +251,6 @@ ALERT_FACILITY_SCHEMA_KEYS = frozenset(
     {"prescribe", "adjustPrescription", "refill", "medicationStatement", "stopMedication"}
 )
 
-# Per-command-type default shown when a command carries no stored alert_facility
-# metadata, so the flag reflects the type's default even on cards never opened.
-# Prescribe and adjust prescription default Yes; the rest default No.
-ALERT_FACILITY_DEFAULT_BY_SCHEMA_KEY = {
-    "prescribe": "Yes",
-    "adjustPrescription": "Yes",
-    "refill": "No",
-    "medicationStatement": "No",
-    "stopMedication": "No",
-}
-
 _CAMEL_BOUNDARY_RE = re.compile(r"([a-z0-9])([A-Z])")
 
 # Canonical labels for schema_keys whose humanized form would look wrong
@@ -2415,7 +2404,11 @@ class ScribeSessionView(StaffSessionAuthMixin, SimpleAPI):
             data = row.get("data") or {}
             details = _details_for_command(data)
             if alert_facility_enabled and schema_key in ALERT_FACILITY_SCHEMA_KEYS:
-                value = alert_facility_by_command.get(str(row["id"]), ALERT_FACILITY_DEFAULT_BY_SCHEMA_KEY[schema_key])
+                # Post-feature commands always carry an explicit alert_facility metadata
+                # row (build_effects writes one via pending_metadata). Missing metadata
+                # therefore means a pre-feature (or non-Scribe) command — default it to
+                # "Yes" so historical cards are shown unaltered.
+                value = alert_facility_by_command.get(str(row["id"]), "Yes")
                 details.append({"label": "Alert Facility", "value": value})
             commands.append(
                 {

--- a/hyperscribe/scribe/api/session_view.py
+++ b/hyperscribe/scribe/api/session_view.py
@@ -2111,7 +2111,13 @@ class ScribeSessionView(StaffSessionAuthMixin, SimpleAPI):
             # silently dropped by build_amend_edit_effects and logged at WARN
             # there. We don't surface them in the response - they signal a
             # stale or buggy frontend, not a user-facing condition.
-            effects, attempted = build_amend_edit_effects(commands, note_uuid)
+            # feature_flags is threaded through so a void+recreate re-emits
+            # per-command metadata (e.g. Alert Facility) for the recreated
+            # command — otherwise an amended command reads back as pre-feature.
+            feature_flags = {
+                "AlertFacilityCommands": parse_alert_facility_commands(self.secrets.get("AlertFacilityCommands"))
+            }
+            effects, attempted = build_amend_edit_effects(commands, note_uuid, feature_flags)
 
         # Audit fires after the state read + effect-emission step. ``audit_event``
         # catches broad Exception via log.exception, so an audit-write failure

--- a/hyperscribe/scribe/api/session_view.py
+++ b/hyperscribe/scribe/api/session_view.py
@@ -244,6 +244,13 @@ _AMEND_AUDIT_ENTRY_KEYS = (
 # read-only card — no per-type routing into the existing SOAP groups.
 FROM_THE_NOTE_SECTION = "from_the_note"
 
+# Committed-command schema keys that carry the Alert Facility flag (stored as
+# command metadata, not in Command.data). Used to surface the flag on the flat
+# ADDITIONAL COMMANDS cards so it stays visible after a command hits the chart.
+ALERT_FACILITY_SCHEMA_KEYS = frozenset(
+    {"prescribe", "adjustPrescription", "refill", "medicationStatement", "stopMedication"}
+)
+
 _CAMEL_BOUNDARY_RE = re.compile(r"([a-z0-9])([A-Z])")
 
 # Canonical labels for schema_keys whose humanized form would look wrong
@@ -2372,10 +2379,33 @@ class ScribeSessionView(StaffSessionAuthMixin, SimpleAPI):
             .exclude(state="entered_in_error")
             .values("id", "schema_key", "data")
         )
+
+        # Alert Facility lives in command metadata (not Command.data), so read it
+        # back in one batched query and surface it as a detail row — keeping the
+        # flag visible on the flat cards, consistent with the pre-commit view.
+        # Absent metadata defaults to "Yes", matching the Scribe-side default.
+        alert_facility_enabled = bool(self.secrets.get("AlertFacilityEnabled"))
+        alert_facility_by_command: dict[str, str] = {}
+        if alert_facility_enabled:
+            from canvas_sdk.v1.data.command import CommandMetadata
+
+            alert_command_ids = [
+                row["id"] for row in rows if (row.get("schema_key") or "") in ALERT_FACILITY_SCHEMA_KEYS
+            ]
+            if alert_command_ids:
+                for meta in CommandMetadata.objects.filter(
+                    command__id__in=alert_command_ids, key="alert_facility"
+                ).values("command__id", "value"):
+                    alert_facility_by_command[str(meta["command__id"])] = meta["value"]
+
         commands: list[dict[str, Any]] = []
         for row in rows:
             schema_key = row.get("schema_key") or ""
             data = row.get("data") or {}
+            details = _details_for_command(data)
+            if alert_facility_enabled and schema_key in ALERT_FACILITY_SCHEMA_KEYS:
+                value = alert_facility_by_command.get(str(row["id"]), "Yes")
+                details.append({"label": "Alert Facility", "value": value})
             commands.append(
                 {
                     "command_uuid": str(row["id"]),
@@ -2383,7 +2413,7 @@ class ScribeSessionView(StaffSessionAuthMixin, SimpleAPI):
                     "section_key": FROM_THE_NOTE_SECTION,
                     "label": _humanize_schema_key(schema_key),
                     "data": data,
-                    "details": _details_for_command(data),
+                    "details": details,
                     "already_documented": True,
                     "_from_note": True,
                 }

--- a/hyperscribe/scribe/api/session_view.py
+++ b/hyperscribe/scribe/api/session_view.py
@@ -54,6 +54,11 @@ from hyperscribe.scribe.backend import (
     TranscriptItem,
     get_backend_from_secrets,
 )
+from hyperscribe.scribe.commands._alert_facility import (
+    COMMAND_TYPE_BY_SCHEMA_KEY,
+    DEFAULT_ON_BY_COMMAND_TYPE,
+    parse_alert_facility_commands,
+)
 from hyperscribe.scribe.commands.ap_split import split_plan_into_diagnoses
 from hyperscribe.scribe.commands.diagnosis_candidates import PatientConditionSnapshot
 from hyperscribe.scribe.commands.builder import (
@@ -244,40 +249,20 @@ _AMEND_AUDIT_ENTRY_KEYS = (
 # read-only card — no per-type routing into the existing SOAP groups.
 FROM_THE_NOTE_SECTION = "from_the_note"
 
-# Committed-command schema keys that carry the Alert Facility flag (stored as
-# command metadata, not in Command.data). Used to surface the flag on the flat
-# ADDITIONAL COMMANDS cards so it stays visible after a command hits the chart.
-ALERT_FACILITY_SCHEMA_KEYS = frozenset(
-    {"prescribe", "adjustPrescription", "refill", "medicationStatement", "stopMedication"}
-)
 
-# Per-command-type default for the Alert Facility flag, keyed by the frontend
-# command_type (snake_case). Prescribe and adjust prescription default on; the
-# rest default off. Applied only to freshly generated cards (see
-# _inject_alert_facility_defaults) so a new card shows its default without being
-# opened, while historical commands are left untouched.
-ALERT_FACILITY_DEFAULT_BY_COMMAND_TYPE = {
-    "prescribe": True,
-    "adjust_prescription": True,
-    "refill": False,
-    "medication_statement": False,
-    "stop_medication": False,
-}
-
-
-def _inject_alert_facility_defaults(proposals: list[dict[str, Any]], enabled: bool) -> None:
+def _inject_alert_facility_defaults(proposals: list[dict[str, Any]], allowed_commands: set[str]) -> None:
     """Materialize the per-type Alert Facility default onto freshly generated
     command/recommendation proposals so a new card displays its default without
-    being opened. ``setdefault`` means an explicit, already-chosen value always
-    wins. No-op when the feature flag is off. Only ever called on the current
-    generation's proposals — never on historical/committed commands."""
-    if not enabled:
+    being opened. Applies only to command types in ``allowed_commands``.
+    ``setdefault`` means an explicit, already-chosen value always wins. Only ever
+    called on the current generation's proposals — never on historical commands."""
+    if not allowed_commands:
         return
     for proposal in proposals:
         command_type = proposal.get("command_type")
-        if not isinstance(command_type, str):
+        if not isinstance(command_type, str) or command_type not in allowed_commands:
             continue
-        default_on = ALERT_FACILITY_DEFAULT_BY_COMMAND_TYPE.get(command_type)
+        default_on = DEFAULT_ON_BY_COMMAND_TYPE.get(command_type)
         data = proposal.get("data")
         if default_on is not None and isinstance(data, dict):
             data.setdefault("alert_facility", default_on)
@@ -1488,11 +1473,12 @@ class ScribeSessionView(StaffSessionAuthMixin, SimpleAPI):
 
         # ── Alert Facility: stamp per-type defaults onto freshly generated cards ──
         # So a new command/recommendation shows its default without being opened.
-        # Runs only on fresh generation (never on cache reload or /note-commands),
-        # and setdefault leaves any explicit value untouched.
-        alert_facility_enabled = bool(self.secrets.get("AlertFacilityEnabled"))
-        _inject_alert_facility_defaults(commands_list, alert_facility_enabled)
-        _inject_alert_facility_defaults(recommendations_list, alert_facility_enabled)
+        # Only for command types the AlertFacilityCommands secret allows; runs only on
+        # fresh generation (never on cache reload or /note-commands), and setdefault
+        # leaves any explicit value untouched.
+        alert_facility_commands = parse_alert_facility_commands(self.secrets.get("AlertFacilityCommands"))
+        _inject_alert_facility_defaults(commands_list, alert_facility_commands)
+        _inject_alert_facility_defaults(recommendations_list, alert_facility_commands)
 
         # ── Save to database ──
         # `mode` and `selected_template_name` are owned by the session lifecycle
@@ -1791,7 +1777,9 @@ class ScribeSessionView(StaffSessionAuthMixin, SimpleAPI):
                     status_code=HTTPStatus.BAD_REQUEST,
                 )
             ]
-        feature_flags = {"AlertFacilityEnabled": bool(self.secrets.get("AlertFacilityEnabled"))}
+        feature_flags = {
+            "AlertFacilityCommands": parse_alert_facility_commands(self.secrets.get("AlertFacilityCommands"))
+        }
         # Carry-forward assess backgrounds from prior signed notes BEFORE building
         # effects, so the SDK command constructor sees the prefilled value. This
         # mirrors the symmetric placement of ``annotate_duplicates`` (called by
@@ -2423,15 +2411,14 @@ class ScribeSessionView(StaffSessionAuthMixin, SimpleAPI):
         # Alert Facility lives in command metadata (not Command.data), so read it
         # back in one batched query and surface it as a detail row — keeping the
         # flag visible on the flat cards, consistent with the pre-commit view.
-        # Absent metadata defaults to "Yes", matching the Scribe-side default.
-        alert_facility_enabled = bool(self.secrets.get("AlertFacilityEnabled"))
+        # Only for command types the AlertFacilityCommands secret allows.
+        allowed_commands = parse_alert_facility_commands(self.secrets.get("AlertFacilityCommands"))
+        allowed_schema_keys = {sk for sk, ct in COMMAND_TYPE_BY_SCHEMA_KEY.items() if ct in allowed_commands}
         alert_facility_by_command: dict[str, str] = {}
-        if alert_facility_enabled:
+        if allowed_schema_keys:
             from canvas_sdk.v1.data.command import CommandMetadata
 
-            alert_command_ids = [
-                row["id"] for row in rows if (row.get("schema_key") or "") in ALERT_FACILITY_SCHEMA_KEYS
-            ]
+            alert_command_ids = [row["id"] for row in rows if (row.get("schema_key") or "") in allowed_schema_keys]
             if alert_command_ids:
                 for meta in CommandMetadata.objects.filter(
                     command__id__in=alert_command_ids, key="alert_facility"
@@ -2443,7 +2430,7 @@ class ScribeSessionView(StaffSessionAuthMixin, SimpleAPI):
             schema_key = row.get("schema_key") or ""
             data = row.get("data") or {}
             details = _details_for_command(data)
-            if alert_facility_enabled and schema_key in ALERT_FACILITY_SCHEMA_KEYS:
+            if schema_key in allowed_schema_keys:
                 # Show the flag only when the command actually recorded one. Post-feature
                 # commands always carry an explicit alert_facility metadata row (build_effects
                 # writes one via pending_metadata); a missing row means a pre-feature (or

--- a/hyperscribe/scribe/api/session_view.py
+++ b/hyperscribe/scribe/api/session_view.py
@@ -673,13 +673,20 @@ def _load_summary(note_id: str, alert_facility_commands: set[str]) -> dict[str, 
             if updated:
                 mode = inferred
     commands = row["commands"] or []
+    recommendations = row["recommendations"] or []
+    # Reconcile BOTH surfaces against the committed record. _inject stamps a
+    # per-type default onto commands and recommendations alike, so both can
+    # carry a fabricated value that must be re-derived once a card is committed.
+    # (An unaccepted recommendation has no committed command_uuid and is left
+    # untouched, so it keeps its in-flight default.)
     _reconcile_committed_alert_facility(commands, note_id, alert_facility_commands)
+    _reconcile_committed_alert_facility(recommendations, note_id, alert_facility_commands)
     return {
         "note": row["note_data"] or None,
         "commands": commands,
         "approved": row["approved"],
         "was_finalized": row["was_finalized"],
-        "recommendations": row["recommendations"] or [],
+        "recommendations": recommendations,
         "unmatched_conditions": row["unmatched_conditions"] or [],
         "diagnosis_suggestions": row["diagnosis_suggestions"] or {},
         "selected_template_name": row["selected_template_name"] or None,

--- a/hyperscribe/scribe/api/session_view.py
+++ b/hyperscribe/scribe/api/session_view.py
@@ -251,6 +251,17 @@ ALERT_FACILITY_SCHEMA_KEYS = frozenset(
     {"prescribe", "adjustPrescription", "refill", "medicationStatement", "stopMedication"}
 )
 
+# Per-command-type default shown when a command carries no stored alert_facility
+# metadata, so the flag reflects the type's default even on cards never opened.
+# Prescribe and adjust prescription default Yes; the rest default No.
+ALERT_FACILITY_DEFAULT_BY_SCHEMA_KEY = {
+    "prescribe": "Yes",
+    "adjustPrescription": "Yes",
+    "refill": "No",
+    "medicationStatement": "No",
+    "stopMedication": "No",
+}
+
 _CAMEL_BOUNDARY_RE = re.compile(r"([a-z0-9])([A-Z])")
 
 # Canonical labels for schema_keys whose humanized form would look wrong
@@ -2404,7 +2415,7 @@ class ScribeSessionView(StaffSessionAuthMixin, SimpleAPI):
             data = row.get("data") or {}
             details = _details_for_command(data)
             if alert_facility_enabled and schema_key in ALERT_FACILITY_SCHEMA_KEYS:
-                value = alert_facility_by_command.get(str(row["id"]), "Yes")
+                value = alert_facility_by_command.get(str(row["id"]), ALERT_FACILITY_DEFAULT_BY_SCHEMA_KEY[schema_key])
                 details.append({"label": "Alert Facility", "value": value})
             commands.append(
                 {

--- a/hyperscribe/scribe/api/session_view.py
+++ b/hyperscribe/scribe/api/session_view.py
@@ -593,7 +593,60 @@ def _infer_mode_for_heal(note_dbid: int) -> str:
     return ""
 
 
-def _load_summary(note_id: str) -> dict[str, Any] | None:
+def _reconcile_committed_alert_facility(
+    commands: list[dict[str, Any]], note_id: str, allowed_commands: set[str]
+) -> None:
+    """Make the Alert Facility value shown for COMMITTED commands match the committed record.
+
+    The Scribe cache can hold a fabricated/default ``alert_facility`` that was never written to
+    the chart (e.g. stamped by a post-launch re-generation, or carried forward on an edit-save).
+    For a committed command the committed ``CommandMetadata`` is the source of truth: show its
+    value when present, and show nothing when absent (a pre-feature command). Uncommitted (draft)
+    commands are left alone so their working value keeps showing. Mutates ``commands`` in place —
+    display-only; the persisted cache row is not rewritten.
+    """
+    if not allowed_commands:
+        return
+    applicable_uuids = [
+        str(c["command_uuid"])
+        for c in commands
+        if isinstance(c, dict) and c.get("command_type") in allowed_commands and c.get("command_uuid")
+    ]
+    if not applicable_uuids:
+        return
+
+    from canvas_sdk.v1.data.command import Command, CommandMetadata
+
+    committed_uuids = {
+        str(cid)
+        for cid in Command.objects.filter(note__id=note_id, id__in=applicable_uuids)
+        .exclude(state="entered_in_error")
+        .values_list("id", flat=True)
+    }
+    if not committed_uuids:
+        return
+    value_by_uuid = {
+        str(meta["command__id"]): meta["value"]
+        for meta in CommandMetadata.objects.filter(command__id__in=committed_uuids, key="alert_facility").values(
+            "command__id", "value"
+        )
+    }
+    for command in commands:
+        if not isinstance(command, dict) or command.get("command_type") not in allowed_commands:
+            continue
+        uuid = str(command.get("command_uuid") or "")
+        if uuid not in committed_uuids:
+            continue  # uncommitted draft — keep its working value
+        data = command.get("data")
+        if not isinstance(data, dict):
+            continue
+        if uuid in value_by_uuid:
+            data["alert_facility"] = value_by_uuid[uuid] == "Yes"
+        else:
+            data.pop("alert_facility", None)
+
+
+def _load_summary(note_id: str, alert_facility_commands: set[str]) -> dict[str, Any] | None:
     note_dbid = Note.objects.values_list("dbid", flat=True).get(id=note_id)
     row = (
         ScribeSummary.objects.filter(note_id=note_dbid)
@@ -619,9 +672,11 @@ def _load_summary(note_id: str) -> dict[str, Any] | None:
             updated = ScribeSummary.objects.filter(note_id=note_dbid, mode="").update(mode=inferred)
             if updated:
                 mode = inferred
+    commands = row["commands"] or []
+    _reconcile_committed_alert_facility(commands, note_id, alert_facility_commands)
     return {
         "note": row["note_data"] or None,
-        "commands": row["commands"] or [],
+        "commands": commands,
         "approved": row["approved"],
         "was_finalized": row["was_finalized"],
         "recommendations": row["recommendations"] or [],
@@ -831,7 +886,7 @@ def _load_initial_data(note_id: str, secrets: dict[str, str]) -> dict[str, Any]:
     """Compile all data needed for the Scribe UI initial render."""
     return {
         "transcript": _load_transcript(note_id),
-        "summary": _load_summary(note_id),
+        "summary": _load_summary(note_id, parse_alert_facility_commands(secrets.get("AlertFacilityCommands"))),
         "assignees": _load_assignees(),
         "templates": _load_templates(secrets),
     }
@@ -1085,7 +1140,7 @@ class ScribeSessionView(StaffSessionAuthMixin, SimpleAPI):
         note_id = self.request.query_params.get("note_id", "")
         if not note_id:
             return [JSONResponse({"error": "note_id is required"}, status_code=HTTPStatus.BAD_REQUEST)]
-        data = _load_summary(note_id)
+        data = _load_summary(note_id, parse_alert_facility_commands(self.secrets.get("AlertFacilityCommands")))
         if data is None:
             return [
                 JSONResponse(

--- a/hyperscribe/scribe/commands/_alert_facility.py
+++ b/hyperscribe/scribe/commands/_alert_facility.py
@@ -1,0 +1,45 @@
+"""Shared config + parsing for the Alert Facility flag.
+
+Alert Facility is gated per command type via the ``AlertFacilityCommands`` secret,
+a comma-separated list of ``command_type`` names. A command shows the toggle (and
+records / displays the flag) only when its ``command_type`` is in that list; an
+empty/unset list turns the feature off everywhere.
+
+This module is the single source of truth for the supported command types, their
+committed ``schema_key`` mapping, their per-type default, and the secret parser —
+shared by the API views (``scribe_view``, ``session_view``) so backend and frontend
+stay consistent.
+"""
+
+from __future__ import annotations
+
+# Frontend/parser ``command_type`` (snake_case) -> committed ``Command.schema_key`` (camelCase).
+SCHEMA_KEY_BY_COMMAND_TYPE: dict[str, str] = {
+    "prescribe": "prescribe",
+    "adjust_prescription": "adjustPrescription",
+    "refill": "refill",
+    "medication_statement": "medicationStatement",
+    "stop_medication": "stopMedication",
+}
+
+# Reverse lookup for the committed ``/note-commands`` cards, which carry schema_key.
+COMMAND_TYPE_BY_SCHEMA_KEY: dict[str, str] = {v: k for k, v in SCHEMA_KEY_BY_COMMAND_TYPE.items()}
+
+# Per-command-type default position when no explicit value exists. Prescribe and
+# adjust prescription default on; the rest default off.
+DEFAULT_ON_BY_COMMAND_TYPE: dict[str, bool] = {
+    "prescribe": True,
+    "adjust_prescription": True,
+    "refill": False,
+    "medication_statement": False,
+    "stop_medication": False,
+}
+
+SUPPORTED_COMMAND_TYPES: frozenset[str] = frozenset(SCHEMA_KEY_BY_COMMAND_TYPE)
+
+
+def parse_alert_facility_commands(raw: str | None) -> set[str]:
+    """Parse the ``AlertFacilityCommands`` secret (comma-separated command types)
+    into a normalized set of allowed command types. Blank entries and unknown
+    names (typos, unsupported commands) are dropped."""
+    return {entry.strip().lower() for entry in (raw or "").split(",") if entry.strip()} & SUPPORTED_COMMAND_TYPES

--- a/hyperscribe/scribe/commands/adjust_prescription.py
+++ b/hyperscribe/scribe/commands/adjust_prescription.py
@@ -125,6 +125,23 @@ class AdjustPrescriptionParser(CommandParser):
             command_uuid=command_uuid,
         )
 
+    def pending_metadata(
+        self,
+        command: _BaseCommand,
+        proposal: dict[str, Any] | None = None,
+        feature_flags: dict[str, bool] | None = None,
+    ) -> dict[str, Any] | None:
+        if not (feature_flags or {}).get("AlertFacilityEnabled"):
+            return None
+        # Alert Facility defaults to Yes; only an explicit stored ``False`` records No.
+        truthy = ((proposal or {}).get("data") or {}).get("alert_facility", True) is not False
+        return {
+            "command_uuid": command.command_uuid,
+            "command_type": self.command_type,
+            "note_uuid": command.note_uuid,
+            "metadata": {"alert_facility": "Yes" if truthy else "No"},
+        }
+
     def to_effects(self, command: _BaseCommand, note_uuid: str | None = None) -> list[Effect]:
         """Adjust prescriptions require originate + review (same as prescriptions)."""
         return [command.originate(), command.review()]

--- a/hyperscribe/scribe/commands/adjust_prescription.py
+++ b/hyperscribe/scribe/commands/adjust_prescription.py
@@ -129,9 +129,9 @@ class AdjustPrescriptionParser(CommandParser):
         self,
         command: _BaseCommand,
         proposal: dict[str, Any] | None = None,
-        feature_flags: dict[str, bool] | None = None,
+        feature_flags: dict[str, Any] | None = None,
     ) -> dict[str, Any] | None:
-        if not (feature_flags or {}).get("AlertFacilityEnabled"):
+        if self.command_type not in (feature_flags or {}).get("AlertFacilityCommands", set()):
             return None
         # Alert Facility defaults to Yes; only an explicit stored ``False`` records No.
         truthy = ((proposal or {}).get("data") or {}).get("alert_facility", True) is not False

--- a/hyperscribe/scribe/commands/base.py
+++ b/hyperscribe/scribe/commands/base.py
@@ -83,7 +83,7 @@ class CommandParser(ABC):
         self,
         command: _BaseCommand,
         proposal: dict[str, Any] | None = None,
-        feature_flags: dict[str, bool] | None = None,
+        feature_flags: dict[str, Any] | None = None,
     ) -> dict[str, Any] | None:
         """Return metadata to upsert, or None. Override per command type."""
         return None

--- a/hyperscribe/scribe/commands/builder.py
+++ b/hyperscribe/scribe/commands/builder.py
@@ -674,6 +674,7 @@ NON_EDITABLE_AMEND_COMMAND_TYPES: frozenset[str] = frozenset(
 def build_amend_edit_effects(
     proposals: list[dict[str, Any]],
     note_uuid: str,
+    feature_flags: dict[str, Any] | None = None,
 ) -> tuple[list[Effect], list[dict[str, Any]]]:
     """Build Canvas SDK Effects for amendment-mode edits of already-documented commands.
 
@@ -682,6 +683,12 @@ def build_amend_edit_effects(
     silently dropped and logged at WARN (defense in depth - we never trust a
     hand-crafted payload enough to invent a uuid or emit effects for a
     non-amendable section).
+
+    ``feature_flags`` is threaded through to ``pending_metadata`` so a
+    void+recreate re-emits per-command metadata (e.g. Alert Facility) for the
+    recreated command. Without this, an amended command lands in the chart with
+    no metadata row and every read path treats it as pre-feature — silently
+    dropping a value that was genuinely recorded on the original.
 
     Returns ``(effects, attempted)`` where ``attempted`` carries enough state
     for the API layer to (a) emit a structured audit-log entry and (b) let the
@@ -768,6 +775,16 @@ def build_amend_edit_effects(
             mode = "void_recreate_questionnaire"
         else:
             effects.append(new_command.originate())
+            # Re-emit pending metadata (e.g. Alert Facility) for the recreated
+            # command. Must land after originate (the Command row now exists)
+            # and before commit (attaches while still STAGED) — mirrors the
+            # originate -> metadata -> commit ordering in build_effects. A no-op
+            # for command types without pending metadata or when the feature is
+            # off for this type.
+            meta = builder.pending_metadata(new_command, proposal, feature_flags)
+            if meta:
+                for key, value in (meta.get("metadata") or {}).items():
+                    effects.append(_build_unvalidated_metadata_effect(new_command, key, value))
             if section_key in CUSTOM_COMMAND_ROUTED_SECTIONS:
                 mode = "void_recreate_custom"
             else:

--- a/hyperscribe/scribe/commands/builder.py
+++ b/hyperscribe/scribe/commands/builder.py
@@ -372,7 +372,7 @@ _BUILD_ERROR_LABELS: dict[str, str] = {
 def build_effects(
     proposals: list[dict[str, Any]],
     note_uuid: str,
-    feature_flags: dict[str, bool] | None = None,
+    feature_flags: dict[str, Any] | None = None,
 ) -> tuple[list[Effect], list[dict[str, Any]], list[dict[str, Any]], list[dict[str, Any]]]:
     """Convert selected command proposals into Canvas SDK Effects.
 

--- a/hyperscribe/scribe/commands/medication_statement.py
+++ b/hyperscribe/scribe/commands/medication_statement.py
@@ -124,8 +124,8 @@ class MedicationParser(CommandParser):
     ) -> dict[str, Any] | None:
         if not (feature_flags or {}).get("AlertFacilityEnabled"):
             return None
-        # Alert Facility defaults to Yes; only an explicit stored ``False`` records No.
-        truthy = ((proposal or {}).get("data") or {}).get("alert_facility", True) is not False
+        # Medication statement defaults to No; only an explicit stored ``True`` records Yes.
+        truthy = ((proposal or {}).get("data") or {}).get("alert_facility", False) is not False
         return {
             "command_uuid": command.command_uuid,
             "command_type": self.command_type,

--- a/hyperscribe/scribe/commands/medication_statement.py
+++ b/hyperscribe/scribe/commands/medication_statement.py
@@ -124,7 +124,8 @@ class MedicationParser(CommandParser):
     ) -> dict[str, Any] | None:
         if not (feature_flags or {}).get("AlertFacilityEnabled"):
             return None
-        truthy = bool(proposal and proposal.get("data", {}).get("alert_facility"))
+        # Alert Facility defaults to Yes; only an explicit stored ``False`` records No.
+        truthy = ((proposal or {}).get("data") or {}).get("alert_facility", True) is not False
         return {
             "command_uuid": command.command_uuid,
             "command_type": self.command_type,

--- a/hyperscribe/scribe/commands/medication_statement.py
+++ b/hyperscribe/scribe/commands/medication_statement.py
@@ -120,9 +120,9 @@ class MedicationParser(CommandParser):
         self,
         command: _BaseCommand,
         proposal: dict[str, Any] | None = None,
-        feature_flags: dict[str, bool] | None = None,
+        feature_flags: dict[str, Any] | None = None,
     ) -> dict[str, Any] | None:
-        if not (feature_flags or {}).get("AlertFacilityEnabled"):
+        if self.command_type not in (feature_flags or {}).get("AlertFacilityCommands", set()):
             return None
         # Medication statement defaults to No; only an explicit stored ``True`` records Yes.
         truthy = ((proposal or {}).get("data") or {}).get("alert_facility", False) is not False

--- a/hyperscribe/scribe/commands/prescription.py
+++ b/hyperscribe/scribe/commands/prescription.py
@@ -83,6 +83,23 @@ class PrescriptionParser(CommandParser):
             command_uuid=command_uuid,
         )
 
+    def pending_metadata(
+        self,
+        command: _BaseCommand,
+        proposal: dict[str, Any] | None = None,
+        feature_flags: dict[str, bool] | None = None,
+    ) -> dict[str, Any] | None:
+        if not (feature_flags or {}).get("AlertFacilityEnabled"):
+            return None
+        # Alert Facility defaults to Yes; only an explicit stored ``False`` records No.
+        truthy = ((proposal or {}).get("data") or {}).get("alert_facility", True) is not False
+        return {
+            "command_uuid": command.command_uuid,
+            "command_type": self.command_type,
+            "note_uuid": command.note_uuid,
+            "metadata": {"alert_facility": "Yes" if truthy else "No"},
+        }
+
     def to_effects(self, command: _BaseCommand, note_uuid: str | None = None) -> list[Effect]:
         """Prescriptions require originate + review (not commit) for provider sign-off."""
         return [command.originate(), command.review()]

--- a/hyperscribe/scribe/commands/prescription.py
+++ b/hyperscribe/scribe/commands/prescription.py
@@ -87,9 +87,9 @@ class PrescriptionParser(CommandParser):
         self,
         command: _BaseCommand,
         proposal: dict[str, Any] | None = None,
-        feature_flags: dict[str, bool] | None = None,
+        feature_flags: dict[str, Any] | None = None,
     ) -> dict[str, Any] | None:
-        if not (feature_flags or {}).get("AlertFacilityEnabled"):
+        if self.command_type not in (feature_flags or {}).get("AlertFacilityCommands", set()):
             return None
         # Alert Facility defaults to Yes; only an explicit stored ``False`` records No.
         truthy = ((proposal or {}).get("data") or {}).get("alert_facility", True) is not False

--- a/hyperscribe/scribe/commands/refill.py
+++ b/hyperscribe/scribe/commands/refill.py
@@ -115,9 +115,9 @@ class RefillParser(CommandParser):
         self,
         command: _BaseCommand,
         proposal: dict[str, Any] | None = None,
-        feature_flags: dict[str, bool] | None = None,
+        feature_flags: dict[str, Any] | None = None,
     ) -> dict[str, Any] | None:
-        if not (feature_flags or {}).get("AlertFacilityEnabled"):
+        if self.command_type not in (feature_flags or {}).get("AlertFacilityCommands", set()):
             return None
         # Refill defaults to No; only an explicit stored ``True`` records Yes.
         truthy = ((proposal or {}).get("data") or {}).get("alert_facility", False) is not False

--- a/hyperscribe/scribe/commands/refill.py
+++ b/hyperscribe/scribe/commands/refill.py
@@ -119,8 +119,8 @@ class RefillParser(CommandParser):
     ) -> dict[str, Any] | None:
         if not (feature_flags or {}).get("AlertFacilityEnabled"):
             return None
-        # Alert Facility defaults to Yes; only an explicit stored ``False`` records No.
-        truthy = ((proposal or {}).get("data") or {}).get("alert_facility", True) is not False
+        # Refill defaults to No; only an explicit stored ``True`` records Yes.
+        truthy = ((proposal or {}).get("data") or {}).get("alert_facility", False) is not False
         return {
             "command_uuid": command.command_uuid,
             "command_type": self.command_type,

--- a/hyperscribe/scribe/commands/refill.py
+++ b/hyperscribe/scribe/commands/refill.py
@@ -111,6 +111,23 @@ class RefillParser(CommandParser):
             command_uuid=command_uuid,
         )
 
+    def pending_metadata(
+        self,
+        command: _BaseCommand,
+        proposal: dict[str, Any] | None = None,
+        feature_flags: dict[str, bool] | None = None,
+    ) -> dict[str, Any] | None:
+        if not (feature_flags or {}).get("AlertFacilityEnabled"):
+            return None
+        # Alert Facility defaults to Yes; only an explicit stored ``False`` records No.
+        truthy = ((proposal or {}).get("data") or {}).get("alert_facility", True) is not False
+        return {
+            "command_uuid": command.command_uuid,
+            "command_type": self.command_type,
+            "note_uuid": command.note_uuid,
+            "metadata": {"alert_facility": "Yes" if truthy else "No"},
+        }
+
     def to_effects(self, command: _BaseCommand, note_uuid: str | None = None) -> list[Effect]:
         """Refills require originate + review (same as prescriptions)."""
         return [command.originate(), command.review()]

--- a/hyperscribe/scribe/commands/stop_medication.py
+++ b/hyperscribe/scribe/commands/stop_medication.py
@@ -39,7 +39,8 @@ class StopMedicationParser(CommandParser):
     ) -> dict[str, Any] | None:
         if not (feature_flags or {}).get("AlertFacilityEnabled"):
             return None
-        truthy = bool(proposal and proposal.get("data", {}).get("alert_facility"))
+        # Alert Facility defaults to Yes; only an explicit stored ``False`` records No.
+        truthy = ((proposal or {}).get("data") or {}).get("alert_facility", True) is not False
         return {
             "command_uuid": command.command_uuid,
             "command_type": self.command_type,

--- a/hyperscribe/scribe/commands/stop_medication.py
+++ b/hyperscribe/scribe/commands/stop_medication.py
@@ -35,9 +35,9 @@ class StopMedicationParser(CommandParser):
         self,
         command: _BaseCommand,
         proposal: dict[str, Any] | None = None,
-        feature_flags: dict[str, bool] | None = None,
+        feature_flags: dict[str, Any] | None = None,
     ) -> dict[str, Any] | None:
-        if not (feature_flags or {}).get("AlertFacilityEnabled"):
+        if self.command_type not in (feature_flags or {}).get("AlertFacilityCommands", set()):
             return None
         # Stop medication defaults to No; only an explicit stored ``True`` records Yes.
         truthy = ((proposal or {}).get("data") or {}).get("alert_facility", False) is not False

--- a/hyperscribe/scribe/commands/stop_medication.py
+++ b/hyperscribe/scribe/commands/stop_medication.py
@@ -39,8 +39,8 @@ class StopMedicationParser(CommandParser):
     ) -> dict[str, Any] | None:
         if not (feature_flags or {}).get("AlertFacilityEnabled"):
             return None
-        # Alert Facility defaults to Yes; only an explicit stored ``False`` records No.
-        truthy = ((proposal or {}).get("data") or {}).get("alert_facility", True) is not False
+        # Stop medication defaults to No; only an explicit stored ``True`` records Yes.
+        truthy = ((proposal or {}).get("data") or {}).get("alert_facility", False) is not False
         return {
             "command_uuid": command.command_uuid,
             "command_type": self.command_type,

--- a/hyperscribe/scribe/static/app.js
+++ b/hyperscribe/scribe/static/app.js
@@ -6,7 +6,7 @@ import { Audit } from '/plugin-io/api/hyperscribe/scribe/static/audit.js';
 
 const html = htm.bind(h);
 
-export function App({ noteId, view, providerName, providerPhotoUrl, patientName, patientBirthDate, patientGender, patientId, staffId, staffName, debugMode, noteEditable, isAuthor, alertFacilityEnabled, manualModeOnly, dictationEnabled, initialData }) {
+export function App({ noteId, view, providerName, providerPhotoUrl, patientName, patientBirthDate, patientGender, patientId, staffId, staffName, debugMode, noteEditable, isAuthor, alertFacilityCommands, manualModeOnly, dictationEnabled, initialData }) {
   if (view === 'audit') {
     return html`<${Audit} noteId=${noteId} />`;
   }
@@ -29,7 +29,7 @@ export function App({ noteId, view, providerName, providerPhotoUrl, patientName,
       debugMode=${debugMode}
       noteEditable=${noteEditable}
       isAuthor=${isAuthor}
-      alertFacilityEnabled=${alertFacilityEnabled}
+      alertFacilityCommands=${alertFacilityCommands}
       manualModeOnly=${manualModeOnly}
       dictationEnabled=${dictationEnabled}
       initialData=${initialData}

--- a/hyperscribe/scribe/static/index.html
+++ b/hyperscribe/scribe/static/index.html
@@ -68,7 +68,7 @@
       debugMode: '{{ debug_mode }}' === 'true',
       noteEditable: '{{ note_editable }}' === 'true',
       isAuthor: '{{ is_author }}' === 'true',
-      alertFacilityEnabled: '{{ alert_facility_enabled }}' === 'true',
+      alertFacilityCommands: new Set('{{ alert_facility_commands }}'.split(',').map(s => s.trim()).filter(Boolean)),
       manualModeOnly: '{{ manual_mode_only }}' === 'true',
       dictationEnabled: '{{ dictation_enabled }}' === 'true',
       initialData: initialData,

--- a/hyperscribe/scribe/static/medication-row.js
+++ b/hyperscribe/scribe/static/medication-row.js
@@ -24,7 +24,7 @@ function useDebounce(fn, delay) {
   }, [fn, delay]);
 }
 
-export function MedicationRow({ command, commandIndex, onEdit, onDelete, readOnly, alertFacilityEnabled, onEditingChange }) {
+export function MedicationRow({ command, commandIndex, onEdit, onDelete, readOnly, alertFacilityCommands, onEditingChange }) {
   const [editing, setEditing] = useState(!command.display);
   useEffect(() => {
     onEditingChange?.(commandIndex, editing);
@@ -110,9 +110,10 @@ export function MedicationRow({ command, commandIndex, onEdit, onDelete, readOnl
 
   const handleSave = () => {
     const newData = { ...command.data, medication_text: selectedDisplay, sig };
-    // Materialize the flag for a brand-new card or when the user set it; otherwise the
-    // `...command.data` spread preserves any existing value and an absent one stays absent.
-    if (!command.display || alertFacilityTouched) {
+    // Materialize the flag only when this command type is enabled AND it's a brand-new card
+    // or the user set it; otherwise the `...command.data` spread preserves any existing value
+    // and an absent one stays absent.
+    if (alertFacilityCommands.has(command.command_type) && (!command.display || alertFacilityTouched)) {
       newData.alert_facility = alertFacility;
     }
     if (selectedFdb) {
@@ -156,7 +157,7 @@ export function MedicationRow({ command, commandIndex, onEdit, onDelete, readOnl
         <div class="order-view">
           <div class="order-view-name">${command.display}</div>
           ${command.data.sig && html`<div class="order-view-sig">${command.data.sig}</div>`}
-          ${alertFacilityEnabled && (command.data.alert_facility === true || command.data.alert_facility === false) && html`<div class="order-view-alert-facility">Alert Facility: ${command.data.alert_facility ? 'Yes' : 'No'}</div>`}
+          ${alertFacilityCommands.has(command.command_type) && (command.data.alert_facility === true || command.data.alert_facility === false) && html`<div class="order-view-alert-facility">Alert Facility: ${command.data.alert_facility ? 'Yes' : 'No'}</div>`}
         </div>
       </div>
     `;
@@ -209,7 +210,7 @@ export function MedicationRow({ command, commandIndex, onEdit, onDelete, readOnl
               placeholder="e.g. Take 1 tablet daily"
             />
           </div>
-          ${alertFacilityEnabled && html`
+          ${alertFacilityCommands.has(command.command_type) && html`
           <div class="history-form-field">
             <button type="button" class="alert-facility-toggle" onClick=${() => { setAlertFacility(prev => !prev); setAlertFacilityTouched(true); }}>
               <div class="toggle-switch${alertFacility ? ' on' : ''}">
@@ -235,7 +236,7 @@ export function MedicationRow({ command, commandIndex, onEdit, onDelete, readOnl
       <div class="order-view">
         <div class="order-view-name">${command.display}</div>
         ${command.data.sig && html`<div class="order-view-sig">${command.data.sig}</div>`}
-        ${alertFacilityEnabled && (command.data.alert_facility === true || command.data.alert_facility === false) && html`<div class="order-view-alert-facility">Alert Facility: ${command.data.alert_facility ? 'Yes' : 'No'}</div>`}
+        ${alertFacilityCommands.has(command.command_type) && (command.data.alert_facility === true || command.data.alert_facility === false) && html`<div class="order-view-alert-facility">Alert Facility: ${command.data.alert_facility ? 'Yes' : 'No'}</div>`}
       </div>
     </div>
   `;

--- a/hyperscribe/scribe/static/medication-row.js
+++ b/hyperscribe/scribe/static/medication-row.js
@@ -39,7 +39,8 @@ export function MedicationRow({ command, commandIndex, onEdit, onDelete, readOnl
   );
   const [selectedDisplay, setSelectedDisplay] = useState(command.data.medication_text || '');
   const [sig, setSig] = useState(command.data.sig || '');
-  const [alertFacility, setAlertFacility] = useState(!!command.data.alert_facility);
+  // Defaults to Yes (on); only an explicit stored `false` keeps it off.
+  const [alertFacility, setAlertFacility] = useState(command.data.alert_facility !== false);
   const inputRef = useRef(null);
   const containerRef = useRef(null);
 
@@ -124,7 +125,7 @@ export function MedicationRow({ command, commandIndex, onEdit, onDelete, readOnl
     setSelectedFdb(isFdbStructured(command.data.fdb_code) ? command.data.fdb_code : null);
     setSelectedDisplay(command.data.medication_text || '');
     setSig(command.data.sig || '');
-    setAlertFacility(!!command.data.alert_facility);
+    setAlertFacility(command.data.alert_facility !== false);
     setResults([]);
     setEditing(false);
   };
@@ -146,6 +147,7 @@ export function MedicationRow({ command, commandIndex, onEdit, onDelete, readOnl
         <div class="order-view">
           <div class="order-view-name">${command.display}</div>
           ${command.data.sig && html`<div class="order-view-sig">${command.data.sig}</div>`}
+          ${alertFacilityEnabled && html`<div class="order-view-alert-facility">Alert Facility: ${command.data.alert_facility !== false ? 'Yes' : 'No'}</div>`}
         </div>
       </div>
     `;
@@ -224,7 +226,7 @@ export function MedicationRow({ command, commandIndex, onEdit, onDelete, readOnl
       <div class="order-view">
         <div class="order-view-name">${command.display}</div>
         ${command.data.sig && html`<div class="order-view-sig">${command.data.sig}</div>`}
-        ${alertFacilityEnabled && command.data.alert_facility && html`<span class="badge badge-alert">Alert Facility</span>`}
+        ${alertFacilityEnabled && html`<div class="order-view-alert-facility">Alert Facility: ${command.data.alert_facility !== false ? 'Yes' : 'No'}</div>`}
       </div>
     </div>
   `;

--- a/hyperscribe/scribe/static/medication-row.js
+++ b/hyperscribe/scribe/static/medication-row.js
@@ -147,7 +147,7 @@ export function MedicationRow({ command, commandIndex, onEdit, onDelete, readOnl
         <div class="order-view">
           <div class="order-view-name">${command.display}</div>
           ${command.data.sig && html`<div class="order-view-sig">${command.data.sig}</div>`}
-          ${alertFacilityEnabled && html`<div class="order-view-alert-facility">Alert Facility: ${command.data.alert_facility !== false ? 'Yes' : 'No'}</div>`}
+          ${alertFacilityEnabled && html`<div class="order-view-alert-facility">Alert Facility: ${command.data.alert_facility === true ? 'Yes' : 'No'}</div>`}
         </div>
       </div>
     `;
@@ -226,7 +226,7 @@ export function MedicationRow({ command, commandIndex, onEdit, onDelete, readOnl
       <div class="order-view">
         <div class="order-view-name">${command.display}</div>
         ${command.data.sig && html`<div class="order-view-sig">${command.data.sig}</div>`}
-        ${alertFacilityEnabled && html`<div class="order-view-alert-facility">Alert Facility: ${command.data.alert_facility !== false ? 'Yes' : 'No'}</div>`}
+        ${alertFacilityEnabled && html`<div class="order-view-alert-facility">Alert Facility: ${command.data.alert_facility === true ? 'Yes' : 'No'}</div>`}
       </div>
     </div>
   `;

--- a/hyperscribe/scribe/static/medication-row.js
+++ b/hyperscribe/scribe/static/medication-row.js
@@ -39,8 +39,8 @@ export function MedicationRow({ command, commandIndex, onEdit, onDelete, readOnl
   );
   const [selectedDisplay, setSelectedDisplay] = useState(command.data.medication_text || '');
   const [sig, setSig] = useState(command.data.sig || '');
-  // Defaults to Yes (on); only an explicit stored `false` keeps it off.
-  const [alertFacility, setAlertFacility] = useState(command.data.alert_facility !== false);
+  // Medication statement defaults to No (off); only an explicit stored `true` turns it on.
+  const [alertFacility, setAlertFacility] = useState(command.data.alert_facility === true);
   const inputRef = useRef(null);
   const containerRef = useRef(null);
 
@@ -125,7 +125,7 @@ export function MedicationRow({ command, commandIndex, onEdit, onDelete, readOnl
     setSelectedFdb(isFdbStructured(command.data.fdb_code) ? command.data.fdb_code : null);
     setSelectedDisplay(command.data.medication_text || '');
     setSig(command.data.sig || '');
-    setAlertFacility(command.data.alert_facility !== false);
+    setAlertFacility(command.data.alert_facility === true);
     setResults([]);
     setEditing(false);
   };

--- a/hyperscribe/scribe/static/medication-row.js
+++ b/hyperscribe/scribe/static/medication-row.js
@@ -41,6 +41,9 @@ export function MedicationRow({ command, commandIndex, onEdit, onDelete, readOnl
   const [sig, setSig] = useState(command.data.sig || '');
   // Medication statement defaults to No (off); only an explicit stored `true` turns it on.
   const [alertFacility, setAlertFacility] = useState(command.data.alert_facility === true);
+  // Only persist the flag when the user actually engaged it (or the command already
+  // carries one, or it's brand new) — never fabricate a value on an unrelated edit.
+  const [alertFacilityTouched, setAlertFacilityTouched] = useState(false);
   const inputRef = useRef(null);
   const containerRef = useRef(null);
 
@@ -106,7 +109,12 @@ export function MedicationRow({ command, commandIndex, onEdit, onDelete, readOnl
   };
 
   const handleSave = () => {
-    const newData = { ...command.data, medication_text: selectedDisplay, sig, alert_facility: alertFacility };
+    const newData = { ...command.data, medication_text: selectedDisplay, sig };
+    // Materialize the flag for a brand-new card or when the user set it; otherwise the
+    // `...command.data` spread preserves any existing value and an absent one stays absent.
+    if (!command.display || alertFacilityTouched) {
+      newData.alert_facility = alertFacility;
+    }
     if (selectedFdb) {
       newData.fdb_code = selectedFdb;
     } else {
@@ -126,6 +134,7 @@ export function MedicationRow({ command, commandIndex, onEdit, onDelete, readOnl
     setSelectedDisplay(command.data.medication_text || '');
     setSig(command.data.sig || '');
     setAlertFacility(command.data.alert_facility === true);
+    setAlertFacilityTouched(false);
     setResults([]);
     setEditing(false);
   };
@@ -147,7 +156,7 @@ export function MedicationRow({ command, commandIndex, onEdit, onDelete, readOnl
         <div class="order-view">
           <div class="order-view-name">${command.display}</div>
           ${command.data.sig && html`<div class="order-view-sig">${command.data.sig}</div>`}
-          ${alertFacilityEnabled && html`<div class="order-view-alert-facility">Alert Facility: ${command.data.alert_facility === true ? 'Yes' : 'No'}</div>`}
+          ${alertFacilityEnabled && (command.data.alert_facility === true || command.data.alert_facility === false) && html`<div class="order-view-alert-facility">Alert Facility: ${command.data.alert_facility ? 'Yes' : 'No'}</div>`}
         </div>
       </div>
     `;
@@ -202,7 +211,7 @@ export function MedicationRow({ command, commandIndex, onEdit, onDelete, readOnl
           </div>
           ${alertFacilityEnabled && html`
           <div class="history-form-field">
-            <button type="button" class="alert-facility-toggle" onClick=${() => setAlertFacility(prev => !prev)}>
+            <button type="button" class="alert-facility-toggle" onClick=${() => { setAlertFacility(prev => !prev); setAlertFacilityTouched(true); }}>
               <div class="toggle-switch${alertFacility ? ' on' : ''}">
                 <div class="toggle-knob" />
               </div>
@@ -226,7 +235,7 @@ export function MedicationRow({ command, commandIndex, onEdit, onDelete, readOnl
       <div class="order-view">
         <div class="order-view-name">${command.display}</div>
         ${command.data.sig && html`<div class="order-view-sig">${command.data.sig}</div>`}
-        ${alertFacilityEnabled && html`<div class="order-view-alert-facility">Alert Facility: ${command.data.alert_facility === true ? 'Yes' : 'No'}</div>`}
+        ${alertFacilityEnabled && (command.data.alert_facility === true || command.data.alert_facility === false) && html`<div class="order-view-alert-facility">Alert Facility: ${command.data.alert_facility ? 'Yes' : 'No'}</div>`}
       </div>
     </div>
   `;

--- a/hyperscribe/scribe/static/order-row.js
+++ b/hyperscribe/scribe/static/order-row.js
@@ -288,7 +288,7 @@ function InteractionWarningInline({ warning }) {
   `;
 }
 
-export function OrderRow({ command, commandIndex, onEdit, onDelete, readOnly, patientId, noteId, staffId, staffName, noteDiagnoses = [], isRecommendation, onEditingChange }) {
+export function OrderRow({ command, commandIndex, onEdit, onDelete, readOnly, alertFacilityEnabled, patientId, noteId, staffId, staffName, noteDiagnoses = [], isRecommendation, onEditingChange }) {
   const isNew = !command.display;
   const [editing, setEditing] = useState(isNew);
   useEffect(() => {
@@ -328,6 +328,11 @@ export function OrderRow({ command, commandIndex, onEdit, onDelete, readOnly, pa
   const [pharmacySearched, setPharmacySearched] = useState(false);
   const [interactionWarning, setInteractionWarning] = useState(null);
   const [checkingInteractions, setCheckingInteractions] = useState(false);
+
+  // Alert Facility flag is per-command (not per-tab), so it lives outside the
+  // Rx snapshot machinery and persists across prescribe/refill/adjust tab switches.
+  // Defaults to Yes (on); only an explicit stored `false` keeps it off.
+  const [alertFacility, setAlertFacility] = useState(command.data.alert_facility !== false);
 
   // "Change to" medication (adjust_prescription only).
   const [changeToQuery, setChangeToQuery] = useState(command.data.new_medication_text || '');
@@ -1152,6 +1157,7 @@ export function OrderRow({ command, commandIndex, onEdit, onDelete, readOnly, pa
         pharmacy: selectedPharmacy || null,
         pharmacy_name: selectedPharmacy ? pharmacyQuery : null,
         quantities: medQuantities.map(q => ({ representative_ndc: q.representative_ndc, ncpdp_quantity_qualifier_code: q.ncpdp_quantity_qualifier_code, clinical_quantity_description: q.label, quantity: 1 })),
+        alert_facility: alertFacility,
       };
       // Include "change to" medication for adjust_prescription.
       if (activeTab === 'adjust_prescription' && changeToFdb) {
@@ -1820,6 +1826,16 @@ export function OrderRow({ command, commandIndex, onEdit, onDelete, readOnly, pa
                 `}
               </div>
             `}
+            ${alertFacilityEnabled && RX_TAB_KEYS.has(activeTab) && html`
+              <div class="history-form-field">
+                <button type="button" class="alert-facility-toggle" onClick=${() => setAlertFacility(prev => !prev)}>
+                  <div class="toggle-switch${alertFacility ? ' on' : ''}">
+                    <div class="toggle-knob" />
+                  </div>
+                  Alert Facility
+                </button>
+              </div>
+            `}
             <div class="questionnaire-form-actions">
               <button type="button" class="form-btn form-btn-cancel" onClick=${handleCancel}>Cancel</button>
               <button
@@ -1892,6 +1908,7 @@ export function OrderRow({ command, commandIndex, onEdit, onDelete, readOnly, pa
             <div class="order-view-name">${command.display}</div>
             ${d.sig && html`<div class="order-view-sig">Sig: ${d.sig}</div>`}
             ${detailParts.length > 0 && html`<div class="order-view-details">${detailParts.join(' · ')}</div>`}
+            ${alertFacilityEnabled && html`<div class="order-view-alert-facility">Alert Facility: ${d.alert_facility !== false ? 'Yes' : 'No'}</div>`}
           </div>
         </div>
         ${interactionWarning && html`<${InteractionWarningInline} warning=${interactionWarning} />`}
@@ -1945,6 +1962,7 @@ export function OrderRow({ command, commandIndex, onEdit, onDelete, readOnly, pa
       <div class="order-view">
         <span class="command-type-label">${badgeLabel}</span>
         <div class="order-view-name">${command.display}</div>
+        ${alertFacilityEnabled && RX_TAB_KEYS.has(command.command_type) && html`<div class="order-view-alert-facility">Alert Facility: ${command.data.alert_facility !== false ? 'Yes' : 'No'}</div>`}
       </div>
     </div>
   `;

--- a/hyperscribe/scribe/static/order-row.js
+++ b/hyperscribe/scribe/static/order-row.js
@@ -345,6 +345,9 @@ export function OrderRow({ command, commandIndex, onEdit, onDelete, readOnly, al
   const [alertFacility, setAlertFacility] = useState(
     alertFacilityOn(command.command_type || 'prescribe', command.data.alert_facility),
   );
+  // Only persist the flag when the user actually engaged it (or it's a brand-new
+  // card, or a value already exists) — never fabricate one on an unrelated edit.
+  const [alertFacilityTouched, setAlertFacilityTouched] = useState(false);
 
   // "Change to" medication (adjust_prescription only).
   const [changeToQuery, setChangeToQuery] = useState(command.data.new_medication_text || '');
@@ -1171,8 +1174,15 @@ export function OrderRow({ command, commandIndex, onEdit, onDelete, readOnly, al
         pharmacy: selectedPharmacy || null,
         pharmacy_name: selectedPharmacy ? pharmacyQuery : null,
         quantities: medQuantities.map(q => ({ representative_ndc: q.representative_ndc, ncpdp_quantity_qualifier_code: q.ncpdp_quantity_qualifier_code, clinical_quantity_description: q.label, quantity: 1 })),
-        alert_facility: alertFacility,
       };
+      // Alert Facility: materialize for a brand-new card or when the user set it;
+      // otherwise preserve any existing value (and leave a value-less card blank).
+      // handleSave rebuilds `data` from scratch, so existing values must be carried over.
+      if (isNew || alertFacilityTouched) {
+        data.alert_facility = alertFacility;
+      } else if (command.data.alert_facility !== undefined) {
+        data.alert_facility = command.data.alert_facility;
+      }
       // Include "change to" medication for adjust_prescription.
       if (activeTab === 'adjust_prescription' && changeToFdb) {
         data.new_fdb_code = changeToFdb;
@@ -1842,7 +1852,7 @@ export function OrderRow({ command, commandIndex, onEdit, onDelete, readOnly, al
             `}
             ${alertFacilityEnabled && RX_TAB_KEYS.has(activeTab) && html`
               <div class="history-form-field">
-                <button type="button" class="alert-facility-toggle" onClick=${() => setAlertFacility(prev => !prev)}>
+                <button type="button" class="alert-facility-toggle" onClick=${() => { setAlertFacility(prev => !prev); setAlertFacilityTouched(true); }}>
                   <div class="toggle-switch${alertFacility ? ' on' : ''}">
                     <div class="toggle-knob" />
                   </div>
@@ -1922,7 +1932,7 @@ export function OrderRow({ command, commandIndex, onEdit, onDelete, readOnly, al
             <div class="order-view-name">${command.display}</div>
             ${d.sig && html`<div class="order-view-sig">Sig: ${d.sig}</div>`}
             ${detailParts.length > 0 && html`<div class="order-view-details">${detailParts.join(' · ')}</div>`}
-            ${alertFacilityEnabled && html`<div class="order-view-alert-facility">Alert Facility: ${alertFacilityOn(command.command_type, d.alert_facility) ? 'Yes' : 'No'}</div>`}
+            ${alertFacilityEnabled && (d.alert_facility === true || d.alert_facility === false) && html`<div class="order-view-alert-facility">Alert Facility: ${d.alert_facility ? 'Yes' : 'No'}</div>`}
           </div>
         </div>
         ${interactionWarning && html`<${InteractionWarningInline} warning=${interactionWarning} />`}
@@ -1976,7 +1986,7 @@ export function OrderRow({ command, commandIndex, onEdit, onDelete, readOnly, al
       <div class="order-view">
         <span class="command-type-label">${badgeLabel}</span>
         <div class="order-view-name">${command.display}</div>
-        ${alertFacilityEnabled && RX_TAB_KEYS.has(command.command_type) && html`<div class="order-view-alert-facility">Alert Facility: ${alertFacilityOn(command.command_type, command.data.alert_facility) ? 'Yes' : 'No'}</div>`}
+        ${alertFacilityEnabled && RX_TAB_KEYS.has(command.command_type) && (command.data.alert_facility === true || command.data.alert_facility === false) && html`<div class="order-view-alert-facility">Alert Facility: ${command.data.alert_facility ? 'Yes' : 'No'}</div>`}
       </div>
     </div>
   `;

--- a/hyperscribe/scribe/static/order-row.js
+++ b/hyperscribe/scribe/static/order-row.js
@@ -22,6 +22,10 @@ const REFILLS_MIN = 0;
 const REFILLS_MAX = 99;
 const RX_TAB_KEYS = new Set(['prescribe', 'refill', 'adjust_prescription']);
 
+// Per-command-type default position for the Alert Facility toggle (edit-mode
+// starting position only). Prescribe and adjust prescription default on; refill off.
+const ALERT_FACILITY_DEFAULT_ON = { prescribe: true, adjust_prescription: true, refill: false };
+
 // Full NCPDP clinical quantity descriptions
 const CLINICAL_QUANTITY_DESCRIPTIONS = [
   { code: 'C48473', label: 'Ampule' },
@@ -300,10 +304,11 @@ export function OrderRow({ command, commandIndex, onEdit, onDelete, readOnly, al
   // Per-tab Rx state snapshots (saved when switching away, restored when switching back).
   const rxSnapshots = useRef({});
 
-  const initRxState = () => ({
+  const initRxState = (tabKey) => ({
     medQuery: '', selectedFdb: null, selectedMedDisplay: '', medQuantities: buildTypeToDispenseOptions([]),
     sig: '', daysSupply: '', quantity: '', typeToDispense: '', refills: '',
     substitutions: true, noteToPharmacist: '', interactionWarning: null, selectedPharmacy: '', pharmacyQuery: '',
+    alertFacility: !!ALERT_FACILITY_DEFAULT_ON[tabKey],
   });
 
   // Rx state
@@ -329,10 +334,16 @@ export function OrderRow({ command, commandIndex, onEdit, onDelete, readOnly, al
   const [interactionWarning, setInteractionWarning] = useState(null);
   const [checkingInteractions, setCheckingInteractions] = useState(false);
 
-  // Alert Facility flag is per-command (not per-tab), so it lives outside the
-  // Rx snapshot machinery and persists across prescribe/refill/adjust tab switches.
-  // Defaults to Yes (on); only an explicit stored `false` keeps it off.
-  const [alertFacility, setAlertFacility] = useState(command.data.alert_facility !== false);
+  // Alert Facility toggle default is per command type (edit-mode starting position);
+  // an explicit stored value always wins. Mirrored into the per-tab Rx snapshots below
+  // so switching tabs follows the target tab's default until the user changes it.
+  const [alertFacility, setAlertFacility] = useState(
+    command.data.alert_facility === true
+      ? true
+      : command.data.alert_facility === false
+        ? false
+        : !!ALERT_FACILITY_DEFAULT_ON[command.command_type || 'prescribe'],
+  );
 
   // "Change to" medication (adjust_prescription only).
   const [changeToQuery, setChangeToQuery] = useState(command.data.new_medication_text || '');
@@ -373,6 +384,7 @@ export function OrderRow({ command, commandIndex, onEdit, onDelete, readOnly, al
     medQuery, selectedFdb, selectedMedDisplay, medQuantities,
     sig, daysSupply, quantity, typeToDispense, refills,
     substitutions, noteToPharmacist, interactionWarning, selectedPharmacy, pharmacyQuery,
+    alertFacility,
   });
 
   const restoreRxSnapshot = (snap) => {
@@ -390,6 +402,7 @@ export function OrderRow({ command, commandIndex, onEdit, onDelete, readOnly, al
     setSelectedPharmacy(snap.selectedPharmacy);
     setPharmacyQuery(snap.pharmacyQuery);
     setInteractionWarning(snap.interactionWarning);
+    setAlertFacility(snap.alertFacility);
     setMedResults([]);
     setMedSearched(false);
   };
@@ -1241,7 +1254,7 @@ export function OrderRow({ command, commandIndex, onEdit, onDelete, readOnly, al
                     if (RX_TABS.has(tab.key) && rxSnapshots.current[tab.key]) {
                       restoreRxSnapshot(rxSnapshots.current[tab.key]);
                     } else if (RX_TABS.has(tab.key)) {
-                      restoreRxSnapshot(initRxState());
+                      restoreRxSnapshot(initRxState(tab.key));
                     }
                     setActiveTab(tab.key);
                   }}

--- a/hyperscribe/scribe/static/order-row.js
+++ b/hyperscribe/scribe/static/order-row.js
@@ -22,9 +22,14 @@ const REFILLS_MIN = 0;
 const REFILLS_MAX = 99;
 const RX_TAB_KEYS = new Set(['prescribe', 'refill', 'adjust_prescription']);
 
-// Per-command-type default position for the Alert Facility toggle (edit-mode
-// starting position only). Prescribe and adjust prescription default on; refill off.
+// Per-command-type default for Alert Facility. Prescribe and adjust prescription
+// default on; refill off. Applied everywhere (toggle, recorded value, display) so
+// a card gets its default without having to be opened.
 const ALERT_FACILITY_DEFAULT_ON = { prescribe: true, adjust_prescription: true, refill: false };
+
+// Effective on/off state: an explicit stored value wins, otherwise the type default.
+const alertFacilityOn = (commandType, raw) =>
+  raw === true ? true : raw === false ? false : !!ALERT_FACILITY_DEFAULT_ON[commandType];
 
 // Full NCPDP clinical quantity descriptions
 const CLINICAL_QUANTITY_DESCRIPTIONS = [
@@ -338,11 +343,7 @@ export function OrderRow({ command, commandIndex, onEdit, onDelete, readOnly, al
   // an explicit stored value always wins. Mirrored into the per-tab Rx snapshots below
   // so switching tabs follows the target tab's default until the user changes it.
   const [alertFacility, setAlertFacility] = useState(
-    command.data.alert_facility === true
-      ? true
-      : command.data.alert_facility === false
-        ? false
-        : !!ALERT_FACILITY_DEFAULT_ON[command.command_type || 'prescribe'],
+    alertFacilityOn(command.command_type || 'prescribe', command.data.alert_facility),
   );
 
   // "Change to" medication (adjust_prescription only).
@@ -1921,7 +1922,7 @@ export function OrderRow({ command, commandIndex, onEdit, onDelete, readOnly, al
             <div class="order-view-name">${command.display}</div>
             ${d.sig && html`<div class="order-view-sig">Sig: ${d.sig}</div>`}
             ${detailParts.length > 0 && html`<div class="order-view-details">${detailParts.join(' · ')}</div>`}
-            ${alertFacilityEnabled && html`<div class="order-view-alert-facility">Alert Facility: ${d.alert_facility !== false ? 'Yes' : 'No'}</div>`}
+            ${alertFacilityEnabled && html`<div class="order-view-alert-facility">Alert Facility: ${alertFacilityOn(command.command_type, d.alert_facility) ? 'Yes' : 'No'}</div>`}
           </div>
         </div>
         ${interactionWarning && html`<${InteractionWarningInline} warning=${interactionWarning} />`}
@@ -1975,7 +1976,7 @@ export function OrderRow({ command, commandIndex, onEdit, onDelete, readOnly, al
       <div class="order-view">
         <span class="command-type-label">${badgeLabel}</span>
         <div class="order-view-name">${command.display}</div>
-        ${alertFacilityEnabled && RX_TAB_KEYS.has(command.command_type) && html`<div class="order-view-alert-facility">Alert Facility: ${command.data.alert_facility !== false ? 'Yes' : 'No'}</div>`}
+        ${alertFacilityEnabled && RX_TAB_KEYS.has(command.command_type) && html`<div class="order-view-alert-facility">Alert Facility: ${alertFacilityOn(command.command_type, command.data.alert_facility) ? 'Yes' : 'No'}</div>`}
       </div>
     </div>
   `;

--- a/hyperscribe/scribe/static/order-row.js
+++ b/hyperscribe/scribe/static/order-row.js
@@ -297,7 +297,7 @@ function InteractionWarningInline({ warning }) {
   `;
 }
 
-export function OrderRow({ command, commandIndex, onEdit, onDelete, readOnly, alertFacilityEnabled, patientId, noteId, staffId, staffName, noteDiagnoses = [], isRecommendation, onEditingChange }) {
+export function OrderRow({ command, commandIndex, onEdit, onDelete, readOnly, alertFacilityCommands, patientId, noteId, staffId, staffName, noteDiagnoses = [], isRecommendation, onEditingChange }) {
   const isNew = !command.display;
   const [editing, setEditing] = useState(isNew);
   useEffect(() => {
@@ -1175,10 +1175,11 @@ export function OrderRow({ command, commandIndex, onEdit, onDelete, readOnly, al
         pharmacy_name: selectedPharmacy ? pharmacyQuery : null,
         quantities: medQuantities.map(q => ({ representative_ndc: q.representative_ndc, ncpdp_quantity_qualifier_code: q.ncpdp_quantity_qualifier_code, clinical_quantity_description: q.label, quantity: 1 })),
       };
-      // Alert Facility: materialize for a brand-new card or when the user set it;
-      // otherwise preserve any existing value (and leave a value-less card blank).
-      // handleSave rebuilds `data` from scratch, so existing values must be carried over.
-      if (isNew || alertFacilityTouched) {
+      // Alert Facility: materialize only when this command type is enabled AND it's a
+      // brand-new card or the user set it; otherwise preserve any existing value (and leave
+      // a value-less card blank). handleSave rebuilds `data` from scratch, so an existing
+      // value must be carried over — preserved regardless of the enable gate.
+      if (alertFacilityCommands.has(activeTab) && (isNew || alertFacilityTouched)) {
         data.alert_facility = alertFacility;
       } else if (command.data.alert_facility !== undefined) {
         data.alert_facility = command.data.alert_facility;
@@ -1850,7 +1851,7 @@ export function OrderRow({ command, commandIndex, onEdit, onDelete, readOnly, al
                 `}
               </div>
             `}
-            ${alertFacilityEnabled && RX_TAB_KEYS.has(activeTab) && html`
+            ${alertFacilityCommands.has(activeTab) && html`
               <div class="history-form-field">
                 <button type="button" class="alert-facility-toggle" onClick=${() => { setAlertFacility(prev => !prev); setAlertFacilityTouched(true); }}>
                   <div class="toggle-switch${alertFacility ? ' on' : ''}">
@@ -1932,7 +1933,7 @@ export function OrderRow({ command, commandIndex, onEdit, onDelete, readOnly, al
             <div class="order-view-name">${command.display}</div>
             ${d.sig && html`<div class="order-view-sig">Sig: ${d.sig}</div>`}
             ${detailParts.length > 0 && html`<div class="order-view-details">${detailParts.join(' · ')}</div>`}
-            ${alertFacilityEnabled && (d.alert_facility === true || d.alert_facility === false) && html`<div class="order-view-alert-facility">Alert Facility: ${d.alert_facility ? 'Yes' : 'No'}</div>`}
+            ${alertFacilityCommands.has(command.command_type) && (d.alert_facility === true || d.alert_facility === false) && html`<div class="order-view-alert-facility">Alert Facility: ${d.alert_facility ? 'Yes' : 'No'}</div>`}
           </div>
         </div>
         ${interactionWarning && html`<${InteractionWarningInline} warning=${interactionWarning} />`}
@@ -1986,7 +1987,7 @@ export function OrderRow({ command, commandIndex, onEdit, onDelete, readOnly, al
       <div class="order-view">
         <span class="command-type-label">${badgeLabel}</span>
         <div class="order-view-name">${command.display}</div>
-        ${alertFacilityEnabled && RX_TAB_KEYS.has(command.command_type) && (command.data.alert_facility === true || command.data.alert_facility === false) && html`<div class="order-view-alert-facility">Alert Facility: ${command.data.alert_facility ? 'Yes' : 'No'}</div>`}
+        ${alertFacilityCommands.has(command.command_type) && (command.data.alert_facility === true || command.data.alert_facility === false) && html`<div class="order-view-alert-facility">Alert Facility: ${command.data.alert_facility ? 'Yes' : 'No'}</div>`}
       </div>
     </div>
   `;

--- a/hyperscribe/scribe/static/soap-group.js
+++ b/hyperscribe/scribe/static/soap-group.js
@@ -118,7 +118,7 @@ const CHARGE_SEARCH_BASE = '/plugin-io/api/hyperscribe/scribe-session';
 
 const REMOVAL_TYPES = new Set(['stop_medication', 'remove_allergy', 'resolve_condition']);
 
-function RemovalRow({ command, commandIndex, onEdit, onDelete, readOnly, patientId, alertFacilityEnabled }) {
+function RemovalRow({ command, commandIndex, onEdit, onDelete, readOnly, patientId, alertFacilityCommands }) {
   const data = command.data || {};
   const type = command.command_type;
   const hasItem = !!(data.medication_id || data.allergy_id || data.condition_id);
@@ -189,10 +189,10 @@ function RemovalRow({ command, commandIndex, onEdit, onDelete, readOnly, patient
       <span class="removal-action-label">${config.actionLabel}</span>
       <span class="removal-item-name">${itemName}</span>
     </div>
-    ${type === 'stop_medication' && readOnly && (data.rationale || (alertFacilityEnabled && (data.alert_facility === true || data.alert_facility === false))) && html`
+    ${type === 'stop_medication' && readOnly && (data.rationale || (alertFacilityCommands.has(command.command_type) && (data.alert_facility === true || data.alert_facility === false))) && html`
       <div style="margin-top: 2px;">
         ${data.rationale && html`<div style="font-size: 13px; color: #6b7280;">${data.rationale}</div>`}
-        ${alertFacilityEnabled && (data.alert_facility === true || data.alert_facility === false) && html`<div class="order-view-alert-facility">Alert Facility: ${data.alert_facility ? 'Yes' : 'No'}</div>`}
+        ${alertFacilityCommands.has(command.command_type) && (data.alert_facility === true || data.alert_facility === false) && html`<div class="order-view-alert-facility">Alert Facility: ${data.alert_facility ? 'Yes' : 'No'}</div>`}
       </div>
     `}
     ${type === 'stop_medication' && hasItem && !readOnly && html`
@@ -206,7 +206,7 @@ function RemovalRow({ command, commandIndex, onEdit, onDelete, readOnly, patient
           placeholder="Reason for stopping..."
         />
       </div>
-      ${alertFacilityEnabled && html`
+      ${alertFacilityCommands.has(command.command_type) && html`
       <div class="history-form-field" style="margin-top: 8px;">
         <button type="button" class="alert-facility-toggle" onClick=${() => onEdit(commandIndex, { ...data, alert_facility: !data.alert_facility })}>
           <div class="toggle-switch${data.alert_facility === true ? ' on' : ''}">
@@ -715,7 +715,7 @@ function AddConditionSearch({ onAdd, patientId }) {
   `;
 }
 
-export function SoapGroup({ title, groupColor, sections, commandBySectionKey, onEditCommand, onDeleteCommand, adHocCommands, assignees, onAddTask, onAddOrder, onAddPlan, onMoveToPlan, onAddAppointment, onAddVitals, onAddPhysicalExam, onAddMentalStatusExam, onAddMedication, onAddAllergy, onAddStopMedication, onAddRemoveAllergy, onAddResolveCondition, onAddHistory, onAddQuestionnaire, onAddCharge, readOnly, canEdit = true, isAmending = false, sectionConditions, patientId, noteId, staffId, staffName, recommendations, onEditRecommendation, onDeleteRecommendation, onAcceptRecommendation, onRejectRecommendation, onAddCondition, unmatchedConditions, diagnosisSuggestions, noteDiagnoses = [], onAddNow, hideRejected, alertFacilityEnabled, onEditingChange, questionnaireScores, chargeMatrixDiagnoses = [], chargeMatrixCharges = [], searchCharges = () => {}, suggestedCharges = [], onToggleChargePointer = () => {}, onReorderDiagnoses = () => {}, onAddChargeModifier = () => {}, onRemoveChargeModifier = () => {}, onSetChargeComment = () => {}, onClearChargeComment = () => {}, onRemoveChargeByUuid = () => {}, examTemplates, onCarryForwardExam, isPsychiatry = false, dictation }) {
+export function SoapGroup({ title, groupColor, sections, commandBySectionKey, onEditCommand, onDeleteCommand, adHocCommands, assignees, onAddTask, onAddOrder, onAddPlan, onMoveToPlan, onAddAppointment, onAddVitals, onAddPhysicalExam, onAddMentalStatusExam, onAddMedication, onAddAllergy, onAddStopMedication, onAddRemoveAllergy, onAddResolveCondition, onAddHistory, onAddQuestionnaire, onAddCharge, readOnly, canEdit = true, isAmending = false, sectionConditions, patientId, noteId, staffId, staffName, recommendations, onEditRecommendation, onDeleteRecommendation, onAcceptRecommendation, onRejectRecommendation, onAddCondition, unmatchedConditions, diagnosisSuggestions, noteDiagnoses = [], onAddNow, hideRejected, alertFacilityCommands, onEditingChange, questionnaireScores, chargeMatrixDiagnoses = [], chargeMatrixCharges = [], searchCharges = () => {}, suggestedCharges = [], onToggleChargePointer = () => {}, onReorderDiagnoses = () => {}, onAddChargeModifier = () => {}, onRemoveChargeModifier = () => {}, onSetChargeComment = () => {}, onClearChargeComment = () => {}, onRemoveChargeByUuid = () => {}, examTemplates, onCarryForwardExam, isPsychiatry = false, dictation }) {
   const isCharges = title === 'CHARGES';
   const coveredKeys = getCoveredKeys(commandBySectionKey);
 
@@ -995,7 +995,7 @@ export function SoapGroup({ title, groupColor, sections, commandBySectionKey, on
                           onDelete=${onDeleteCommand}
                           readOnly=${reRowReadOnly}
                           patientId=${patientId}
-                          alertFacilityEnabled=${alertFacilityEnabled}
+                          alertFacilityCommands=${alertFacilityCommands}
                         />
                       </div>
                       ${!readOnly && !re.command.already_documented && !re.command._adding && html`<div class="recommendation-actions"><button type="button" class="rec-remove-x" onClick=${() => onDeleteCommand(re.index)} title="Remove">${ICON_X}</button></div>`}
@@ -1224,7 +1224,7 @@ export function SoapGroup({ title, groupColor, sections, commandBySectionKey, on
                           commandIndex=${entry.index}
                           onEdit=${onEditCommand}
                           onDelete=${onDeleteCommand}
-                          alertFacilityEnabled=${alertFacilityEnabled}
+                          alertFacilityCommands=${alertFacilityCommands}
                           readOnly=${medRowReadOnly}
                           onEditingChange=${onEditingChange}
                         />
@@ -1251,7 +1251,7 @@ export function SoapGroup({ title, groupColor, sections, commandBySectionKey, on
                           commandIndex=${entry.index}
                           onEdit=${onEditCommand}
                           onDelete=${onDeleteCommand}
-                          alertFacilityEnabled=${alertFacilityEnabled}
+                          alertFacilityCommands=${alertFacilityCommands}
                           readOnly=${adHocMedRowReadOnly}
                           onEditingChange=${onEditingChange}
                         />
@@ -1280,7 +1280,7 @@ export function SoapGroup({ title, groupColor, sections, commandBySectionKey, on
                           command=${entry.command}
                           commandIndex=${entry.index}
                           onEdit=${onEditRecommendation}
-                          alertFacilityEnabled=${alertFacilityEnabled}
+                          alertFacilityCommands=${alertFacilityCommands}
                           readOnly=${medRecRowReadOnly || isRejected}
                           onEditingChange=${onEditingChange}                        />
                       </div>
@@ -1303,7 +1303,7 @@ export function SoapGroup({ title, groupColor, sections, commandBySectionKey, on
                           onDelete=${onDeleteCommand}
                           readOnly=${stopMedRowReadOnly}
                           patientId=${patientId}
-                          alertFacilityEnabled=${alertFacilityEnabled}
+                          alertFacilityCommands=${alertFacilityCommands}
                         />
                       </div>
                       ${!readOnly && html`<div class="recommendation-actions">
@@ -1406,7 +1406,7 @@ export function SoapGroup({ title, groupColor, sections, commandBySectionKey, on
                           onDelete=${onDeleteCommand}
                           readOnly=${removeAllergyRowReadOnly}
                           patientId=${patientId}
-                          alertFacilityEnabled=${alertFacilityEnabled}
+                          alertFacilityCommands=${alertFacilityCommands}
                         />
                       </div>
                       ${!readOnly && !entry.command.already_documented && !entry.command._adding && html`<div class="recommendation-actions"><button type="button" class="rec-remove-x" onClick=${() => onDeleteCommand(entry.index)} title="Remove">${ICON_X}</button></div>`}
@@ -1490,7 +1490,7 @@ export function SoapGroup({ title, groupColor, sections, commandBySectionKey, on
                           onDelete=${onDeleteCommand}
                           readOnly=${resolveRowReadOnly}
                           patientId=${patientId}
-                          alertFacilityEnabled=${alertFacilityEnabled}
+                          alertFacilityCommands=${alertFacilityCommands}
                         />
                       </div>
                       ${!readOnly && !entry.command.already_documented && !entry.command._adding && html`<div class="recommendation-actions"><button type="button" class="rec-remove-x" onClick=${() => onDeleteCommand(entry.index)} title="Remove">${ICON_X}</button></div>`}
@@ -1602,7 +1602,7 @@ export function SoapGroup({ title, groupColor, sections, commandBySectionKey, on
                     onEdit=${onEditCommand}
                     onDelete=${onDeleteCommand}
                     readOnly=${orderRowReadOnly}
-                    alertFacilityEnabled=${alertFacilityEnabled}
+                    alertFacilityCommands=${alertFacilityCommands}
                     patientId=${patientId}
                     noteId=${noteId}
                     staffId=${staffId}
@@ -1763,7 +1763,7 @@ export function SoapGroup({ title, groupColor, sections, commandBySectionKey, on
                       commandIndex=${entry.index}
                       onEdit=${onEditRecommendation}
                       readOnly=${rxRecRowReadOnly || isRejected}
-                      alertFacilityEnabled=${alertFacilityEnabled}
+                      alertFacilityCommands=${alertFacilityCommands}
                       patientId=${patientId}
                       noteId=${noteId}
                       staffId=${staffId}
@@ -1811,7 +1811,7 @@ export function SoapGroup({ title, groupColor, sections, commandBySectionKey, on
                       commandIndex=${entry.index}
                       onEdit=${onEditRecommendation}
                       readOnly=${referRecRowReadOnly || isRejected}
-                      alertFacilityEnabled=${alertFacilityEnabled}
+                      alertFacilityCommands=${alertFacilityCommands}
                       patientId=${patientId}
                       noteId=${noteId}
                       staffId=${staffId}

--- a/hyperscribe/scribe/static/soap-group.js
+++ b/hyperscribe/scribe/static/soap-group.js
@@ -150,13 +150,14 @@ function RemovalRow({ command, commandIndex, onEdit, onDelete, readOnly, patient
     return () => { cancelled = true; };
   }, [hasItem, patientId, type]);
 
-  // Alert Facility defaults to Yes. This row is controlled (no Save button), so
-  // seed the value once when it's unset — otherwise an untouched default would
-  // display "on" but silently record "No" at commit. An explicit `false` is left alone.
+  // Stop medication defaults to No. This row is controlled (no Save button), so
+  // seed the value once when it's unset — otherwise the toggle would show "off"
+  // while the command silently records the backend default at commit. Seeding
+  // keeps the toggle and the stored value in agreement. An explicit value is left alone.
   useEffect(() => {
     if (type !== 'stop_medication' || readOnly || !alertFacilityEnabled) return;
     if (data.alert_facility === undefined) {
-      onEdit(commandIndex, { ...data, alert_facility: true });
+      onEdit(commandIndex, { ...data, alert_facility: false });
     }
   }, [type, readOnly, alertFacilityEnabled, commandIndex]);
 
@@ -218,8 +219,8 @@ function RemovalRow({ command, commandIndex, onEdit, onDelete, readOnly, patient
       </div>
       ${alertFacilityEnabled && html`
       <div class="history-form-field" style="margin-top: 8px;">
-        <button type="button" class="alert-facility-toggle" onClick=${() => onEdit(commandIndex, { ...data, alert_facility: data.alert_facility === false })}>
-          <div class="toggle-switch${data.alert_facility !== false ? ' on' : ''}">
+        <button type="button" class="alert-facility-toggle" onClick=${() => onEdit(commandIndex, { ...data, alert_facility: !data.alert_facility })}>
+          <div class="toggle-switch${data.alert_facility === true ? ' on' : ''}">
             <div class="toggle-knob" />
           </div>
           Alert Facility

--- a/hyperscribe/scribe/static/soap-group.js
+++ b/hyperscribe/scribe/static/soap-group.js
@@ -150,17 +150,6 @@ function RemovalRow({ command, commandIndex, onEdit, onDelete, readOnly, patient
     return () => { cancelled = true; };
   }, [hasItem, patientId, type]);
 
-  // Stop medication defaults to No. This row is controlled (no Save button), so
-  // seed the value once when it's unset — otherwise the toggle would show "off"
-  // while the command silently records the backend default at commit. Seeding
-  // keeps the toggle and the stored value in agreement. An explicit value is left alone.
-  useEffect(() => {
-    if (type !== 'stop_medication' || readOnly || !alertFacilityEnabled) return;
-    if (data.alert_facility === undefined) {
-      onEdit(commandIndex, { ...data, alert_facility: false });
-    }
-  }, [type, readOnly, alertFacilityEnabled, commandIndex]);
-
   const handleSelectChange = (e) => {
     const selectedId = e.target.value;
     if (!selectedId) return;
@@ -200,10 +189,10 @@ function RemovalRow({ command, commandIndex, onEdit, onDelete, readOnly, patient
       <span class="removal-action-label">${config.actionLabel}</span>
       <span class="removal-item-name">${itemName}</span>
     </div>
-    ${type === 'stop_medication' && readOnly && (data.rationale || alertFacilityEnabled) && html`
+    ${type === 'stop_medication' && readOnly && (data.rationale || (alertFacilityEnabled && (data.alert_facility === true || data.alert_facility === false))) && html`
       <div style="margin-top: 2px;">
         ${data.rationale && html`<div style="font-size: 13px; color: #6b7280;">${data.rationale}</div>`}
-        ${alertFacilityEnabled && html`<div class="order-view-alert-facility">Alert Facility: ${data.alert_facility === true ? 'Yes' : 'No'}</div>`}
+        ${alertFacilityEnabled && (data.alert_facility === true || data.alert_facility === false) && html`<div class="order-view-alert-facility">Alert Facility: ${data.alert_facility ? 'Yes' : 'No'}</div>`}
       </div>
     `}
     ${type === 'stop_medication' && hasItem && !readOnly && html`

--- a/hyperscribe/scribe/static/soap-group.js
+++ b/hyperscribe/scribe/static/soap-group.js
@@ -150,6 +150,16 @@ function RemovalRow({ command, commandIndex, onEdit, onDelete, readOnly, patient
     return () => { cancelled = true; };
   }, [hasItem, patientId, type]);
 
+  // Alert Facility defaults to Yes. This row is controlled (no Save button), so
+  // seed the value once when it's unset — otherwise an untouched default would
+  // display "on" but silently record "No" at commit. An explicit `false` is left alone.
+  useEffect(() => {
+    if (type !== 'stop_medication' || readOnly || !alertFacilityEnabled) return;
+    if (data.alert_facility === undefined) {
+      onEdit(commandIndex, { ...data, alert_facility: true });
+    }
+  }, [type, readOnly, alertFacilityEnabled, commandIndex]);
+
   const handleSelectChange = (e) => {
     const selectedId = e.target.value;
     if (!selectedId) return;
@@ -188,13 +198,13 @@ function RemovalRow({ command, commandIndex, onEdit, onDelete, readOnly, patient
     <div class="removal-row${readOnly ? ' read-only' : ''}">
       <span class="removal-action-label">${config.actionLabel}</span>
       <span class="removal-item-name">${itemName}</span>
-      ${type === 'stop_medication' && readOnly && (data.rationale || data.alert_facility) && html`
-        <div style="font-size: 13px; color: #6b7280; margin-top: 2px;">
-          ${data.rationale || ''}
-          ${alertFacilityEnabled && data.alert_facility && html`<span class="badge badge-alert" style="margin-left: 6px;">Alert Facility</span>`}
-        </div>
-      `}
     </div>
+    ${type === 'stop_medication' && readOnly && (data.rationale || alertFacilityEnabled) && html`
+      <div style="margin-top: 2px;">
+        ${data.rationale && html`<div style="font-size: 13px; color: #6b7280;">${data.rationale}</div>`}
+        ${alertFacilityEnabled && html`<div class="order-view-alert-facility">Alert Facility: ${data.alert_facility !== false ? 'Yes' : 'No'}</div>`}
+      </div>
+    `}
     ${type === 'stop_medication' && hasItem && !readOnly && html`
       <div class="history-form-field" style="margin-top: 8px;">
         <label class="history-form-label">Rationale</label>
@@ -208,8 +218,8 @@ function RemovalRow({ command, commandIndex, onEdit, onDelete, readOnly, patient
       </div>
       ${alertFacilityEnabled && html`
       <div class="history-form-field" style="margin-top: 8px;">
-        <button type="button" class="alert-facility-toggle" onClick=${() => onEdit(commandIndex, { ...data, alert_facility: !data.alert_facility })}>
-          <div class="toggle-switch${data.alert_facility ? ' on' : ''}">
+        <button type="button" class="alert-facility-toggle" onClick=${() => onEdit(commandIndex, { ...data, alert_facility: data.alert_facility === false })}>
+          <div class="toggle-switch${data.alert_facility !== false ? ' on' : ''}">
             <div class="toggle-knob" />
           </div>
           Alert Facility
@@ -1602,6 +1612,7 @@ export function SoapGroup({ title, groupColor, sections, commandBySectionKey, on
                     onEdit=${onEditCommand}
                     onDelete=${onDeleteCommand}
                     readOnly=${orderRowReadOnly}
+                    alertFacilityEnabled=${alertFacilityEnabled}
                     patientId=${patientId}
                     noteId=${noteId}
                     staffId=${staffId}
@@ -1762,6 +1773,7 @@ export function SoapGroup({ title, groupColor, sections, commandBySectionKey, on
                       commandIndex=${entry.index}
                       onEdit=${onEditRecommendation}
                       readOnly=${rxRecRowReadOnly || isRejected}
+                      alertFacilityEnabled=${alertFacilityEnabled}
                       patientId=${patientId}
                       noteId=${noteId}
                       staffId=${staffId}
@@ -1809,6 +1821,7 @@ export function SoapGroup({ title, groupColor, sections, commandBySectionKey, on
                       commandIndex=${entry.index}
                       onEdit=${onEditRecommendation}
                       readOnly=${referRecRowReadOnly || isRejected}
+                      alertFacilityEnabled=${alertFacilityEnabled}
                       patientId=${patientId}
                       noteId=${noteId}
                       staffId=${staffId}

--- a/hyperscribe/scribe/static/soap-group.js
+++ b/hyperscribe/scribe/static/soap-group.js
@@ -203,7 +203,7 @@ function RemovalRow({ command, commandIndex, onEdit, onDelete, readOnly, patient
     ${type === 'stop_medication' && readOnly && (data.rationale || alertFacilityEnabled) && html`
       <div style="margin-top: 2px;">
         ${data.rationale && html`<div style="font-size: 13px; color: #6b7280;">${data.rationale}</div>`}
-        ${alertFacilityEnabled && html`<div class="order-view-alert-facility">Alert Facility: ${data.alert_facility !== false ? 'Yes' : 'No'}</div>`}
+        ${alertFacilityEnabled && html`<div class="order-view-alert-facility">Alert Facility: ${data.alert_facility === true ? 'Yes' : 'No'}</div>`}
       </div>
     `}
     ${type === 'stop_medication' && hasItem && !readOnly && html`

--- a/hyperscribe/scribe/static/styles.css
+++ b/hyperscribe/scribe/static/styles.css
@@ -510,6 +510,10 @@ h2 { margin-bottom: 4px; }
 .toggle-knob { width: 16px; height: 16px; border-radius: 50%; background: #fff; position: absolute; top: 2px; left: 2px; transition: left 0.2s; box-shadow: 0 1px 2px rgba(0,0,0,0.15); }
 .toggle-switch.on .toggle-knob { left: 18px; }
 .alert-facility-toggle { display: flex; align-items: center; gap: 8px; font-size: 13px; font-weight: 600; color: #6b7280; cursor: pointer; user-select: none; background: none; border: none; padding: 0; margin: 0; font-family: inherit; text-align: left; }
+/* Alert Facility — plain view-mode line showing the flag value; matches the
+   order details line (medication statement, stop medication, prescribe,
+   adjust prescription, refill) */
+.order-view-alert-facility { font-size: 12px; color: #888; }
 
 .summary-section {
   margin-bottom: 24px;

--- a/hyperscribe/scribe/static/summary.js
+++ b/hyperscribe/scribe/static/summary.js
@@ -473,7 +473,7 @@ function buildCommandBySectionKey(commands) {
   return map;
 }
 
-function renderSoapGroups(sections, commandBySectionKey, onEditCommand, onDeleteCommand, { adHocCommands, objectiveAdHocCommands, historyAdHocCommands, subjectiveAdHocCommands, chargeAdHocCommands, assignees, onAddTask, onAddOrder, onAddPlan, onMoveToPlan, onAddAppointment, onAddMedication, onAddAllergy, onAddStopMedication, onAddRemoveAllergy, onAddResolveCondition, onAddHistory, onAddQuestionnaire, onAddCharge, onAddTemplateCharge, onRemoveChargeByCpt, templateCharges, readOnly, canEdit = true, isAmending, sectionConditions, patientId, noteId, staffId, staffName, recommendations, onEditRecommendation, onDeleteRecommendation, onAcceptRecommendation, onRejectRecommendation, onAddCondition, unmatchedConditions, diagnosisSuggestions, onAddNow, onAddVitals, onAddPhysicalExam, onAddMentalStatusExam, hideRejected, alertFacilityEnabled, onEditingChange, questionnaireScores, chargeMatrixDiagnoses, chargeMatrixCharges, searchCharges, suggestedCharges, onToggleChargePointer, onReorderDiagnoses, onAddChargeModifier, onRemoveChargeModifier, onSetChargeComment, onClearChargeComment, onRemoveChargeByUuid, examTemplates, onCarryForwardExam, noteDiagnoses, isPsychiatry, dictation } = {}) {
+function renderSoapGroups(sections, commandBySectionKey, onEditCommand, onDeleteCommand, { adHocCommands, objectiveAdHocCommands, historyAdHocCommands, subjectiveAdHocCommands, chargeAdHocCommands, assignees, onAddTask, onAddOrder, onAddPlan, onMoveToPlan, onAddAppointment, onAddMedication, onAddAllergy, onAddStopMedication, onAddRemoveAllergy, onAddResolveCondition, onAddHistory, onAddQuestionnaire, onAddCharge, onAddTemplateCharge, onRemoveChargeByCpt, templateCharges, readOnly, canEdit = true, isAmending, sectionConditions, patientId, noteId, staffId, staffName, recommendations, onEditRecommendation, onDeleteRecommendation, onAcceptRecommendation, onRejectRecommendation, onAddCondition, unmatchedConditions, diagnosisSuggestions, onAddNow, onAddVitals, onAddPhysicalExam, onAddMentalStatusExam, hideRejected, alertFacilityCommands, onEditingChange, questionnaireScores, chargeMatrixDiagnoses, chargeMatrixCharges, searchCharges, suggestedCharges, onToggleChargePointer, onReorderDiagnoses, onAddChargeModifier, onRemoveChargeModifier, onSetChargeComment, onClearChargeComment, onRemoveChargeByUuid, examTemplates, onCarryForwardExam, noteDiagnoses, isPsychiatry, dictation } = {}) {
   return SOAP_GROUPS
     .map(group => {
       const matching = sections.filter(s => group.keys.has(s.key.toLowerCase()));
@@ -541,7 +541,7 @@ function renderSoapGroups(sections, commandBySectionKey, onEditCommand, onDelete
         noteDiagnoses=${noteDiagnoses}
         onAddNow=${(isPlan || isObjective) ? onAddNow : null}
         hideRejected=${hideRejected}
-        alertFacilityEnabled=${alertFacilityEnabled}
+        alertFacilityCommands=${alertFacilityCommands}
         onEditingChange=${onEditingChange}
         questionnaireScores=${isObjective ? questionnaireScores : null}
         examTemplates=${(isObjective || isSubjective) ? examTemplates : null}
@@ -553,7 +553,7 @@ function renderSoapGroups(sections, commandBySectionKey, onEditCommand, onDelete
     .filter(Boolean);
 }
 
-export function Scribe({ noteId, patientId, staffId, staffName, providerName, providerPhotoUrl, patientName, patientBirthDate, patientGender, debugMode, noteEditable = true, isAuthor = false, alertFacilityEnabled = false, manualModeOnly = false, dictationEnabled = false, initialData = null }) {
+export function Scribe({ noteId, patientId, staffId, staffName, providerName, providerPhotoUrl, patientName, patientBirthDate, patientGender, debugMode, noteEditable = true, isAuthor = false, alertFacilityCommands = new Set(), manualModeOnly = false, dictationEnabled = false, initialData = null }) {
   const initSummary = initialData?.summary ?? null;
   const [noteData, setNoteData] = useState(initSummary?.note ?? null);
   const [generating, setGenerating] = useState(false);
@@ -3566,7 +3566,7 @@ export function Scribe({ noteId, patientId, staffId, staffName, providerName, pr
           diagnosisSuggestions,
           onAddNow: (authorEditable && !(wasFinalized && !approved)) ? handleAddNow : null,
           hideRejected,
-          alertFacilityEnabled,
+          alertFacilityCommands,
           onEditingChange: handleEditingChange,
           questionnaireScores: collectQuestionnaireScores(commands),
           chargeMatrixDiagnoses,

--- a/tests/hyperscribe/libraries/test_constants.py
+++ b/tests/hyperscribe/libraries/test_constants.py
@@ -134,7 +134,7 @@ def test_constants():
         "SECRET_NOTION_FEEDBACK_DATABASE_ID": "NotionFeedbackDatabaseId",
         "SECRET_SCRIBE_BACKEND": "ScribeBackend",
         "SECRET_SCRIBE_NOTE_TYPES": "ScribeNoteTypes",
-        "SECRET_ALERT_FACILITY_ENABLED": "AlertFacilityEnabled",
+        "SECRET_ALERT_FACILITY_COMMANDS": "AlertFacilityCommands",
         "SECRET_SCRIBE_DEBUG_STAFFERS": "ScribeDebugStaffers",
         "SECRET_VISIT_TEMPLATES": "VisitTemplates",
         "SECRET_NOTION_API_KEY": "NotionAPIKey",

--- a/tests/hyperscribe/scribe/api/test_session_view.py
+++ b/tests/hyperscribe/scribe/api/test_session_view.py
@@ -2609,7 +2609,7 @@ def test_edit_existing_commands_rfv_direct_edit(
     assert "rejected" not in data
     assert len(result) == 2  # JSONResponse + 1 effect
     assert result[1] is mock_effect
-    mock_build.assert_called_once_with(commands, "note-uuid-123")
+    mock_build.assert_called_once_with(commands, "note-uuid-123", {"AlertFacilityCommands": set()})
     mock_audit.assert_called_once()
     audit_call = mock_audit.call_args
     assert audit_call.args[0] == "note-uuid-123"
@@ -3039,7 +3039,7 @@ def test_edit_existing_commands_state_lookup_handles_uuid_type_from_postgres(
     )
     body = json.loads(result[0].content)
     assert "conflicts" not in body
-    mock_build.assert_called_once_with(commands, "note-uuid-123")
+    mock_build.assert_called_once_with(commands, "note-uuid-123", {"AlertFacilityCommands": set()})
 
 
 @patch("hyperscribe.scribe.api.session_view.audit_event")
@@ -3154,7 +3154,7 @@ def test_edit_existing_commands_reads_state_before_emitting_effects(
     # And NOT through the no-longer-supported select_for_update() path.
     mock_command.objects.select_for_update.assert_not_called()
     # Happy path: build_amend_edit_effects was invoked (no conflict surfaced).
-    mock_build.assert_called_once_with(commands, "note-uuid-123")
+    mock_build.assert_called_once_with(commands, "note-uuid-123", {"AlertFacilityCommands": set()})
 
 
 @patch("hyperscribe.scribe.api.session_view.audit_event")

--- a/tests/hyperscribe/scribe/api/test_session_view.py
+++ b/tests/hyperscribe/scribe/api/test_session_view.py
@@ -3632,6 +3632,96 @@ def test_inject_alert_facility_defaults_ignores_unrelated_and_malformed() -> Non
     assert "data" not in proposals[2]
 
 
+# ---- _reconcile_committed_alert_facility: committed record is truth for locked cards ----
+
+
+@patch("canvas_sdk.v1.data.command.CommandMetadata")
+@patch("canvas_sdk.v1.data.command.Command")
+def test_reconcile_committed_alert_facility_sets_strips_and_preserves(
+    mock_command: MagicMock, mock_metadata: MagicMock
+) -> None:
+    from hyperscribe.scribe.api.session_view import _reconcile_committed_alert_facility
+
+    commands = [
+        {"command_type": "prescribe", "command_uuid": "u-yes", "data": {"alert_facility": False}},
+        {"command_type": "refill", "command_uuid": "u-no", "data": {"alert_facility": True}},
+        {"command_type": "medication_statement", "command_uuid": "u-strip", "data": {"alert_facility": True}},
+        {"command_type": "prescribe", "command_uuid": "u-draft", "data": {"alert_facility": True}},
+        {"command_type": "prescribe", "command_uuid": "u-add", "data": {}},
+    ]
+    # u-draft is NOT in the committed set (an in-progress draft).
+    mock_command.objects.filter.return_value.exclude.return_value.values_list.return_value = [
+        "u-yes",
+        "u-no",
+        "u-strip",
+        "u-add",
+    ]
+    mock_metadata.objects.filter.return_value.values.return_value = [
+        {"command__id": "u-yes", "value": "Yes"},
+        {"command__id": "u-no", "value": "No"},
+        {"command__id": "u-add", "value": "Yes"},
+    ]
+    _reconcile_committed_alert_facility(commands, "note-uuid", _ALL_ALERT_COMMANDS)
+
+    assert commands[0]["data"]["alert_facility"] is True  # committed + "Yes" → True (committed wins over stale cache)
+    assert commands[1]["data"]["alert_facility"] is False  # committed + "No" → False
+    assert "alert_facility" not in commands[2]["data"]  # committed + no metadata → stripped (pre-feature)
+    assert commands[3]["data"]["alert_facility"] is True  # uncommitted draft → untouched
+    assert commands[4]["data"]["alert_facility"] is True  # committed + "Yes" → key added even though cache lacked it
+
+
+@patch("canvas_sdk.v1.data.command.Command")
+def test_reconcile_committed_alert_facility_empty_allowset_is_noop(mock_command: MagicMock) -> None:
+    from hyperscribe.scribe.api.session_view import _reconcile_committed_alert_facility
+
+    commands = [{"command_type": "prescribe", "command_uuid": "u1", "data": {"alert_facility": True}}]
+    _reconcile_committed_alert_facility(commands, "note-uuid", set())
+    assert commands[0]["data"]["alert_facility"] is True
+    mock_command.objects.filter.assert_not_called()
+
+
+@patch("canvas_sdk.v1.data.command.Command")
+def test_reconcile_committed_alert_facility_skips_disallowed_type(mock_command: MagicMock) -> None:
+    from hyperscribe.scribe.api.session_view import _reconcile_committed_alert_facility
+
+    commands = [{"command_type": "prescribe", "command_uuid": "u1", "data": {"alert_facility": True}}]
+    _reconcile_committed_alert_facility(commands, "note-uuid", {"refill"})  # prescribe not allowed
+    assert commands[0]["data"]["alert_facility"] is True  # untouched; no query issued
+    mock_command.objects.filter.assert_not_called()
+
+
+@patch("canvas_sdk.v1.data.command.CommandMetadata")
+@patch("canvas_sdk.v1.data.command.Command")
+@patch("hyperscribe.scribe.api.session_view.ScribeSummary")
+@patch("hyperscribe.scribe.api.session_view.Note")
+def test_load_summary_strips_alert_facility_when_not_in_committed_record(
+    mock_note: MagicMock, mock_summary: MagicMock, mock_command: MagicMock, mock_metadata: MagicMock
+) -> None:
+    """A locked/committed command whose cache carries a fabricated alert_facility but has no
+    committed metadata row is served with the flag stripped."""
+    from hyperscribe.scribe.api.session_view import _load_summary
+
+    mock_note.objects.values_list.return_value.get.return_value = 7
+    mock_summary.objects.filter.return_value.values.return_value.first.return_value = {
+        "note_data": None,
+        "commands": [{"command_type": "prescribe", "command_uuid": "u1", "data": {"alert_facility": True}}],
+        "approved": True,
+        "was_finalized": True,
+        "recommendations": [],
+        "unmatched_conditions": [],
+        "diagnosis_suggestions": {},
+        "selected_template_name": "",
+        "mode": "ai",
+    }
+    mock_command.objects.filter.return_value.exclude.return_value.values_list.return_value = ["u1"]  # committed
+    mock_metadata.objects.filter.return_value.values.return_value = []  # but no metadata row
+
+    data = _load_summary("note-uuid", {"prescribe"})
+
+    assert data is not None
+    assert "alert_facility" not in data["commands"][0]["data"]
+
+
 # ---- Alert Facility per-command-type default (frontend source pins) ----
 #
 # Structural pins, not runtime behavioral pins — they do NOT execute the React

--- a/tests/hyperscribe/scribe/api/test_session_view.py
+++ b/tests/hyperscribe/scribe/api/test_session_view.py
@@ -3534,6 +3534,73 @@ def test_note_commands_no_alert_facility_for_unrelated_schema_key(
     assert all(d["label"] != "Alert Facility" for d in details)
 
 
+# ---- Alert Facility per-command-type toggle default (frontend source pins) ----
+#
+# Structural pins, not runtime behavioral pins — they do NOT execute the React
+# code. They guard the edit-mode toggle default position for each command type:
+# medication statement + stop medication default OFF, prescribe + adjust
+# prescription default ON, refill default OFF. A JS test harness (to assert
+# runtime behavior) is out of scope.
+
+
+def _static_source(filename: str) -> str:
+    from pathlib import Path
+
+    path = Path(__file__).resolve().parents[4] / "hyperscribe" / "scribe" / "static" / filename
+    return path.read_text()
+
+
+def test_order_row_alert_facility_default_map_is_per_type() -> None:
+    """OrderRow (prescribe/adjust/refill) defaults: prescribe & adjust ON, refill OFF."""
+    src = _static_source("order-row.js")
+    assert "const ALERT_FACILITY_DEFAULT_ON = { prescribe: true, adjust_prescription: true, refill: false };" in src, (
+        "order-row.js is missing the per-type Alert Facility default map "
+        "`ALERT_FACILITY_DEFAULT_ON = { prescribe: true, adjust_prescription: true, refill: false }`. "
+        "Refill must default OFF while prescribe/adjust default ON."
+    )
+    # The default must be mirrored through the per-tab snapshot machinery so the
+    # toggle follows the active tab (initRxState seeds it; snapshot/restore carry it).
+    assert "alertFacility: !!ALERT_FACILITY_DEFAULT_ON[tabKey]" in src, (
+        "initRxState must seed alertFacility from ALERT_FACILITY_DEFAULT_ON[tabKey] so a "
+        "freshly-opened tab follows its own default."
+    )
+    assert "restoreRxSnapshot(initRxState(tab.key))" in src, (
+        "The tab-switch handler must pass the target tab key to initRxState so switching "
+        "tabs applies that tab's default."
+    )
+    assert "setAlertFacility(snap.alertFacility)" in src, (
+        "restoreRxSnapshot must restore alertFacility, otherwise a manual toggle is lost on tab switch."
+    )
+
+
+def test_medication_row_alert_facility_defaults_off() -> None:
+    """Medication statement toggle defaults OFF: the toggle state is seeded from
+    `alert_facility === true`. (The read-only display line keeps `!== false` by
+    design — this change is toggle-position-only.)"""
+    src = _static_source("medication-row.js")
+    assert "useState(command.data.alert_facility === true)" in src, (
+        "medication-row.js must seed the Alert Facility toggle from `alert_facility === true` "
+        "(default OFF). A `!== false` seed would default it ON."
+    )
+    # Both toggle bindings (initial seed + cancel reset) must use the OFF-default form.
+    assert src.count("command.data.alert_facility === true") >= 2, (
+        "Both the initial seed and the cancel-reset of alertFacility must use "
+        "`command.data.alert_facility === true` so the toggle consistently defaults OFF."
+    )
+
+
+def test_stop_medication_alert_facility_defaults_off() -> None:
+    """Stop medication (controlled RemovalRow) defaults OFF: seeds `false`, toggle reads `=== true`."""
+    src = _static_source("soap-group.js")
+    assert "alert_facility: false" in src, (
+        "soap-group.js RemovalRow must seed stop_medication's Alert Facility to `false` "
+        "(default OFF) so the controlled toggle and the stored value agree."
+    )
+    assert "data.alert_facility === true ? ' on'" in src, (
+        "The stop_medication toggle must render ON only when `alert_facility === true` (default OFF)."
+    )
+
+
 @patch("canvas_sdk.v1.data.command.Command")
 def test_note_commands_includes_data_for_diagnose(mock_command: MagicMock) -> None:
     """KOALA-5759: every synced command must carry its raw ``data`` payload.

--- a/tests/hyperscribe/scribe/api/test_session_view.py
+++ b/tests/hyperscribe/scribe/api/test_session_view.py
@@ -2383,7 +2383,7 @@ def test_insert_commands_success(mock_build: MagicMock) -> None:
     assert len(result) == 3  # JSONResponse + 2 effects
     assert result[1] is mock_effect_1
     assert result[2] is mock_effect_2
-    mock_build.assert_called_once_with(commands, "note-uuid-123", {"AlertFacilityEnabled": False})
+    mock_build.assert_called_once_with(commands, "note-uuid-123", {"AlertFacilityCommands": set()})
 
 
 @patch("hyperscribe.scribe.api.session_view.build_effects")
@@ -3471,12 +3471,35 @@ def test_note_commands_appends_alert_facility_from_metadata(mock_command: MagicM
         {"command__id": "uuid-rx", "value": "No"},
     ]
     view = _helper_instance()
-    view.secrets["AlertFacilityEnabled"] = "true"
+    view.secrets["AlertFacilityCommands"] = "prescribe,adjust_prescription,refill,medication_statement,stop_medication"
     view.request = SimpleNamespace(query_params={"note_id": "note-uuid"}, headers={})
     result = view.get_note_commands()
 
     details = json.loads(result[0].content)["commands"][0]["details"]
     assert {"label": "Alert Facility", "value": "No"} in details
+
+
+@patch("canvas_sdk.v1.data.command.CommandMetadata")
+@patch("canvas_sdk.v1.data.command.Command")
+def test_note_commands_respects_command_allowlist(mock_command: MagicMock, mock_metadata: MagicMock) -> None:
+    """Only command types in AlertFacilityCommands show the flag — even a disallowed
+    command that has recorded metadata is left without an Alert Facility line."""
+    mock_command.objects.filter.return_value.exclude.return_value.values.return_value = [
+        {"id": "uuid-rx", "schema_key": "prescribe", "data": {}},
+        {"id": "uuid-ref", "schema_key": "refill", "data": {}},
+    ]
+    mock_metadata.objects.filter.return_value.values.return_value = [
+        {"command__id": "uuid-rx", "value": "Yes"},
+        {"command__id": "uuid-ref", "value": "No"},
+    ]
+    view = _helper_instance()
+    view.secrets["AlertFacilityCommands"] = "prescribe"  # refill NOT allowed
+    view.request = SimpleNamespace(query_params={"note_id": "note-uuid"}, headers={})
+    result = view.get_note_commands()
+
+    details_by_id = {c["command_uuid"]: c["details"] for c in json.loads(result[0].content)["commands"]}
+    assert {"label": "Alert Facility", "value": "Yes"} in details_by_id["uuid-rx"]
+    assert all(d["label"] != "Alert Facility" for d in details_by_id["uuid-ref"])
 
 
 @patch("canvas_sdk.v1.data.command.CommandMetadata")
@@ -3494,7 +3517,7 @@ def test_note_commands_omits_alert_facility_without_metadata(mock_command: Magic
     ]
     mock_metadata.objects.filter.return_value.values.return_value = []
     view = _helper_instance()
-    view.secrets["AlertFacilityEnabled"] = "true"
+    view.secrets["AlertFacilityCommands"] = "prescribe,adjust_prescription,refill,medication_statement,stop_medication"
     view.request = SimpleNamespace(query_params={"note_id": "note-uuid"}, headers={})
     result = view.get_note_commands()
 
@@ -3530,7 +3553,7 @@ def test_note_commands_no_alert_facility_for_unrelated_schema_key(
     ]
     mock_metadata.objects.filter.return_value.values.return_value = []
     view = _helper_instance()
-    view.secrets["AlertFacilityEnabled"] = "true"
+    view.secrets["AlertFacilityCommands"] = "prescribe,adjust_prescription,refill,medication_statement,stop_medication"
     view.request = SimpleNamespace(query_params={"note_id": "note-uuid"}, headers={})
     result = view.get_note_commands()
 
@@ -3541,11 +3564,14 @@ def test_note_commands_no_alert_facility_for_unrelated_schema_key(
 # ---- _inject_alert_facility_defaults: stamp per-type defaults on fresh cards ----
 
 
-def test_inject_alert_facility_defaults_flag_off_is_noop() -> None:
+_ALL_ALERT_COMMANDS = {"prescribe", "adjust_prescription", "refill", "medication_statement", "stop_medication"}
+
+
+def test_inject_alert_facility_defaults_empty_allowset_is_noop() -> None:
     from hyperscribe.scribe.api.session_view import _inject_alert_facility_defaults
 
     proposals = [{"command_type": "prescribe", "data": {}}]
-    _inject_alert_facility_defaults(proposals, enabled=False)
+    _inject_alert_facility_defaults(proposals, set())
     assert proposals[0]["data"] == {}
 
 
@@ -3559,12 +3585,24 @@ def test_inject_alert_facility_defaults_sets_per_type_default() -> None:
         {"command_type": "medication_statement", "data": {}},
         {"command_type": "stop_medication", "data": {}},
     ]
-    _inject_alert_facility_defaults(proposals, enabled=True)
+    _inject_alert_facility_defaults(proposals, _ALL_ALERT_COMMANDS)
     assert proposals[0]["data"]["alert_facility"] is True
     assert proposals[1]["data"]["alert_facility"] is True
     assert proposals[2]["data"]["alert_facility"] is False
     assert proposals[3]["data"]["alert_facility"] is False
     assert proposals[4]["data"]["alert_facility"] is False
+
+
+def test_inject_alert_facility_defaults_skips_command_not_in_allowset() -> None:
+    from hyperscribe.scribe.api.session_view import _inject_alert_facility_defaults
+
+    proposals = [
+        {"command_type": "prescribe", "data": {}},
+        {"command_type": "refill", "data": {}},
+    ]
+    _inject_alert_facility_defaults(proposals, {"prescribe"})
+    assert proposals[0]["data"]["alert_facility"] is True  # in the allow-set
+    assert "alert_facility" not in proposals[1]["data"]  # refill not allowed → untouched
 
 
 def test_inject_alert_facility_defaults_preserves_explicit_value() -> None:
@@ -3575,7 +3613,7 @@ def test_inject_alert_facility_defaults_preserves_explicit_value() -> None:
         {"command_type": "prescribe", "data": {"alert_facility": False}},
         {"command_type": "refill", "data": {"alert_facility": True}},
     ]
-    _inject_alert_facility_defaults(proposals, enabled=True)
+    _inject_alert_facility_defaults(proposals, _ALL_ALERT_COMMANDS)
     assert proposals[0]["data"]["alert_facility"] is False
     assert proposals[1]["data"]["alert_facility"] is True
 
@@ -3588,7 +3626,7 @@ def test_inject_alert_facility_defaults_ignores_unrelated_and_malformed() -> Non
         {"command_type": "prescribe", "data": None},  # malformed data
         {"command_type": "prescribe"},  # no data key
     ]
-    _inject_alert_facility_defaults(proposals, enabled=True)
+    _inject_alert_facility_defaults(proposals, _ALL_ALERT_COMMANDS)
     assert "alert_facility" not in proposals[0]["data"]
     assert proposals[1]["data"] is None
     assert "data" not in proposals[2]
@@ -3633,10 +3671,13 @@ def test_order_row_alert_facility_toggle_default_and_explicit_display() -> None:
     )
     assert "d.alert_facility === true || d.alert_facility === false" in src
     assert "command.data.alert_facility === true || command.data.alert_facility === false" in src
-    # handleSave persists the flag only when new / touched / already-present.
+    # Per-command gating: toggle + display + save all gate on the allow-set membership.
+    assert "alertFacilityCommands.has(activeTab)" in src, "OrderRow toggle must gate on the active tab's membership."
+    assert "alertFacilityCommands.has(command.command_type)" in src, "OrderRow display must gate on command membership."
+    # handleSave persists the flag only when enabled AND (new or touched).
     assert "alertFacilityTouched" in src, "order-row.js must track whether the toggle was touched."
-    assert "if (isNew || alertFacilityTouched) {" in src, (
-        "handleSave must only materialize alert_facility for a new card or a touched toggle."
+    assert "if (alertFacilityCommands.has(activeTab) && (isNew || alertFacilityTouched)) {" in src, (
+        "handleSave must only materialize alert_facility for an enabled command that is new or touched."
     )
 
 
@@ -3650,12 +3691,13 @@ def test_medication_row_alert_facility_off_default_and_explicit_display() -> Non
     assert "alert_facility !== false" not in src, (
         "medication-row.js still contains a `!== false` Alert Facility default (defaults ON)."
     )
-    # Display gates on an explicit boolean; no fabricated default.
+    # Display gates on an explicit boolean AND command membership; no fabricated default.
     assert "command.data.alert_facility === true || command.data.alert_facility === false" in src
+    assert "alertFacilityCommands.has(command.command_type)" in src, "MedicationRow must gate on command membership."
     assert "alertFacilityTouched" in src, "medication-row.js must track whether the toggle was touched."
-    assert "if (!command.display || alertFacilityTouched) {" in src, (
-        "handleSave must only materialize alert_facility for a new card or a touched toggle."
-    )
+    assert (
+        "if (alertFacilityCommands.has(command.command_type) && (!command.display || alertFacilityTouched)) {" in src
+    ), "handleSave must only materialize alert_facility for an enabled command that is new or touched."
 
 
 def test_stop_medication_alert_facility_no_seed_and_explicit_display() -> None:

--- a/tests/hyperscribe/scribe/api/test_session_view.py
+++ b/tests/hyperscribe/scribe/api/test_session_view.py
@@ -3481,13 +3481,18 @@ def test_note_commands_appends_alert_facility_from_metadata(mock_command: MagicM
 
 @patch("canvas_sdk.v1.data.command.CommandMetadata")
 @patch("canvas_sdk.v1.data.command.Command")
-def test_note_commands_alert_facility_defaults_yes_without_metadata(
+def test_note_commands_alert_facility_defaults_per_type_without_metadata(
     mock_command: MagicMock, mock_metadata: MagicMock
 ) -> None:
-    """Flag on + no stored metadata (pre-feature command): defaults to Yes,
-    matching the Scribe-side display default."""
+    """Flag on + no stored metadata: the flat card shows the per-command-type
+    default — prescribe/adjust Yes, medication statement / stop medication /
+    refill No — so a card gets its default without being opened."""
     mock_command.objects.filter.return_value.exclude.return_value.values.return_value = [
-        {"id": "uuid-med", "schema_key": "medicationStatement", "data": {"medication": "Lisinopril"}},
+        {"id": "uuid-rx", "schema_key": "prescribe", "data": {}},
+        {"id": "uuid-adj", "schema_key": "adjustPrescription", "data": {}},
+        {"id": "uuid-ref", "schema_key": "refill", "data": {}},
+        {"id": "uuid-med", "schema_key": "medicationStatement", "data": {}},
+        {"id": "uuid-stop", "schema_key": "stopMedication", "data": {}},
     ]
     mock_metadata.objects.filter.return_value.values.return_value = []
     view = _helper_instance()
@@ -3495,8 +3500,12 @@ def test_note_commands_alert_facility_defaults_yes_without_metadata(
     view.request = SimpleNamespace(query_params={"note_id": "note-uuid"}, headers={})
     result = view.get_note_commands()
 
-    details = json.loads(result[0].content)["commands"][0]["details"]
-    assert {"label": "Alert Facility", "value": "Yes"} in details
+    details_by_id = {c["command_uuid"]: c["details"] for c in json.loads(result[0].content)["commands"]}
+    assert {"label": "Alert Facility", "value": "Yes"} in details_by_id["uuid-rx"]
+    assert {"label": "Alert Facility", "value": "Yes"} in details_by_id["uuid-adj"]
+    assert {"label": "Alert Facility", "value": "No"} in details_by_id["uuid-ref"]
+    assert {"label": "Alert Facility", "value": "No"} in details_by_id["uuid-med"]
+    assert {"label": "Alert Facility", "value": "No"} in details_by_id["uuid-stop"]
 
 
 @patch("canvas_sdk.v1.data.command.CommandMetadata")
@@ -3534,13 +3543,13 @@ def test_note_commands_no_alert_facility_for_unrelated_schema_key(
     assert all(d["label"] != "Alert Facility" for d in details)
 
 
-# ---- Alert Facility per-command-type toggle default (frontend source pins) ----
+# ---- Alert Facility per-command-type default (frontend source pins) ----
 #
 # Structural pins, not runtime behavioral pins — they do NOT execute the React
-# code. They guard the edit-mode toggle default position for each command type:
-# medication statement + stop medication default OFF, prescribe + adjust
-# prescription default ON, refill default OFF. A JS test harness (to assert
-# runtime behavior) is out of scope.
+# code. They guard the per-command-type default (toggle AND view-mode display):
+# medication statement + stop medication + refill default OFF; prescribe +
+# adjust prescription default ON. A JS test harness (to assert runtime
+# behavior) is out of scope.
 
 
 def _static_source(filename: str) -> str:
@@ -3571,26 +3580,35 @@ def test_order_row_alert_facility_default_map_is_per_type() -> None:
     assert "setAlertFacility(snap.alertFacility)" in src, (
         "restoreRxSnapshot must restore alertFacility, otherwise a manual toggle is lost on tab switch."
     )
+    # Toggle seed AND view-mode display must both resolve the default through the
+    # type-aware helper, so an unopened card shows its per-type default.
+    assert "const alertFacilityOn = " in src, "order-row.js must define the alertFacilityOn resolver."
+    assert src.count("alertFacilityOn(command.command_type") >= 2, (
+        "The view-mode display lines must resolve Alert Facility via "
+        "alertFacilityOn(command.command_type, ...) so refill shows No and prescribe/adjust show Yes "
+        "without the card being opened."
+    )
 
 
 def test_medication_row_alert_facility_defaults_off() -> None:
-    """Medication statement toggle defaults OFF: the toggle state is seeded from
-    `alert_facility === true`. (The read-only display line keeps `!== false` by
-    design — this change is toggle-position-only.)"""
+    """Medication statement defaults OFF for both the toggle and the display; no `!== false` remains."""
     src = _static_source("medication-row.js")
     assert "useState(command.data.alert_facility === true)" in src, (
         "medication-row.js must seed the Alert Facility toggle from `alert_facility === true` "
         "(default OFF). A `!== false` seed would default it ON."
     )
-    # Both toggle bindings (initial seed + cancel reset) must use the OFF-default form.
-    assert src.count("command.data.alert_facility === true") >= 2, (
-        "Both the initial seed and the cancel-reset of alertFacility must use "
-        "`command.data.alert_facility === true` so the toggle consistently defaults OFF."
+    # Seed, cancel-reset, and both display lines must use the OFF-default form; no ON-default left.
+    assert "alert_facility !== false" not in src, (
+        "medication-row.js still contains a `!== false` Alert Facility default, which defaults ON "
+        "instead of OFF for medication statement."
+    )
+    assert "command.data.alert_facility === true ? 'Yes' : 'No'" in src, (
+        "The medication statement view-mode line must default OFF (`=== true ? 'Yes' : 'No'`)."
     )
 
 
 def test_stop_medication_alert_facility_defaults_off() -> None:
-    """Stop medication (controlled RemovalRow) defaults OFF: seeds `false`, toggle reads `=== true`."""
+    """Stop medication (controlled RemovalRow) defaults OFF: seeds `false`, toggle + line read `=== true`."""
     src = _static_source("soap-group.js")
     assert "alert_facility: false" in src, (
         "soap-group.js RemovalRow must seed stop_medication's Alert Facility to `false` "
@@ -3598,6 +3616,9 @@ def test_stop_medication_alert_facility_defaults_off() -> None:
     )
     assert "data.alert_facility === true ? ' on'" in src, (
         "The stop_medication toggle must render ON only when `alert_facility === true` (default OFF)."
+    )
+    assert "data.alert_facility === true ? 'Yes' : 'No'" in src, (
+        "The stop_medication read-only line must default OFF (`=== true ? 'Yes' : 'No'`)."
     )
 
 

--- a/tests/hyperscribe/scribe/api/test_session_view.py
+++ b/tests/hyperscribe/scribe/api/test_session_view.py
@@ -3481,12 +3481,10 @@ def test_note_commands_appends_alert_facility_from_metadata(mock_command: MagicM
 
 @patch("canvas_sdk.v1.data.command.CommandMetadata")
 @patch("canvas_sdk.v1.data.command.Command")
-def test_note_commands_alert_facility_defaults_yes_without_metadata(
-    mock_command: MagicMock, mock_metadata: MagicMock
-) -> None:
+def test_note_commands_omits_alert_facility_without_metadata(mock_command: MagicMock, mock_metadata: MagicMock) -> None:
     """No stored metadata means a pre-feature (or non-Scribe) command — post-feature
     commands always carry an explicit alert_facility metadata row. Such historical
-    cards default to Yes for every type, so history is shown unaltered."""
+    cards show NO Alert Facility line, so history is left unaltered."""
     mock_command.objects.filter.return_value.exclude.return_value.values.return_value = [
         {"id": "uuid-rx", "schema_key": "prescribe", "data": {}},
         {"id": "uuid-adj", "schema_key": "adjustPrescription", "data": {}},
@@ -3502,7 +3500,7 @@ def test_note_commands_alert_facility_defaults_yes_without_metadata(
 
     details_by_id = {c["command_uuid"]: c["details"] for c in json.loads(result[0].content)["commands"]}
     for cmd_id in ("uuid-rx", "uuid-adj", "uuid-ref", "uuid-med", "uuid-stop"):
-        assert {"label": "Alert Facility", "value": "Yes"} in details_by_id[cmd_id], cmd_id
+        assert all(d["label"] != "Alert Facility" for d in details_by_id[cmd_id]), cmd_id
 
 
 @patch("canvas_sdk.v1.data.command.CommandMetadata")
@@ -3540,6 +3538,62 @@ def test_note_commands_no_alert_facility_for_unrelated_schema_key(
     assert all(d["label"] != "Alert Facility" for d in details)
 
 
+# ---- _inject_alert_facility_defaults: stamp per-type defaults on fresh cards ----
+
+
+def test_inject_alert_facility_defaults_flag_off_is_noop() -> None:
+    from hyperscribe.scribe.api.session_view import _inject_alert_facility_defaults
+
+    proposals = [{"command_type": "prescribe", "data": {}}]
+    _inject_alert_facility_defaults(proposals, enabled=False)
+    assert proposals[0]["data"] == {}
+
+
+def test_inject_alert_facility_defaults_sets_per_type_default() -> None:
+    from hyperscribe.scribe.api.session_view import _inject_alert_facility_defaults
+
+    proposals = [
+        {"command_type": "prescribe", "data": {}},
+        {"command_type": "adjust_prescription", "data": {}},
+        {"command_type": "refill", "data": {}},
+        {"command_type": "medication_statement", "data": {}},
+        {"command_type": "stop_medication", "data": {}},
+    ]
+    _inject_alert_facility_defaults(proposals, enabled=True)
+    assert proposals[0]["data"]["alert_facility"] is True
+    assert proposals[1]["data"]["alert_facility"] is True
+    assert proposals[2]["data"]["alert_facility"] is False
+    assert proposals[3]["data"]["alert_facility"] is False
+    assert proposals[4]["data"]["alert_facility"] is False
+
+
+def test_inject_alert_facility_defaults_preserves_explicit_value() -> None:
+    from hyperscribe.scribe.api.session_view import _inject_alert_facility_defaults
+
+    # setdefault semantics: an already-chosen value always wins over the type default.
+    proposals = [
+        {"command_type": "prescribe", "data": {"alert_facility": False}},
+        {"command_type": "refill", "data": {"alert_facility": True}},
+    ]
+    _inject_alert_facility_defaults(proposals, enabled=True)
+    assert proposals[0]["data"]["alert_facility"] is False
+    assert proposals[1]["data"]["alert_facility"] is True
+
+
+def test_inject_alert_facility_defaults_ignores_unrelated_and_malformed() -> None:
+    from hyperscribe.scribe.api.session_view import _inject_alert_facility_defaults
+
+    proposals = [
+        {"command_type": "diagnose", "data": {}},  # not an alert-facility type
+        {"command_type": "prescribe", "data": None},  # malformed data
+        {"command_type": "prescribe"},  # no data key
+    ]
+    _inject_alert_facility_defaults(proposals, enabled=True)
+    assert "alert_facility" not in proposals[0]["data"]
+    assert proposals[1]["data"] is None
+    assert "data" not in proposals[2]
+
+
 # ---- Alert Facility per-command-type default (frontend source pins) ----
 #
 # Structural pins, not runtime behavioral pins — they do NOT execute the React
@@ -3556,67 +3610,69 @@ def _static_source(filename: str) -> str:
     return path.read_text()
 
 
-def test_order_row_alert_facility_default_map_is_per_type() -> None:
-    """OrderRow (prescribe/adjust/refill) defaults: prescribe & adjust ON, refill OFF."""
+def test_order_row_alert_facility_toggle_default_and_explicit_display() -> None:
+    """OrderRow: toggle seed uses the per-type default (prescribe/adjust ON, refill OFF)
+    via the alertFacilityOn resolver; the view-mode display shows a value ONLY when one is
+    explicitly stored (no fabricated default); handleSave never fabricates a value."""
     src = _static_source("order-row.js")
-    assert "const ALERT_FACILITY_DEFAULT_ON = { prescribe: true, adjust_prescription: true, refill: false };" in src, (
-        "order-row.js is missing the per-type Alert Facility default map "
-        "`ALERT_FACILITY_DEFAULT_ON = { prescribe: true, adjust_prescription: true, refill: false }`. "
-        "Refill must default OFF while prescribe/adjust default ON."
-    )
-    # The default must be mirrored through the per-tab snapshot machinery so the
-    # toggle follows the active tab (initRxState seeds it; snapshot/restore carry it).
-    assert "alertFacility: !!ALERT_FACILITY_DEFAULT_ON[tabKey]" in src, (
-        "initRxState must seed alertFacility from ALERT_FACILITY_DEFAULT_ON[tabKey] so a "
-        "freshly-opened tab follows its own default."
-    )
-    assert "restoreRxSnapshot(initRxState(tab.key))" in src, (
-        "The tab-switch handler must pass the target tab key to initRxState so switching "
-        "tabs applies that tab's default."
-    )
-    assert "setAlertFacility(snap.alertFacility)" in src, (
-        "restoreRxSnapshot must restore alertFacility, otherwise a manual toggle is lost on tab switch."
-    )
-    # Toggle seed AND view-mode display must both resolve the default through the
-    # type-aware helper, so an unopened card shows its per-type default.
+    # Per-type default map + resolver, used for the toggle seed / per-tab snapshot machinery.
+    assert "const ALERT_FACILITY_DEFAULT_ON = { prescribe: true, adjust_prescription: true, refill: false };" in src
     assert "const alertFacilityOn = " in src, "order-row.js must define the alertFacilityOn resolver."
-    assert src.count("alertFacilityOn(command.command_type") >= 2, (
-        "The view-mode display lines must resolve Alert Facility via "
-        "alertFacilityOn(command.command_type, ...) so refill shows No and prescribe/adjust show Yes "
-        "without the card being opened."
+    assert "alertFacilityOn(command.command_type || 'prescribe', command.data.alert_facility)" in src, (
+        "The toggle seed must resolve the per-type default via alertFacilityOn."
+    )
+    assert "alertFacility: !!ALERT_FACILITY_DEFAULT_ON[tabKey]" in src
+    assert "restoreRxSnapshot(initRxState(tab.key))" in src
+    assert "setAlertFacility(snap.alertFacility)" in src
+    # Display must NOT fabricate a default — it gates on an explicit boolean and shows the raw value.
+    # (The seed uses `alertFacilityOn(command.command_type || 'prescribe', ...)`; the old display
+    # calls were `alertFacilityOn(command.command_type, ...)` — that comma form must be gone.)
+    assert "alertFacilityOn(command.command_type," not in src, (
+        "The view-mode display must not resolve a fabricated per-type default via alertFacilityOn — "
+        "it should show a value only when one is explicitly stored."
+    )
+    assert "d.alert_facility === true || d.alert_facility === false" in src
+    assert "command.data.alert_facility === true || command.data.alert_facility === false" in src
+    # handleSave persists the flag only when new / touched / already-present.
+    assert "alertFacilityTouched" in src, "order-row.js must track whether the toggle was touched."
+    assert "if (isNew || alertFacilityTouched) {" in src, (
+        "handleSave must only materialize alert_facility for a new card or a touched toggle."
     )
 
 
-def test_medication_row_alert_facility_defaults_off() -> None:
-    """Medication statement defaults OFF for both the toggle and the display; no `!== false` remains."""
+def test_medication_row_alert_facility_off_default_and_explicit_display() -> None:
+    """Medication statement: toggle seeds OFF; display shows a value only when explicitly stored;
+    handleSave does not fabricate a value; no ON-default (`!== false`) remains."""
     src = _static_source("medication-row.js")
     assert "useState(command.data.alert_facility === true)" in src, (
-        "medication-row.js must seed the Alert Facility toggle from `alert_facility === true` "
-        "(default OFF). A `!== false` seed would default it ON."
+        "medication-row.js must seed the toggle from `alert_facility === true` (default OFF)."
     )
-    # Seed, cancel-reset, and both display lines must use the OFF-default form; no ON-default left.
     assert "alert_facility !== false" not in src, (
-        "medication-row.js still contains a `!== false` Alert Facility default, which defaults ON "
-        "instead of OFF for medication statement."
+        "medication-row.js still contains a `!== false` Alert Facility default (defaults ON)."
     )
-    assert "command.data.alert_facility === true ? 'Yes' : 'No'" in src, (
-        "The medication statement view-mode line must default OFF (`=== true ? 'Yes' : 'No'`)."
+    # Display gates on an explicit boolean; no fabricated default.
+    assert "command.data.alert_facility === true || command.data.alert_facility === false" in src
+    assert "alertFacilityTouched" in src, "medication-row.js must track whether the toggle was touched."
+    assert "if (!command.display || alertFacilityTouched) {" in src, (
+        "handleSave must only materialize alert_facility for a new card or a touched toggle."
     )
 
 
-def test_stop_medication_alert_facility_defaults_off() -> None:
-    """Stop medication (controlled RemovalRow) defaults OFF: seeds `false`, toggle + line read `=== true`."""
+def test_stop_medication_alert_facility_no_seed_and_explicit_display() -> None:
+    """Stop medication (controlled RemovalRow): toggle reads `=== true` (OFF default), the
+    read-only line shows a value only when explicitly stored, and there is NO mount seed
+    fabricating a value."""
     src = _static_source("soap-group.js")
-    assert "alert_facility: false" in src, (
-        "soap-group.js RemovalRow must seed stop_medication's Alert Facility to `false` "
-        "(default OFF) so the controlled toggle and the stored value agree."
-    )
     assert "data.alert_facility === true ? ' on'" in src, (
         "The stop_medication toggle must render ON only when `alert_facility === true` (default OFF)."
     )
-    assert "data.alert_facility === true ? 'Yes' : 'No'" in src, (
-        "The stop_medication read-only line must default OFF (`=== true ? 'Yes' : 'No'`)."
+    # The old mount seed that fabricated a value must be gone.
+    assert "alert_facility: false" not in src, (
+        "The stop_medication mount seed (writing `alert_facility: false`) must be removed so a "
+        "value-less card is never fabricated."
     )
+    # Read-only line gates on an explicit boolean.
+    assert "data.alert_facility === true || data.alert_facility === false" in src
 
 
 @patch("canvas_sdk.v1.data.command.Command")

--- a/tests/hyperscribe/scribe/api/test_session_view.py
+++ b/tests/hyperscribe/scribe/api/test_session_view.py
@@ -3458,6 +3458,82 @@ def test_note_commands_returns_full_shape(mock_command: MagicMock) -> None:
     ]
 
 
+@patch("canvas_sdk.v1.data.command.CommandMetadata")
+@patch("canvas_sdk.v1.data.command.Command")
+def test_note_commands_appends_alert_facility_from_metadata(mock_command: MagicMock, mock_metadata: MagicMock) -> None:
+    """Flag on: the Alert Facility flag (stored as command metadata, not in
+    Command.data) is read back and appended as a detail so it stays visible on
+    the flat ADDITIONAL COMMANDS card after commit."""
+    mock_command.objects.filter.return_value.exclude.return_value.values.return_value = [
+        {"id": "uuid-rx", "schema_key": "prescribe", "data": {"sig": "1 tab daily"}},
+    ]
+    mock_metadata.objects.filter.return_value.values.return_value = [
+        {"command__id": "uuid-rx", "value": "No"},
+    ]
+    view = _helper_instance()
+    view.secrets["AlertFacilityEnabled"] = "true"
+    view.request = SimpleNamespace(query_params={"note_id": "note-uuid"}, headers={})
+    result = view.get_note_commands()
+
+    details = json.loads(result[0].content)["commands"][0]["details"]
+    assert {"label": "Alert Facility", "value": "No"} in details
+
+
+@patch("canvas_sdk.v1.data.command.CommandMetadata")
+@patch("canvas_sdk.v1.data.command.Command")
+def test_note_commands_alert_facility_defaults_yes_without_metadata(
+    mock_command: MagicMock, mock_metadata: MagicMock
+) -> None:
+    """Flag on + no stored metadata (pre-feature command): defaults to Yes,
+    matching the Scribe-side display default."""
+    mock_command.objects.filter.return_value.exclude.return_value.values.return_value = [
+        {"id": "uuid-med", "schema_key": "medicationStatement", "data": {"medication": "Lisinopril"}},
+    ]
+    mock_metadata.objects.filter.return_value.values.return_value = []
+    view = _helper_instance()
+    view.secrets["AlertFacilityEnabled"] = "true"
+    view.request = SimpleNamespace(query_params={"note_id": "note-uuid"}, headers={})
+    result = view.get_note_commands()
+
+    details = json.loads(result[0].content)["commands"][0]["details"]
+    assert {"label": "Alert Facility", "value": "Yes"} in details
+
+
+@patch("canvas_sdk.v1.data.command.CommandMetadata")
+@patch("canvas_sdk.v1.data.command.Command")
+def test_note_commands_no_alert_facility_when_flag_off(mock_command: MagicMock, mock_metadata: MagicMock) -> None:
+    """Flag off: no Alert Facility detail is appended and metadata is not queried."""
+    mock_command.objects.filter.return_value.exclude.return_value.values.return_value = [
+        {"id": "uuid-rx", "schema_key": "prescribe", "data": {"sig": "1 tab daily"}},
+    ]
+    view = _helper_instance()
+    view.request = SimpleNamespace(query_params={"note_id": "note-uuid"}, headers={})
+    result = view.get_note_commands()
+
+    details = json.loads(result[0].content)["commands"][0]["details"]
+    assert all(d["label"] != "Alert Facility" for d in details)
+    mock_metadata.objects.filter.assert_not_called()
+
+
+@patch("canvas_sdk.v1.data.command.CommandMetadata")
+@patch("canvas_sdk.v1.data.command.Command")
+def test_note_commands_no_alert_facility_for_unrelated_schema_key(
+    mock_command: MagicMock, mock_metadata: MagicMock
+) -> None:
+    """Flag on but a non-medication command: no Alert Facility detail."""
+    mock_command.objects.filter.return_value.exclude.return_value.values.return_value = [
+        {"id": "uuid-hpi", "schema_key": "hpi", "data": {"narrative": "Pain"}},
+    ]
+    mock_metadata.objects.filter.return_value.values.return_value = []
+    view = _helper_instance()
+    view.secrets["AlertFacilityEnabled"] = "true"
+    view.request = SimpleNamespace(query_params={"note_id": "note-uuid"}, headers={})
+    result = view.get_note_commands()
+
+    details = json.loads(result[0].content)["commands"][0]["details"]
+    assert all(d["label"] != "Alert Facility" for d in details)
+
+
 @patch("canvas_sdk.v1.data.command.Command")
 def test_note_commands_includes_data_for_diagnose(mock_command: MagicMock) -> None:
     """KOALA-5759: every synced command must carry its raw ``data`` payload.

--- a/tests/hyperscribe/scribe/api/test_session_view.py
+++ b/tests/hyperscribe/scribe/api/test_session_view.py
@@ -3722,6 +3722,49 @@ def test_load_summary_strips_alert_facility_when_not_in_committed_record(
     assert "alert_facility" not in data["commands"][0]["data"]
 
 
+@patch("canvas_sdk.v1.data.command.CommandMetadata")
+@patch("canvas_sdk.v1.data.command.Command")
+@patch("hyperscribe.scribe.api.session_view.ScribeSummary")
+@patch("hyperscribe.scribe.api.session_view.Note")
+def test_load_summary_reconciles_recommendations_like_commands(
+    mock_note: MagicMock, mock_summary: MagicMock, mock_command: MagicMock, mock_metadata: MagicMock
+) -> None:
+    """_inject stamps a per-type default onto recommendations as well as commands,
+    so _load_summary must reconcile BOTH against the committed record — not just
+    commands. A committed recommendation with a fabricated flag but no metadata row
+    is stripped; one with a metadata row shows the true value; an unaccepted
+    recommendation (no committed command) keeps its in-flight default untouched."""
+    from hyperscribe.scribe.api.session_view import _load_summary
+
+    mock_note.objects.values_list.return_value.get.return_value = 7
+    mock_summary.objects.filter.return_value.values.return_value.first.return_value = {
+        "note_data": None,
+        "commands": [],
+        "approved": True,
+        "was_finalized": True,
+        "recommendations": [
+            {"command_type": "prescribe", "command_uuid": "r-strip", "data": {"alert_facility": True}},
+            {"command_type": "medication_statement", "command_uuid": "r-yes", "data": {"alert_facility": False}},
+            {"command_type": "prescribe", "command_uuid": "r-draft", "data": {"alert_facility": True}},
+        ],
+        "unmatched_conditions": [],
+        "diagnosis_suggestions": {},
+        "selected_template_name": "",
+        "mode": "ai",
+    }
+    # r-strip and r-yes are committed; r-draft is an unaccepted recommendation (no committed command).
+    mock_command.objects.filter.return_value.exclude.return_value.values_list.return_value = ["r-strip", "r-yes"]
+    mock_metadata.objects.filter.return_value.values.return_value = [{"command__id": "r-yes", "value": "Yes"}]
+
+    data = _load_summary("note-uuid", {"prescribe", "medication_statement"})
+
+    assert data is not None
+    recs = data["recommendations"]
+    assert "alert_facility" not in recs[0]["data"]  # committed + no metadata → stripped (was fabricated)
+    assert recs[1]["data"]["alert_facility"] is True  # committed + "Yes" → true committed value
+    assert recs[2]["data"]["alert_facility"] is True  # unaccepted rec (uncommitted) → keeps in-flight default
+
+
 # ---- Alert Facility per-command-type default (frontend source pins) ----
 #
 # Structural pins, not runtime behavioral pins — they do NOT execute the React

--- a/tests/hyperscribe/scribe/api/test_session_view.py
+++ b/tests/hyperscribe/scribe/api/test_session_view.py
@@ -3481,12 +3481,12 @@ def test_note_commands_appends_alert_facility_from_metadata(mock_command: MagicM
 
 @patch("canvas_sdk.v1.data.command.CommandMetadata")
 @patch("canvas_sdk.v1.data.command.Command")
-def test_note_commands_alert_facility_defaults_per_type_without_metadata(
+def test_note_commands_alert_facility_defaults_yes_without_metadata(
     mock_command: MagicMock, mock_metadata: MagicMock
 ) -> None:
-    """Flag on + no stored metadata: the flat card shows the per-command-type
-    default — prescribe/adjust Yes, medication statement / stop medication /
-    refill No — so a card gets its default without being opened."""
+    """No stored metadata means a pre-feature (or non-Scribe) command — post-feature
+    commands always carry an explicit alert_facility metadata row. Such historical
+    cards default to Yes for every type, so history is shown unaltered."""
     mock_command.objects.filter.return_value.exclude.return_value.values.return_value = [
         {"id": "uuid-rx", "schema_key": "prescribe", "data": {}},
         {"id": "uuid-adj", "schema_key": "adjustPrescription", "data": {}},
@@ -3501,11 +3501,8 @@ def test_note_commands_alert_facility_defaults_per_type_without_metadata(
     result = view.get_note_commands()
 
     details_by_id = {c["command_uuid"]: c["details"] for c in json.loads(result[0].content)["commands"]}
-    assert {"label": "Alert Facility", "value": "Yes"} in details_by_id["uuid-rx"]
-    assert {"label": "Alert Facility", "value": "Yes"} in details_by_id["uuid-adj"]
-    assert {"label": "Alert Facility", "value": "No"} in details_by_id["uuid-ref"]
-    assert {"label": "Alert Facility", "value": "No"} in details_by_id["uuid-med"]
-    assert {"label": "Alert Facility", "value": "No"} in details_by_id["uuid-stop"]
+    for cmd_id in ("uuid-rx", "uuid-adj", "uuid-ref", "uuid-med", "uuid-stop"):
+        assert {"label": "Alert Facility", "value": "Yes"} in details_by_id[cmd_id], cmd_id
 
 
 @patch("canvas_sdk.v1.data.command.CommandMetadata")

--- a/tests/hyperscribe/scribe/commands/test_adjust_prescription.py
+++ b/tests/hyperscribe/scribe/commands/test_adjust_prescription.py
@@ -207,7 +207,9 @@ def test_pending_metadata_flag_off_returns_none() -> None:
     assert AdjustPrescriptionParser().pending_metadata(cmd, proposal, feature_flags={}) is None
     assert AdjustPrescriptionParser().pending_metadata(cmd, proposal, feature_flags=None) is None
     assert (
-        AdjustPrescriptionParser().pending_metadata(cmd, proposal, feature_flags={"AlertFacilityEnabled": False})
+        AdjustPrescriptionParser().pending_metadata(
+            cmd, proposal, feature_flags={"AlertFacilityCommands": {"prescribe"}}
+        )
         is None
     )
 
@@ -215,7 +217,9 @@ def test_pending_metadata_flag_off_returns_none() -> None:
 def test_pending_metadata_flag_on_alert_truthy_returns_yes() -> None:
     cmd = _make_rx_command()
     proposal = {"data": {"alert_facility": True}}
-    result = AdjustPrescriptionParser().pending_metadata(cmd, proposal, feature_flags={"AlertFacilityEnabled": True})
+    result = AdjustPrescriptionParser().pending_metadata(
+        cmd, proposal, feature_flags={"AlertFacilityCommands": {"adjust_prescription"}}
+    )
     assert result == {
         "command_uuid": cmd.command_uuid,
         "command_type": "adjust_prescription",
@@ -227,7 +231,7 @@ def test_pending_metadata_flag_on_alert_truthy_returns_yes() -> None:
 def test_pending_metadata_flag_on_explicit_false_returns_no() -> None:
     cmd = _make_rx_command()
     result = AdjustPrescriptionParser().pending_metadata(
-        cmd, {"data": {"alert_facility": False}}, feature_flags={"AlertFacilityEnabled": True}
+        cmd, {"data": {"alert_facility": False}}, feature_flags={"AlertFacilityCommands": {"adjust_prescription"}}
     )
     assert result is not None
     assert result["metadata"] == {"alert_facility": "No"}
@@ -241,7 +245,7 @@ def test_pending_metadata_flag_on_defaults_to_yes_when_unset() -> None:
         None,
     ):
         result = AdjustPrescriptionParser().pending_metadata(
-            cmd, proposal, feature_flags={"AlertFacilityEnabled": True}
+            cmd, proposal, feature_flags={"AlertFacilityCommands": {"adjust_prescription"}}
         )
         assert result is not None
         assert result["metadata"] == {"alert_facility": "Yes"}

--- a/tests/hyperscribe/scribe/commands/test_adjust_prescription.py
+++ b/tests/hyperscribe/scribe/commands/test_adjust_prescription.py
@@ -192,3 +192,56 @@ def test_to_effects_returns_originate_and_review() -> None:
     assert len(effects) == 2
     command.originate.assert_called_once()
     command.review.assert_called_once()
+
+
+def _make_rx_command() -> MagicMock:
+    cmd = MagicMock()
+    cmd.command_uuid = "00000000-0000-0000-0000-0000000000d1"
+    cmd.note_uuid = "00000000-0000-0000-0000-0000000000dd"
+    return cmd
+
+
+def test_pending_metadata_flag_off_returns_none() -> None:
+    cmd = _make_rx_command()
+    proposal = {"data": {"alert_facility": True}}
+    assert AdjustPrescriptionParser().pending_metadata(cmd, proposal, feature_flags={}) is None
+    assert AdjustPrescriptionParser().pending_metadata(cmd, proposal, feature_flags=None) is None
+    assert (
+        AdjustPrescriptionParser().pending_metadata(cmd, proposal, feature_flags={"AlertFacilityEnabled": False})
+        is None
+    )
+
+
+def test_pending_metadata_flag_on_alert_truthy_returns_yes() -> None:
+    cmd = _make_rx_command()
+    proposal = {"data": {"alert_facility": True}}
+    result = AdjustPrescriptionParser().pending_metadata(cmd, proposal, feature_flags={"AlertFacilityEnabled": True})
+    assert result == {
+        "command_uuid": cmd.command_uuid,
+        "command_type": "adjust_prescription",
+        "note_uuid": cmd.note_uuid,
+        "metadata": {"alert_facility": "Yes"},
+    }
+
+
+def test_pending_metadata_flag_on_explicit_false_returns_no() -> None:
+    cmd = _make_rx_command()
+    result = AdjustPrescriptionParser().pending_metadata(
+        cmd, {"data": {"alert_facility": False}}, feature_flags={"AlertFacilityEnabled": True}
+    )
+    assert result is not None
+    assert result["metadata"] == {"alert_facility": "No"}
+
+
+def test_pending_metadata_flag_on_defaults_to_yes_when_unset() -> None:
+    cmd = _make_rx_command()
+    for proposal in (
+        {"data": {"alert_facility": True}},
+        {"data": {}},
+        None,
+    ):
+        result = AdjustPrescriptionParser().pending_metadata(
+            cmd, proposal, feature_flags={"AlertFacilityEnabled": True}
+        )
+        assert result is not None
+        assert result["metadata"] == {"alert_facility": "Yes"}

--- a/tests/hyperscribe/scribe/commands/test_alert_facility.py
+++ b/tests/hyperscribe/scribe/commands/test_alert_facility.py
@@ -1,0 +1,42 @@
+from hyperscribe.scribe.commands._alert_facility import (
+    COMMAND_TYPE_BY_SCHEMA_KEY,
+    DEFAULT_ON_BY_COMMAND_TYPE,
+    SCHEMA_KEY_BY_COMMAND_TYPE,
+    SUPPORTED_COMMAND_TYPES,
+    parse_alert_facility_commands,
+)
+
+
+def test_supported_command_types_match_maps() -> None:
+    assert SUPPORTED_COMMAND_TYPES == frozenset(SCHEMA_KEY_BY_COMMAND_TYPE)
+    assert SUPPORTED_COMMAND_TYPES == frozenset(DEFAULT_ON_BY_COMMAND_TYPE)
+    # Reverse map is a true inverse.
+    assert COMMAND_TYPE_BY_SCHEMA_KEY == {v: k for k, v in SCHEMA_KEY_BY_COMMAND_TYPE.items()}
+
+
+def test_schema_key_mapping_is_camelcase() -> None:
+    assert SCHEMA_KEY_BY_COMMAND_TYPE["adjust_prescription"] == "adjustPrescription"
+    assert SCHEMA_KEY_BY_COMMAND_TYPE["medication_statement"] == "medicationStatement"
+    assert SCHEMA_KEY_BY_COMMAND_TYPE["stop_medication"] == "stopMedication"
+
+
+def test_parse_none_and_empty() -> None:
+    assert parse_alert_facility_commands(None) == set()
+    assert parse_alert_facility_commands("") == set()
+    assert parse_alert_facility_commands("   ") == set()
+    assert parse_alert_facility_commands(",, ,") == set()
+
+
+def test_parse_splits_trims_and_lowercases() -> None:
+    assert parse_alert_facility_commands(" Prescribe , REFILL ") == {"prescribe", "refill"}
+
+
+def test_parse_drops_unknown_and_keeps_supported() -> None:
+    assert parse_alert_facility_commands("prescribe,bogus,stop_medication") == {"prescribe", "stop_medication"}
+    # A camelCase schema_key is NOT a valid command_type entry.
+    assert parse_alert_facility_commands("adjustPrescription") == set()
+
+
+def test_parse_all_supported() -> None:
+    raw = "prescribe,adjust_prescription,refill,medication_statement,stop_medication"
+    assert parse_alert_facility_commands(raw) == set(SUPPORTED_COMMAND_TYPES)

--- a/tests/hyperscribe/scribe/commands/test_builder.py
+++ b/tests/hyperscribe/scribe/commands/test_builder.py
@@ -345,11 +345,11 @@ def test_build_effects_medication_with_alert_facility_emits_yes_inline() -> None
 
 
 def test_build_effects_medication_alert_facility_false_writes_no_inline() -> None:
-    """Flag on + alert_facility falsy: still emits inline metadata, value="No"."""
+    """Flag on + alert_facility explicitly False: emits inline metadata, value="No"."""
     proposals: list[dict[str, Any]] = [
         {
             "command_type": "medication_statement",
-            "data": {"medication_text": "Lisinopril 10mg"},
+            "data": {"medication_text": "Lisinopril 10mg", "alert_facility": False},
         },
     ]
     with patch("hyperscribe.scribe.commands.medication_statement.MedicationStatementCommand") as mock_med:

--- a/tests/hyperscribe/scribe/commands/test_builder.py
+++ b/tests/hyperscribe/scribe/commands/test_builder.py
@@ -1199,6 +1199,103 @@ def test_build_amend_edit_effects_hpi_void_and_recreate() -> None:
     assert attempted[0]["new_command_uuid"] == minted_uuid
 
 
+def test_build_amend_edit_effects_medication_statement_reemits_alert_facility_metadata() -> None:
+    """Amending a medication_statement (void+recreate) re-emits the Alert Facility
+    metadata for the recreated command, ordered originate -> metadata -> commit.
+
+    Regression guard: without threading ``feature_flags`` into ``pending_metadata``,
+    the recreated command committed with NO alert_facility metadata row, so every
+    read path (reconcile + /note-commands) treated it as pre-feature and silently
+    dropped a value that was genuinely recorded on the original.
+    """
+    proposals: list[dict[str, Any]] = [
+        {
+            "command_type": "medication_statement",
+            "command_uuid": "old-med-uuid-aaaa-bbbb-cccccccccccc",
+            "section_key": "current_medications",
+            "data": {"medication_text": "Lisinopril 10mg", "alert_facility": True},
+            "display": "Lisinopril 10mg",
+        },
+    ]
+    minted_uuid = "fresh-med-uuid-1111-2222-3333-444444444444"
+    with (
+        patch("hyperscribe.scribe.commands.medication_statement.MedicationStatementCommand") as mock_med,
+        patch("hyperscribe.scribe.commands.builder.uuid.uuid4", return_value=minted_uuid),
+    ):
+        old_inst = MagicMock()
+        old_inst.enter_in_error.return_value = "med_enter_in_error"
+        old_inst.command_uuid = "old-med-uuid-aaaa-bbbb-cccccccccccc"
+        new_inst = MagicMock()
+        new_inst.originate.return_value = "med_originate"
+        new_inst.commit.return_value = "med_commit"
+        new_inst.command_uuid = minted_uuid
+        new_inst.note_uuid = "5899e7bf-5ecb-4399-aceb-0e233bd4a8f0"
+        new_inst.Meta.key = "medicationStatement"
+        mock_med.side_effect = [old_inst, new_inst]
+
+        effects, attempted = build_amend_edit_effects(
+            proposals,
+            "5899e7bf-5ecb-4399-aceb-0e233bd4a8f0",
+            feature_flags={"AlertFacilityCommands": {"medication_statement"}},
+        )
+
+    # EIE(old) -> Originate(new) -> metadata(new) -> Commit(new): metadata lands
+    # after originate (row exists) and before commit (attaches while STAGED).
+    assert len(effects) == 4
+    assert effects[0] == "med_enter_in_error"
+    assert effects[1] == "med_originate"
+    assert effects[3] == "med_commit"
+    meta_effect = effects[2]
+    assert EffectType.Name(meta_effect.type) == "UPSERT_COMMAND_METADATA"
+    assert json.loads(meta_effect.payload) == {
+        "data": {
+            "schema_key": "medicationStatement",
+            "command_id": minted_uuid,  # the RECREATED command carries the metadata
+            "key": "alert_facility",
+            "value": "Yes",
+        },
+    }
+    assert attempted[0]["mode"] == "void_recreate"
+    assert attempted[0]["new_command_uuid"] == minted_uuid
+
+
+@pytest.mark.parametrize("feature_flags", [{"AlertFacilityCommands": set()}, None])
+def test_build_amend_edit_effects_no_alert_facility_metadata_when_gated_off(
+    feature_flags: dict[str, Any] | None,
+) -> None:
+    """The amend re-emit is gated by AlertFacilityCommands (and by feature_flags
+    being threaded at all): with an empty allow-set — or no feature_flags — a
+    void+recreate emits NO metadata effect, only EIE + originate + commit."""
+    proposals: list[dict[str, Any]] = [
+        {
+            "command_type": "medication_statement",
+            "command_uuid": "old-med-uuid-aaaa-bbbb-cccccccccccc",
+            "section_key": "current_medications",
+            "data": {"medication_text": "Lisinopril 10mg", "alert_facility": True},
+            "display": "Lisinopril 10mg",
+        },
+    ]
+    with (
+        patch("hyperscribe.scribe.commands.medication_statement.MedicationStatementCommand") as mock_med,
+        patch("hyperscribe.scribe.commands.builder.uuid.uuid4", return_value="fresh-med-uuid"),
+    ):
+        old_inst = MagicMock()
+        old_inst.enter_in_error.return_value = "med_enter_in_error"
+        new_inst = MagicMock()
+        new_inst.originate.return_value = "med_originate"
+        new_inst.commit.return_value = "med_commit"
+        mock_med.side_effect = [old_inst, new_inst]
+
+        effects, attempted = build_amend_edit_effects(
+            proposals,
+            "5899e7bf-5ecb-4399-aceb-0e233bd4a8f0",
+            feature_flags=feature_flags,
+        )
+
+    assert effects == ["med_enter_in_error", "med_originate", "med_commit"]
+    assert attempted[0]["mode"] == "void_recreate"
+
+
 def test_build_amend_edit_effects_covers_all_void_recreate_sections() -> None:
     """All non-RFV editable sections route through EnterInError(old) +
     Originate(new), with an optional Commit(new) for dedicated-SDK-class

--- a/tests/hyperscribe/scribe/commands/test_builder.py
+++ b/tests/hyperscribe/scribe/commands/test_builder.py
@@ -323,7 +323,7 @@ def test_build_effects_medication_with_alert_facility_emits_yes_inline() -> None
         effects, metadata_pending, attempted, build_errors = build_effects(
             proposals,
             "5899e7bf-5ecb-4399-aceb-0e233bd4a8f0",
-            feature_flags={"AlertFacilityEnabled": True},
+            feature_flags={"AlertFacilityCommands": {"medication_statement"}},
         )
 
     assert len(effects) == 3
@@ -364,7 +364,7 @@ def test_build_effects_medication_alert_facility_false_writes_no_inline() -> Non
         effects, metadata_pending, attempted, build_errors = build_effects(
             proposals,
             "5899e7bf-5ecb-4399-aceb-0e233bd4a8f0",
-            feature_flags={"AlertFacilityEnabled": True},
+            feature_flags={"AlertFacilityCommands": {"medication_statement"}},
         )
 
     assert len(effects) == 3
@@ -391,7 +391,7 @@ def test_build_effects_medication_alert_facility_flag_off_no_metadata() -> None:
         effects, metadata_pending, attempted, build_errors = build_effects(
             proposals,
             "5899e7bf-5ecb-4399-aceb-0e233bd4a8f0",
-            feature_flags={"AlertFacilityEnabled": False},
+            feature_flags={"AlertFacilityCommands": set()},
         )
 
     assert len(effects) == 2

--- a/tests/hyperscribe/scribe/commands/test_medication_statement.py
+++ b/tests/hyperscribe/scribe/commands/test_medication_statement.py
@@ -269,13 +269,22 @@ def test_pending_metadata_flag_on_alert_truthy_returns_yes() -> None:
     }
 
 
-def test_pending_metadata_flag_on_alert_falsy_defaults_to_no() -> None:
+def test_pending_metadata_flag_on_explicit_false_returns_no() -> None:
+    cmd = _make_med_command()
+    result = MedicationParser().pending_metadata(
+        cmd, {"data": {"alert_facility": False}}, feature_flags={"AlertFacilityEnabled": True}
+    )
+    assert result is not None
+    assert result["metadata"] == {"alert_facility": "No"}
+
+
+def test_pending_metadata_flag_on_defaults_to_yes_when_unset() -> None:
     cmd = _make_med_command()
     for proposal in (
-        {"data": {"alert_facility": False}},
+        {"data": {"alert_facility": True}},
         {"data": {}},
         None,
     ):
         result = MedicationParser().pending_metadata(cmd, proposal, feature_flags={"AlertFacilityEnabled": True})
         assert result is not None
-        assert result["metadata"] == {"alert_facility": "No"}
+        assert result["metadata"] == {"alert_facility": "Yes"}

--- a/tests/hyperscribe/scribe/commands/test_medication_statement.py
+++ b/tests/hyperscribe/scribe/commands/test_medication_statement.py
@@ -254,13 +254,18 @@ def test_pending_metadata_flag_off_returns_none() -> None:
     proposal = {"data": {"alert_facility": True}}
     assert MedicationParser().pending_metadata(cmd, proposal, feature_flags={}) is None
     assert MedicationParser().pending_metadata(cmd, proposal, feature_flags=None) is None
-    assert MedicationParser().pending_metadata(cmd, proposal, feature_flags={"AlertFacilityEnabled": False}) is None
+    assert (
+        MedicationParser().pending_metadata(cmd, proposal, feature_flags={"AlertFacilityCommands": {"prescribe"}})
+        is None
+    )
 
 
 def test_pending_metadata_flag_on_alert_truthy_returns_yes() -> None:
     cmd = _make_med_command()
     proposal = {"data": {"alert_facility": True}}
-    result = MedicationParser().pending_metadata(cmd, proposal, feature_flags={"AlertFacilityEnabled": True})
+    result = MedicationParser().pending_metadata(
+        cmd, proposal, feature_flags={"AlertFacilityCommands": {"medication_statement"}}
+    )
     assert result == {
         "command_uuid": cmd.command_uuid,
         "command_type": "medication_statement",
@@ -272,7 +277,7 @@ def test_pending_metadata_flag_on_alert_truthy_returns_yes() -> None:
 def test_pending_metadata_flag_on_explicit_false_returns_no() -> None:
     cmd = _make_med_command()
     result = MedicationParser().pending_metadata(
-        cmd, {"data": {"alert_facility": False}}, feature_flags={"AlertFacilityEnabled": True}
+        cmd, {"data": {"alert_facility": False}}, feature_flags={"AlertFacilityCommands": {"medication_statement"}}
     )
     assert result is not None
     assert result["metadata"] == {"alert_facility": "No"}
@@ -280,7 +285,7 @@ def test_pending_metadata_flag_on_explicit_false_returns_no() -> None:
 
 def test_pending_metadata_flag_on_defaults_to_no_when_unset() -> None:
     cmd = _make_med_command()
-    flags = {"AlertFacilityEnabled": True}
+    flags = {"AlertFacilityCommands": {"medication_statement"}}
     # Explicit True still records Yes.
     assert MedicationParser().pending_metadata(cmd, {"data": {"alert_facility": True}}, flags)["metadata"] == {
         "alert_facility": "Yes"

--- a/tests/hyperscribe/scribe/commands/test_medication_statement.py
+++ b/tests/hyperscribe/scribe/commands/test_medication_statement.py
@@ -278,13 +278,15 @@ def test_pending_metadata_flag_on_explicit_false_returns_no() -> None:
     assert result["metadata"] == {"alert_facility": "No"}
 
 
-def test_pending_metadata_flag_on_defaults_to_yes_when_unset() -> None:
+def test_pending_metadata_flag_on_defaults_to_no_when_unset() -> None:
     cmd = _make_med_command()
-    for proposal in (
-        {"data": {"alert_facility": True}},
-        {"data": {}},
-        None,
-    ):
-        result = MedicationParser().pending_metadata(cmd, proposal, feature_flags={"AlertFacilityEnabled": True})
+    flags = {"AlertFacilityEnabled": True}
+    # Explicit True still records Yes.
+    assert MedicationParser().pending_metadata(cmd, {"data": {"alert_facility": True}}, flags)["metadata"] == {
+        "alert_facility": "Yes"
+    }
+    # Medication statement defaults to No when the value is unset.
+    for proposal in ({"data": {}}, None):
+        result = MedicationParser().pending_metadata(cmd, proposal, flags)
         assert result is not None
-        assert result["metadata"] == {"alert_facility": "Yes"}
+        assert result["metadata"] == {"alert_facility": "No"}

--- a/tests/hyperscribe/scribe/commands/test_prescription.py
+++ b/tests/hyperscribe/scribe/commands/test_prescription.py
@@ -218,3 +218,51 @@ def test_build_invalid_quantity_ignored() -> None:
         parser.build(data, "note-uuid", "cmd-uuid")
 
     assert mock_cmd.call_args.kwargs["quantity_to_dispense"] is None
+
+
+def _make_rx_command() -> MagicMock:
+    cmd = MagicMock()
+    cmd.command_uuid = "00000000-0000-0000-0000-0000000000c1"
+    cmd.note_uuid = "00000000-0000-0000-0000-0000000000cc"
+    return cmd
+
+
+def test_pending_metadata_flag_off_returns_none() -> None:
+    cmd = _make_rx_command()
+    proposal = {"data": {"alert_facility": True}}
+    assert PrescriptionParser().pending_metadata(cmd, proposal, feature_flags={}) is None
+    assert PrescriptionParser().pending_metadata(cmd, proposal, feature_flags=None) is None
+    assert PrescriptionParser().pending_metadata(cmd, proposal, feature_flags={"AlertFacilityEnabled": False}) is None
+
+
+def test_pending_metadata_flag_on_alert_truthy_returns_yes() -> None:
+    cmd = _make_rx_command()
+    proposal = {"data": {"alert_facility": True}}
+    result = PrescriptionParser().pending_metadata(cmd, proposal, feature_flags={"AlertFacilityEnabled": True})
+    assert result == {
+        "command_uuid": cmd.command_uuid,
+        "command_type": "prescribe",
+        "note_uuid": cmd.note_uuid,
+        "metadata": {"alert_facility": "Yes"},
+    }
+
+
+def test_pending_metadata_flag_on_explicit_false_returns_no() -> None:
+    cmd = _make_rx_command()
+    result = PrescriptionParser().pending_metadata(
+        cmd, {"data": {"alert_facility": False}}, feature_flags={"AlertFacilityEnabled": True}
+    )
+    assert result is not None
+    assert result["metadata"] == {"alert_facility": "No"}
+
+
+def test_pending_metadata_flag_on_defaults_to_yes_when_unset() -> None:
+    cmd = _make_rx_command()
+    for proposal in (
+        {"data": {"alert_facility": True}},
+        {"data": {}},
+        None,
+    ):
+        result = PrescriptionParser().pending_metadata(cmd, proposal, feature_flags={"AlertFacilityEnabled": True})
+        assert result is not None
+        assert result["metadata"] == {"alert_facility": "Yes"}

--- a/tests/hyperscribe/scribe/commands/test_prescription.py
+++ b/tests/hyperscribe/scribe/commands/test_prescription.py
@@ -232,13 +232,18 @@ def test_pending_metadata_flag_off_returns_none() -> None:
     proposal = {"data": {"alert_facility": True}}
     assert PrescriptionParser().pending_metadata(cmd, proposal, feature_flags={}) is None
     assert PrescriptionParser().pending_metadata(cmd, proposal, feature_flags=None) is None
-    assert PrescriptionParser().pending_metadata(cmd, proposal, feature_flags={"AlertFacilityEnabled": False}) is None
+    assert (
+        PrescriptionParser().pending_metadata(cmd, proposal, feature_flags={"AlertFacilityCommands": {"refill"}})
+        is None
+    )
 
 
 def test_pending_metadata_flag_on_alert_truthy_returns_yes() -> None:
     cmd = _make_rx_command()
     proposal = {"data": {"alert_facility": True}}
-    result = PrescriptionParser().pending_metadata(cmd, proposal, feature_flags={"AlertFacilityEnabled": True})
+    result = PrescriptionParser().pending_metadata(
+        cmd, proposal, feature_flags={"AlertFacilityCommands": {"prescribe"}}
+    )
     assert result == {
         "command_uuid": cmd.command_uuid,
         "command_type": "prescribe",
@@ -250,7 +255,7 @@ def test_pending_metadata_flag_on_alert_truthy_returns_yes() -> None:
 def test_pending_metadata_flag_on_explicit_false_returns_no() -> None:
     cmd = _make_rx_command()
     result = PrescriptionParser().pending_metadata(
-        cmd, {"data": {"alert_facility": False}}, feature_flags={"AlertFacilityEnabled": True}
+        cmd, {"data": {"alert_facility": False}}, feature_flags={"AlertFacilityCommands": {"prescribe"}}
     )
     assert result is not None
     assert result["metadata"] == {"alert_facility": "No"}
@@ -263,6 +268,8 @@ def test_pending_metadata_flag_on_defaults_to_yes_when_unset() -> None:
         {"data": {}},
         None,
     ):
-        result = PrescriptionParser().pending_metadata(cmd, proposal, feature_flags={"AlertFacilityEnabled": True})
+        result = PrescriptionParser().pending_metadata(
+            cmd, proposal, feature_flags={"AlertFacilityCommands": {"prescribe"}}
+        )
         assert result is not None
         assert result["metadata"] == {"alert_facility": "Yes"}

--- a/tests/hyperscribe/scribe/commands/test_refill.py
+++ b/tests/hyperscribe/scribe/commands/test_refill.py
@@ -10,7 +10,7 @@ returned 200 but REVIEW raised ``ValidationError``.
 from __future__ import annotations
 
 from typing import Any
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -97,3 +97,51 @@ def test_validate_against_patient_rejects_when_medication_inactive() -> None:
 
 def test_command_type() -> None:
     assert RefillParser().command_type == "refill"
+
+
+def _make_rx_command() -> MagicMock:
+    cmd = MagicMock()
+    cmd.command_uuid = "00000000-0000-0000-0000-0000000000e1"
+    cmd.note_uuid = "00000000-0000-0000-0000-0000000000ee"
+    return cmd
+
+
+def test_pending_metadata_flag_off_returns_none() -> None:
+    cmd = _make_rx_command()
+    proposal = {"data": {"alert_facility": True}}
+    assert RefillParser().pending_metadata(cmd, proposal, feature_flags={}) is None
+    assert RefillParser().pending_metadata(cmd, proposal, feature_flags=None) is None
+    assert RefillParser().pending_metadata(cmd, proposal, feature_flags={"AlertFacilityEnabled": False}) is None
+
+
+def test_pending_metadata_flag_on_alert_truthy_returns_yes() -> None:
+    cmd = _make_rx_command()
+    proposal = {"data": {"alert_facility": True}}
+    result = RefillParser().pending_metadata(cmd, proposal, feature_flags={"AlertFacilityEnabled": True})
+    assert result == {
+        "command_uuid": cmd.command_uuid,
+        "command_type": "refill",
+        "note_uuid": cmd.note_uuid,
+        "metadata": {"alert_facility": "Yes"},
+    }
+
+
+def test_pending_metadata_flag_on_explicit_false_returns_no() -> None:
+    cmd = _make_rx_command()
+    result = RefillParser().pending_metadata(
+        cmd, {"data": {"alert_facility": False}}, feature_flags={"AlertFacilityEnabled": True}
+    )
+    assert result is not None
+    assert result["metadata"] == {"alert_facility": "No"}
+
+
+def test_pending_metadata_flag_on_defaults_to_yes_when_unset() -> None:
+    cmd = _make_rx_command()
+    for proposal in (
+        {"data": {"alert_facility": True}},
+        {"data": {}},
+        None,
+    ):
+        result = RefillParser().pending_metadata(cmd, proposal, feature_flags={"AlertFacilityEnabled": True})
+        assert result is not None
+        assert result["metadata"] == {"alert_facility": "Yes"}

--- a/tests/hyperscribe/scribe/commands/test_refill.py
+++ b/tests/hyperscribe/scribe/commands/test_refill.py
@@ -111,13 +111,15 @@ def test_pending_metadata_flag_off_returns_none() -> None:
     proposal = {"data": {"alert_facility": True}}
     assert RefillParser().pending_metadata(cmd, proposal, feature_flags={}) is None
     assert RefillParser().pending_metadata(cmd, proposal, feature_flags=None) is None
-    assert RefillParser().pending_metadata(cmd, proposal, feature_flags={"AlertFacilityEnabled": False}) is None
+    assert (
+        RefillParser().pending_metadata(cmd, proposal, feature_flags={"AlertFacilityCommands": {"prescribe"}}) is None
+    )
 
 
 def test_pending_metadata_flag_on_alert_truthy_returns_yes() -> None:
     cmd = _make_rx_command()
     proposal = {"data": {"alert_facility": True}}
-    result = RefillParser().pending_metadata(cmd, proposal, feature_flags={"AlertFacilityEnabled": True})
+    result = RefillParser().pending_metadata(cmd, proposal, feature_flags={"AlertFacilityCommands": {"refill"}})
     assert result == {
         "command_uuid": cmd.command_uuid,
         "command_type": "refill",
@@ -129,7 +131,7 @@ def test_pending_metadata_flag_on_alert_truthy_returns_yes() -> None:
 def test_pending_metadata_flag_on_explicit_false_returns_no() -> None:
     cmd = _make_rx_command()
     result = RefillParser().pending_metadata(
-        cmd, {"data": {"alert_facility": False}}, feature_flags={"AlertFacilityEnabled": True}
+        cmd, {"data": {"alert_facility": False}}, feature_flags={"AlertFacilityCommands": {"refill"}}
     )
     assert result is not None
     assert result["metadata"] == {"alert_facility": "No"}
@@ -137,7 +139,7 @@ def test_pending_metadata_flag_on_explicit_false_returns_no() -> None:
 
 def test_pending_metadata_flag_on_defaults_to_no_when_unset() -> None:
     cmd = _make_rx_command()
-    flags = {"AlertFacilityEnabled": True}
+    flags = {"AlertFacilityCommands": {"refill"}}
     # Explicit True still records Yes.
     assert RefillParser().pending_metadata(cmd, {"data": {"alert_facility": True}}, flags)["metadata"] == {
         "alert_facility": "Yes"

--- a/tests/hyperscribe/scribe/commands/test_refill.py
+++ b/tests/hyperscribe/scribe/commands/test_refill.py
@@ -135,13 +135,15 @@ def test_pending_metadata_flag_on_explicit_false_returns_no() -> None:
     assert result["metadata"] == {"alert_facility": "No"}
 
 
-def test_pending_metadata_flag_on_defaults_to_yes_when_unset() -> None:
+def test_pending_metadata_flag_on_defaults_to_no_when_unset() -> None:
     cmd = _make_rx_command()
-    for proposal in (
-        {"data": {"alert_facility": True}},
-        {"data": {}},
-        None,
-    ):
-        result = RefillParser().pending_metadata(cmd, proposal, feature_flags={"AlertFacilityEnabled": True})
+    flags = {"AlertFacilityEnabled": True}
+    # Explicit True still records Yes.
+    assert RefillParser().pending_metadata(cmd, {"data": {"alert_facility": True}}, flags)["metadata"] == {
+        "alert_facility": "Yes"
+    }
+    # Refill defaults to No when the value is unset.
+    for proposal in ({"data": {}}, None):
+        result = RefillParser().pending_metadata(cmd, proposal, flags)
         assert result is not None
-        assert result["metadata"] == {"alert_facility": "Yes"}
+        assert result["metadata"] == {"alert_facility": "No"}

--- a/tests/hyperscribe/scribe/commands/test_stop_medication.py
+++ b/tests/hyperscribe/scribe/commands/test_stop_medication.py
@@ -62,13 +62,18 @@ def test_pending_metadata_flag_off_returns_none() -> None:
     proposal = {"data": {"alert_facility": True}}
     assert StopMedicationParser().pending_metadata(cmd, proposal, feature_flags={}) is None
     assert StopMedicationParser().pending_metadata(cmd, proposal, feature_flags=None) is None
-    assert StopMedicationParser().pending_metadata(cmd, proposal, feature_flags={"AlertFacilityEnabled": False}) is None
+    assert (
+        StopMedicationParser().pending_metadata(cmd, proposal, feature_flags={"AlertFacilityCommands": {"prescribe"}})
+        is None
+    )
 
 
 def test_pending_metadata_flag_on_alert_truthy_returns_yes() -> None:
     cmd = _make_stop_command()
     proposal = {"data": {"alert_facility": True}}
-    result = StopMedicationParser().pending_metadata(cmd, proposal, feature_flags={"AlertFacilityEnabled": True})
+    result = StopMedicationParser().pending_metadata(
+        cmd, proposal, feature_flags={"AlertFacilityCommands": {"stop_medication"}}
+    )
     assert result == {
         "command_uuid": cmd.command_uuid,
         "command_type": "stop_medication",
@@ -80,7 +85,7 @@ def test_pending_metadata_flag_on_alert_truthy_returns_yes() -> None:
 def test_pending_metadata_flag_on_explicit_false_returns_no() -> None:
     cmd = _make_stop_command()
     result = StopMedicationParser().pending_metadata(
-        cmd, {"data": {"alert_facility": False}}, feature_flags={"AlertFacilityEnabled": True}
+        cmd, {"data": {"alert_facility": False}}, feature_flags={"AlertFacilityCommands": {"stop_medication"}}
     )
     assert result is not None
     assert result["metadata"] == {"alert_facility": "No"}
@@ -88,7 +93,7 @@ def test_pending_metadata_flag_on_explicit_false_returns_no() -> None:
 
 def test_pending_metadata_flag_on_defaults_to_no_when_unset() -> None:
     cmd = _make_stop_command()
-    flags = {"AlertFacilityEnabled": True}
+    flags = {"AlertFacilityCommands": {"stop_medication"}}
     # Explicit True still records Yes.
     assert StopMedicationParser().pending_metadata(cmd, {"data": {"alert_facility": True}}, flags)["metadata"] == {
         "alert_facility": "Yes"

--- a/tests/hyperscribe/scribe/commands/test_stop_medication.py
+++ b/tests/hyperscribe/scribe/commands/test_stop_medication.py
@@ -77,13 +77,22 @@ def test_pending_metadata_flag_on_alert_truthy_returns_yes() -> None:
     }
 
 
-def test_pending_metadata_flag_on_alert_falsy_defaults_to_no() -> None:
+def test_pending_metadata_flag_on_explicit_false_returns_no() -> None:
+    cmd = _make_stop_command()
+    result = StopMedicationParser().pending_metadata(
+        cmd, {"data": {"alert_facility": False}}, feature_flags={"AlertFacilityEnabled": True}
+    )
+    assert result is not None
+    assert result["metadata"] == {"alert_facility": "No"}
+
+
+def test_pending_metadata_flag_on_defaults_to_yes_when_unset() -> None:
     cmd = _make_stop_command()
     for proposal in (
-        {"data": {"alert_facility": False}},
+        {"data": {"alert_facility": True}},
         {"data": {}},
         None,
     ):
         result = StopMedicationParser().pending_metadata(cmd, proposal, feature_flags={"AlertFacilityEnabled": True})
         assert result is not None
-        assert result["metadata"] == {"alert_facility": "No"}
+        assert result["metadata"] == {"alert_facility": "Yes"}

--- a/tests/hyperscribe/scribe/commands/test_stop_medication.py
+++ b/tests/hyperscribe/scribe/commands/test_stop_medication.py
@@ -86,13 +86,15 @@ def test_pending_metadata_flag_on_explicit_false_returns_no() -> None:
     assert result["metadata"] == {"alert_facility": "No"}
 
 
-def test_pending_metadata_flag_on_defaults_to_yes_when_unset() -> None:
+def test_pending_metadata_flag_on_defaults_to_no_when_unset() -> None:
     cmd = _make_stop_command()
-    for proposal in (
-        {"data": {"alert_facility": True}},
-        {"data": {}},
-        None,
-    ):
-        result = StopMedicationParser().pending_metadata(cmd, proposal, feature_flags={"AlertFacilityEnabled": True})
+    flags = {"AlertFacilityEnabled": True}
+    # Explicit True still records Yes.
+    assert StopMedicationParser().pending_metadata(cmd, {"data": {"alert_facility": True}}, flags)["metadata"] == {
+        "alert_facility": "Yes"
+    }
+    # Stop medication defaults to No when the value is unset.
+    for proposal in ({"data": {}}, None):
+        result = StopMedicationParser().pending_metadata(cmd, proposal, flags)
         assert result is not None
-        assert result["metadata"] == {"alert_facility": "Yes"}
+        assert result["metadata"] == {"alert_facility": "No"}


### PR DESCRIPTION
## Summary

Extends **Alert Facility** to the **prescribe**, **adjust prescription**, and **refill** commands, and — through review — hardens the whole feature across all five supported commands (those three plus **medication statement** and **stop medication**): a clean display treatment, per-command-type defaults, a per-command allow-list secret, and strict backwards-compatibility so historical notes are never altered.

This is the **producer** side; the companion validation plugin ([Medical-Software-Foundation/canvas#417](https://github.com/Medical-Software-Foundation/canvas/pull/417)) enforces the field on the Canvas side for these schema keys.

## What's included

**1. Extend to prescribe / adjust prescription / refill**
- `pending_metadata` added to the three Rx parsers; `build_effects` emits the `alert_facility` command metadata via the existing generic path.

**2. Display treatment**
- Replaced the amber full-width pill with a neutral `Alert Facility: Yes/No` line matching the order details line. Shown consistently in recommendation, documented, and committed states (incl. the flat ADDITIONAL COMMANDS cards, read back from `CommandMetadata`). Fixed stop_medication rendering the flag on the right.

**3. Per-command-type defaults**
- Prescribe & adjust prescription default **Yes**; refill, medication statement & stop medication default **No**. Applies to the toggle's starting position, the value recorded at commit, and freshly generated cards (so a new card shows its default without being opened). An explicit stored value always wins.

**4. Per-command gating via a plugin secret**
- Replaced the global boolean `AlertFacilityEnabled` with **`AlertFacilityCommands`** — a comma-separated allow-list of command types (matching the `ScribeNoteTypes` convention). A command shows the toggle only when its `command_type` is in the list; empty/unset = off everywhere. New shared module `hyperscribe/scribe/commands/_alert_facility.py` is the single source of truth (supported types, schema-key map, per-type defaults, parser).

**5. Backwards compatibility (historical notes untouched)**
- Display shows a value **only when one is genuinely recorded** — never a fabricated default. For committed/locked notes the source of truth is the committed `CommandMetadata`: `_load_summary` reconciles the cache against it, so a pre-feature command with no committed value shows **no** line, while a command with a committed value shows it. `handleSave` no longer fabricates a value on unrelated edits.

**6. Review hardening — make the reconcile invariant complete & uniform**
- **Amend re-emits metadata.** `build_amend_edit_effects` now takes `feature_flags` and re-emits `pending_metadata` for the void+recreated command (ordered originate -> metadata -> commit, mirroring `build_effects`). Previously an amended `medication_statement` / `stop_medication` committed with no `alert_facility` row, so both read paths treated it as pre-feature and **silently dropped a genuinely-recorded value**. No-op for types without pending metadata or when gated off.
- **Recommendations reconciled symmetrically.** `_inject` stamps a per-type default onto recommendations as well as commands, but `_load_summary` only reconciled commands. It now reconciles **both** surfaces, so a committed recommendation shows its true committed value (or nothing when pre-feature); unaccepted recommendations have no committed `command_uuid` and keep their in-flight default.

## Behavior matrix
- **New card** -> shows its per-type default (even unopened); records that value at commit.
- **Explicitly toggled** -> shows/records the chosen value.
- **Committed + no metadata (pre-feature / locked)** -> no Alert Facility line.
- **Command type not in `AlertFacilityCommands`** -> no toggle, no line, no record.

## Migration
`AlertFacilityEnabled` is removed. Set `AlertFacilityCommands` in every environment to the desired command types (e.g. `prescribe,adjust_prescription,refill,medication_statement,stop_medication` for all on). The old secret has no effect.

## Tests
- Parser `pending_metadata` (per-type default / explicit / allow-set gating) for all five commands.
- `build_effects` inline metadata emission.
- `_alert_facility` parser/maps; generation-time default injection; `/note-commands` allow-list + metadata gating.
- `_load_summary` committed-record reconciliation (set / strip / preserve / add; empty + disallowed no-ops), now also covering the **recommendations** surface.
- Amend re-emits `alert_facility` metadata for the recreated command (exact `UPSERT_COMMAND_METADATA` payload) + gating (empty allow-set / no `feature_flags` -> no metadata effect).
- Frontend source-pin tests for the display gates, touched-gated save, and per-command `.has()` gating.
- Full suite green — 2918 passed (ruff + mypy + pytest via pre-commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

