### PR TITLE
feat(scribe): retire accept/reject on condition cards — pick a code to accept, ✕ to dismiss

### DIFF
--- a/hyperscribe/CANVAS_MANIFEST.json
+++ b/hyperscribe/CANVAS_MANIFEST.json
@@ -1,6 +1,6 @@
 {
   "sdk_version": "0.155.0",
-  "plugin_version": "2026-07-07 v0.4.40",
+  "plugin_version": "2026-07-27 v0.4.41",
   "name": "hyperscribe",
   "description": "Create commands based on the content of an audio discussion between a patient and a provider.",
   "url_permissions": [

--- a/hyperscribe/scribe/static/diagnose-row.js
+++ b/hyperscribe/scribe/static/diagnose-row.js
@@ -6,7 +6,10 @@ const html = htm.bind(h);
 
 const ICON_PENCIL = html`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 20h9"/><path d="M16.5 3.5a2.1 2.1 0 0 1 3 3L7 19l-4 1 1-4Z"/></svg>`;
 const ICON_SEARCH = html`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="7"/><line x1="20" y1="20" x2="16.65" y2="16.65"/></svg>`;
-const ICON_X = html`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="6" y1="6" x2="18" y2="18"/><line x1="6" y1="18" x2="18" y2="6"/></svg>`;
+// Revert arrow for the picker menu's "Keep current diagnosis" item. (The picker's own ✕
+// close button is gone — that menu item replaces it, so there is exactly one ✕ on a card
+// and it unambiguously means "dismiss this condition".)
+const ICON_REVERT = html`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 14 4 9l5-5"/><path d="M4 9h11a5 5 0 0 1 0 10h-3"/></svg>`;
 // Vertical ⋮ for the search-bar overflow menu, and a "move to a list/section" glyph for its item.
 const ICON_DOTS = html`<svg viewBox="0 0 24 24" fill="currentColor"><circle cx="12" cy="5" r="1.6"/><circle cx="12" cy="12" r="1.6"/><circle cx="12" cy="19" r="1.6"/></svg>`;
 const ICON_MOVE = html`<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 7h11"/><path d="M4 12h11"/><path d="M4 17h7"/><path d="M15 15l4 2-4 2"/></svg>`;
@@ -30,7 +33,7 @@ function formatIcdCode(raw) {
   return code.length > 3 ? code.slice(0, 3) + '.' + code.slice(3) : code;
 }
 
-export function DiagnoseRow({ command, commandIndex, onEdit, onMoveToPlan, readOnly, suggestions, onEditingChange }) {
+export function DiagnoseRow({ command, commandIndex, onEdit, onMoveToPlan, readOnly, suggestions, onEditingChange, dismissed = false, dismissedRestorable = false }) {
   const data = command.data || {};
   const hasCode = !!data.icd10_code;
   // KOALA_5635_BACKGROUND_ALWAYS_RENDER — Background is available on EVERY
@@ -334,10 +337,17 @@ export function DiagnoseRow({ command, commandIndex, onEdit, onMoveToPlan, readO
           placeholder=${placeholder}
           aria-label="Search diagnosis codes"
         />
-        ${/* ⋮ menu — the escape hatch for A&P items that aren't a codeable diagnosis.
-            Pinned to the right of the search bar so it stays out of the code list and
-            the Reject/Accept buttons. Only offered when the card can be moved. */ ''}
-        ${onMoveToPlan && html`
+        ${/* ⋮ menu — holds the two ways OUT of the picker that aren't "pick a code":
+              * "Move to Wrap Up" for an A&P item that isn't a codeable diagnosis;
+              * "Keep current diagnosis" to abandon a re-code and keep the existing one.
+            The latter is offered only when ``onClose`` is passed, i.e. only in the
+            "Change" flow on an already-coded card — an uncoded card has no code to keep,
+            and its picker is the card's persistent UI rather than a temporary search.
+            This item replaces the picker's old ✕: with both present a card offered three
+            exits (card ✕, picker ✕, menu item), two of them identical, and the two ✕
+            glyphs meant different things ~40px apart. Now the only ✕ on a condition card
+            dismisses the condition. Escape still cancels (handleKeyDown). */ ''}
+        ${(onMoveToPlan || onClose) && html`
           <div class="diagnose-picker-menu" ref=${menuRef}>
             <button
               type="button"
@@ -350,23 +360,39 @@ export function DiagnoseRow({ command, commandIndex, onEdit, onMoveToPlan, readO
             >${ICON_DOTS}</button>
             ${showMenu && html`
               <div class="diagnose-picker-menu-pop" role="menu">
-                <button
-                  type="button"
-                  role="menuitem"
-                  class="diagnose-picker-menu-item"
-                  onMouseDown=${(e) => { e.preventDefault(); setShowMenu(false); onMoveToPlan(commandIndex); }}
-                >
-                  ${ICON_MOVE}
-                  <span>
-                    <span class="dpm-title">Move to Wrap Up</span>
-                    <span class="dpm-help">Not a codeable diagnosis — moves this card's free-text content to the Wrap Up section.</span>
-                  </span>
-                </button>
+                ${onMoveToPlan && html`
+                  <button
+                    type="button"
+                    role="menuitem"
+                    class="diagnose-picker-menu-item"
+                    onMouseDown=${(e) => { e.preventDefault(); setShowMenu(false); onMoveToPlan(commandIndex); }}
+                  >
+                    ${ICON_MOVE}
+                    <span>
+                      <span class="dpm-title">Move to Wrap Up</span>
+                      <span class="dpm-help">Not a codeable diagnosis — moves this card's free-text content to the Wrap Up section.</span>
+                    </span>
+                  </button>
+                `}
+                ${onMoveToPlan && onClose && html`<div class="diagnose-picker-menu-sep"></div>`}
+                ${onClose && html`
+                  <button
+                    type="button"
+                    role="menuitem"
+                    class="diagnose-picker-menu-item"
+                    onMouseDown=${(e) => { e.preventDefault(); setShowMenu(false); onClose(); }}
+                  >
+                    ${ICON_REVERT}
+                    <span>
+                      <span class="dpm-title">Keep current diagnosis</span>
+                      <span class="dpm-help">Closes the search without changing ${formattedCode}.</span>
+                    </span>
+                  </button>
+                `}
               </div>
             `}
           </div>
         `}
-        ${onClose && html`<button type="button" class="diagnose-picker-close" onClick=${onClose} title="Close" aria-label="Close search">${ICON_X}</button>`}
       </div>
       <div class="diagnose-picker-body">
       ${query.length >= 2
@@ -421,10 +447,17 @@ export function DiagnoseRow({ command, commandIndex, onEdit, onMoveToPlan, readO
       <div class="diagnose-row-header">
         <span class="diagnose-row-title">${titleText}</span>
         ${hasCode && html`<span class="diagnose-icd-code">${formattedCode}</span>`}
-        ${/* Uncoded card: the amber "needs-a-pick" badge lives next to the title
-            (not down in the Reject/Accept action column), so the missing-code
-            signal reads right where the diagnosis name is. */ ''}
-        ${!hasCode && !readOnly && html`<span class="rec-warning-pill">Missing: Diagnosis Code</span>`}
+        ${/* Dismissed card: a neutral gray badge states the state, and (when it can be
+            restored) says how. Gray rather than the red rejected badge — dismissing an AI
+            suggestion is routine, not an error. The code chip above is kept when present so
+            it stays visible WHAT was dismissed. */ ''}
+        ${dismissed && html`<span class="rec-dismissed-badge">Dismissed${dismissedRestorable ? ' · click to restore' : ''}</span>`}
+        ${/* Uncoded card: the amber needs-a-pick chip sits next to the title, in the
+            same slot the green ICD code chip occupies on a coded card, and with the
+            same silhouette — so coded vs uncoded reads straight down the column.
+            (.diagnose-needs-code, NOT .rec-warning-pill: that class keeps its louder
+            bordered-pill treatment for real problems like "Assessment too long".) */ ''}
+        ${!hasCode && !readOnly && html`<span class="diagnose-needs-code">Needs Diagnosis Code</span>`}
         ${hasCode && !readOnly && html`
           <button type="button" class="diagnose-change-btn" onClick=${handleClearCode} title="Change diagnosis">${ICON_PENCIL} Change</button>
         `}
@@ -433,11 +466,14 @@ export function DiagnoseRow({ command, commandIndex, onEdit, onMoveToPlan, readO
       ${/* "Change diagnosis" picker (already-coded card). */ ''}
       ${hasCode && editingCode && !readOnly && pickerPanel('Search diagnosis codes', handleCloseChange)}
 
-      ${/* No-diagnosis-code state: the integrated picker is the persistent UI. The
+      ${/* No-diagnosis-code state: the integrated picker is the persistent UI, and
+          selecting one of its rows IS the accept (there is no Accept button). The
           ranker leaves a block uncoded when codes conflict or an unspecified code
           has more-specific options; the picker's ranked recommendations (with
-          provenance) are the provider's pick list. The "Missing: Diagnosis Code"
-          action pill is the sole needs-a-pick signal — no separate hint. */ ''}
+          provenance) are the provider's pick list. The header's "Needs Diagnosis
+          Code" chip is the sole needs-a-pick signal — no separate hint. Note this
+          picker gets no `onClose`, so no "Keep current diagnosis" item: there is no
+          existing code to keep. */ ''}
       ${!hasCode && !readOnly && pickerPanel('Search diagnosis codes')}
 
       ${!editingText && html`

--- a/hyperscribe/scribe/static/soap-group.js
+++ b/hyperscribe/scribe/static/soap-group.js
@@ -451,6 +451,50 @@ function renderRecActions({ command, index, isAccepted, isRejected, incomplete, 
   `;
 }
 
+// Action column for a CONDITION card (diagnose + assess). Deliberately NOT renderRecActions:
+// condition cards have no Accept/Reject at all any more — picking a code from the picker IS the
+// accept, and the ✕ here IS the reject. The other recommendation families keep renderRecActions
+// unchanged.
+//   - already in chart -> quiet "Added" / "Already in chart" settled status, no ✕
+//   - dismissed        -> NOTHING; the whole card is the restore target (see rec-dismissed)
+//   - read-only        -> over-limit pills only
+//   - otherwise        -> a single ✕ that dismisses
+// `overLimit` is a list of warning labels; they surface even on read-only/locked rows so an
+// over-2048 background/assessment is never silently hidden.
+function renderConditionActions({ command, isDismissed, readOnly, onDismiss, overLimit = [] }) {
+  const pills = overLimit.map((label, i) => html`<span key=${'ol' + i} class="rec-warning-pill">${label}</span>`);
+  if (command.already_documented) {
+    const label = command._added_now ? 'Added' : 'Already in chart';
+    return html`
+      <div class="recommendation-actions">
+        ${pills}
+        <span class="rec-settled"><span class="rec-settled-label">${label}</span><span class="rec-settled-check">${ICON_CHECK}</span></span>
+      </div>
+    `;
+  }
+  // A dismissed card is read-only and carries no controls; pills would be noise on it.
+  if (isDismissed) return null;
+  if (readOnly) return pills.length ? html`<div class="recommendation-actions">${pills}</div>` : null;
+  return html`
+    <div class="recommendation-actions">
+      ${pills}
+      <button type="button" class="rec-remove-x" onClick=${onDismiss} title="Dismiss">${ICON_X}</button>
+    </div>
+  `;
+}
+
+// Keyboard activation for a dismissed condition card. The card IS the restore control, so it
+// has to behave like one: Tab-reachable (tabindex="0"), Enter/Space activate. Without this the
+// only way back from an accidental dismiss would be mouse-only.
+function dismissedKeyDown(onRestore) {
+  return (e) => {
+    if (e.key === 'Enter' || e.key === ' ' || e.key === 'Spacebar') {
+      e.preventDefault();
+      onRestore();
+    }
+  };
+}
+
 function AssessNarrative({ command, commandIndex, onEdit, readOnly, onEditingChange }) {
   const data = command.data || {};
   const [editing, setEditing] = useState(false);
@@ -843,19 +887,37 @@ export function SoapGroup({ title, groupColor, sections, commandBySectionKey, on
                      A variant-specific key forces a clean remount instead. */ ''}
                 <div class="subsection" key=${s.key + '-conditions'}>
                   <div class="subsection-title">${key === 'assessment_and_plan' ? 'Conditions' : s.title}</div>
-                  ${cmds.filter(e => e.command.command_type === 'assess').map(entry => {
+                  ${cmds.filter(e => e.command.command_type === 'assess' && (!shouldHideRejected || !(e.command.data && e.command.data.rejected))).map(entry => {
                     const aData = entry.command.data || {};
                     const aCode = aData.icd10_code ? aData.icd10_code.replace(/\./g, '').trim().toUpperCase() : '';
                     const aFormatted = aCode.length > 3 ? aCode.slice(0, 3) + '.' + aCode.slice(3) : aCode;
-                    const assessRowReadOnly = rowLocked(entry.command, viewerReadOnly, isAmending);
+                    // Dismissal now matches the diagnose card: the ✕ marks `data.rejected` (hidden
+                    // by the top-bar toggle, restorable by clicking the card) instead of deleting
+                    // the row outright. The two condition-card types show an identical ✕ in an
+                    // identical place, so they must not differ in permanence — an assess card
+                    // carries AI-written assessment text that a mis-click should not destroy.
+                    const aDismissed = !!aData.rejected;
+                    const assessRowReadOnly = rowLocked(entry.command, viewerReadOnly, isAmending) || aDismissed;
+                    const dismissAssess = () => onEditCommand(entry.index, { ...aData, rejected: true }, 'assess');
+                    const restoreAssess = () => onEditCommand(entry.index, { ...aData, rejected: false }, 'assess');
+                    const aRestorable = aDismissed && !readOnly;
                     return html`
-                      <div class=${`content-block recommendation-block rec-assess${assessRowReadOnly && entry.command.already_documented ? ' command-locked' : ''}`} key=${entry.index}>
+                      <div
+                        class=${`content-block recommendation-block rec-assess${aDismissed ? ' rec-dismissed' : ''}${assessRowReadOnly && entry.command.already_documented ? ' command-locked' : ''}`}
+                        key=${entry.index}
+                        role=${aRestorable ? 'button' : null}
+                        tabIndex=${aRestorable ? 0 : null}
+                        title=${aRestorable ? 'Restore this condition' : null}
+                        onClick=${aRestorable ? restoreAssess : null}
+                        onKeyDown=${aRestorable ? dismissedKeyDown(restoreAssess) : null}
+                      >
                         ${assessRowReadOnly && entry.command.already_documented && ICON_LOCK}
                         <div class="recommendation-content">
                           <div class="diagnose-row">
                             <div class="diagnose-row-header">
                               <span class="diagnose-row-title">${entry.command.display}</span>
                               ${aFormatted ? html`<span class="diagnose-icd-code">${aFormatted}</span>` : ''}
+                              ${aDismissed && html`<span class="rec-dismissed-badge">Dismissed${!readOnly ? ' · click to restore' : ''}</span>`}
                               ${/* Change on an assess (existing-condition) card: re-pick the ICD-10
                                   code. A different code means a different condition, so convert to a
                                   fresh uncoded diagnose (drops condition_id → no false assess against
@@ -880,21 +942,16 @@ export function SoapGroup({ title, groupColor, sections, commandBySectionKey, on
                           </div>
                         </div>
                         ${(() => {
-                          // Over-limit pills surface even on read-only/locked rows (the
-                          // inline counter was removed from the read view), so an
-                          // over-2048 background/assessment is never silently hidden.
-                          // Remove button keeps the target's rec-remove-x styling.
-                          const showRemove = !readOnly && !entry.command.already_documented && !entry.command._adding;
-                          const bgOver = (aData.background || '').length > 2048;
-                          const asmtOver = (aData.narrative || '').length > 2048;
-                          if (!showRemove && !bgOver && !asmtOver) return null;
-                          return html`
-                            <div class="recommendation-actions">
-                              ${bgOver && html`<span class="rec-warning-pill">Background too long</span>`}
-                              ${asmtOver && html`<span class="rec-warning-pill">Assessment too long</span>`}
-                              ${showRemove && html`<button type="button" class="rec-remove-x" onClick=${() => onDeleteCommand(entry.index)} title="Remove">${ICON_X}</button>`}
-                            </div>
-                          `;
+                          const overLimit = [];
+                          if ((aData.background || '').length > 2048) overLimit.push('Background too long');
+                          if ((aData.narrative || '').length > 2048) overLimit.push('Assessment too long');
+                          return renderConditionActions({
+                            command: entry.command,
+                            isDismissed: aDismissed,
+                            readOnly: readOnly || entry.command._adding,
+                            onDismiss: dismissAssess,
+                            overLimit,
+                          });
                         })()}
                       </div>
                     `;
@@ -905,9 +962,10 @@ export function SoapGroup({ title, groupColor, sections, commandBySectionKey, on
                     // lands in this group (see wasInserted note).
                     const dxData = entry.command.data || {};
                     const hasCode = !!dxData.icd10_code;
-                    const isAccepted = hasCode && dxData.accepted;
-                    const isRejected = dxData.rejected;
-                    const isIncomplete = !hasCode && !isRejected;
+                    // `accepted` is now purely derived from "has a code" (summary.js handleEdit),
+                    // so a coded card IS an accepted card. There is no separate accept step and
+                    // no Accept button — picking a code from the picker is the accept.
+                    const isDismissed = !!dxData.rejected;
                     const header = dxData.condition_header || '';
                     // Ranked, grounded code options for an uncoded card. The belt
                     // stamps them directly on the command (data.candidate_suggestions),
@@ -918,42 +976,59 @@ export function SoapGroup({ title, groupColor, sections, commandBySectionKey, on
                     // Uncoded card: ranked grounded options to pick from. The belt stamps
                     // them on the command (data.candidate_suggestions), keyed by block_id;
                     // fall back to the block_id-keyed diagnosisSuggestions map.
-                    const suggestions = (!hasCode && !isRejected
+                    const suggestions = (!hasCode && !isDismissed
                       && (dxData.candidate_suggestions
                         || (diagnosisSuggestions && blockId && diagnosisSuggestions[blockId]))) || null;
 
-                    const handleAcceptDiagnose = () => onEditCommand(entry.index, { ...entry.command.data, accepted: true, rejected: false }, 'diagnose');
-                    const handleRejectDiagnose = () => onEditCommand(entry.index, { ...entry.command.data, rejected: true, accepted: false }, 'diagnose');
+                    const dismissDiagnose = () => onEditCommand(entry.index, { ...dxData, rejected: true }, 'diagnose');
+                    const restoreDiagnose = () => onEditCommand(entry.index, { ...dxData, rejected: false }, 'diagnose');
+                    // A dismissed card becomes the restore control itself, so it needs to be a
+                    // real button: Tab-reachable and Enter/Space activated. It carries no other
+                    // control at all.
+                    const dxRestorable = isDismissed && !readOnly;
 
                     const diagnoseRowReadOnly = rowLocked(entry.command, viewerReadOnly, isAmending);
                     return html`
-                      <div class=${`content-block recommendation-block rec-diagnose${isRejected ? ' rec-rejected' : ''}${!isAccepted && !isRejected && !readOnly && !entry.command.already_documented ? ' rec-needs-review' : ''}${(readOnly || isAmending) && diagnoseRowReadOnly && entry.command.already_documented ? ' command-locked' : ''}`} key=${entry.index}>
+                      <div
+                        class=${`content-block recommendation-block rec-diagnose${isDismissed ? ' rec-dismissed' : ''}${!hasCode && !isDismissed && !readOnly && !entry.command.already_documented ? ' rec-needs-review' : ''}${(readOnly || isAmending) && diagnoseRowReadOnly && entry.command.already_documented ? ' command-locked' : ''}`}
+                        key=${entry.index}
+                        role=${dxRestorable ? 'button' : null}
+                        tabIndex=${dxRestorable ? 0 : null}
+                        title=${dxRestorable ? 'Restore this condition' : null}
+                        onClick=${dxRestorable ? restoreDiagnose : null}
+                        onKeyDown=${dxRestorable ? dismissedKeyDown(restoreDiagnose) : null}
+                      >
                         ${(readOnly || isAmending) && diagnoseRowReadOnly && entry.command.already_documented && ICON_LOCK}
                         <div class="recommendation-content">
                           <${DiagnoseRow}
                             command=${entry.command}
                             commandIndex=${entry.index}
                             onEdit=${onEditCommand}
-                            onMoveToPlan=${diagnoseRowReadOnly || isRejected ? null : onMoveToPlan}
-                            readOnly=${diagnoseRowReadOnly || isRejected}
+                            onMoveToPlan=${diagnoseRowReadOnly || isDismissed ? null : onMoveToPlan}
+                            readOnly=${diagnoseRowReadOnly || isDismissed}
+                            dismissed=${isDismissed}
+                            dismissedRestorable=${dxRestorable}
                             suggestions=${suggestions}
                             onEditingChange=${onEditingChange}
                           />
                         </div>
-                        ${/* Target's accept/reject redesign (renderRecActions) is kept;
-                            the over-limit warning pills are layered in front of it so an
-                            over-2048 background/assessment is never silently hidden, on
-                            editable and read-only rows alike. renderRecActions owns the
-                            "Missing Diagnosis Code" pill, accept/reject, and badges. */ ''}
-                        <div class="recommendation-actions">
-                          ${(dxData.background || '').length > 2048 && html`<span class="rec-warning-pill">Background too long</span>`}
-                          ${(dxData.today_assessment || '').length > 2048 && html`<span class="rec-warning-pill">Assessment too long</span>`}
-                          ${/* incomplete:false → the "Missing: Diagnosis Code" pill is
-                            rendered in the DiagnoseRow header (next to the title) instead
-                            of here in the action column. acceptDisabled still keys off
-                            isIncomplete so Accept stays disabled until a code is picked. */ ''}
-                        ${renderRecActions({ command: entry.command, index: entry.index, isAccepted, isRejected, incomplete: false, missingLabel: 'Diagnosis Code', acceptDisabled: isIncomplete, readOnly, onAccept: handleAcceptDiagnose, onReject: handleRejectDiagnose, onAddNow: null })}
-                        </div>
+                        ${/* No Accept/Reject: picking a code from the picker is the accept, and the
+                            single ✕ here is the reject. Over-limit pills are layered in so an
+                            over-2048 background/assessment is never silently hidden, on editable
+                            and read-only rows alike. A dismissed card gets no action column —
+                            the card itself restores. */ ''}
+                        ${(() => {
+                          const overLimit = [];
+                          if ((dxData.background || '').length > 2048) overLimit.push('Background too long');
+                          if ((dxData.today_assessment || '').length > 2048) overLimit.push('Assessment too long');
+                          return renderConditionActions({
+                            command: entry.command,
+                            isDismissed,
+                            readOnly,
+                            onDismiss: dismissDiagnose,
+                            overLimit,
+                          });
+                        })()}
                       </div>
                     `;
                   })}

--- a/hyperscribe/scribe/static/styles.css
+++ b/hyperscribe/scribe/static/styles.css
@@ -590,11 +590,31 @@ h2 { margin-bottom: 4px; }
 .field-missing { color: #c2410c; }
 .input-missing { border-color: #f59e0b; background: #fffbeb; }
 
-/* Rejected state */
+/* Rejected state (medication / allergy / Rx / referral / task cards, which keep Reject) */
 .recommendation-block.rec-rejected { opacity: 0.5; }
 .rec-rejected-badge {
   padding: 3px 10px; font-size: 11px; font-weight: 600;
   color: #991b1b; background: #fef2f2; border-radius: 12px;
+  white-space: nowrap;
+}
+
+/* Dismissed CONDITION card. The whole card is the restore target, so it carries no controls
+   at all. Opacity is 0.62 rather than rec-rejected's 0.5 because the assessment text has to
+   stay readable enough to judge before restoring, now that no button draws the eye.
+   Neutral gray badge, not the red rec-rejected-badge: dismissing an AI suggestion is routine,
+   and red reads as an error.
+   The card must be rendered as a real focusable control (role="button" tabindex="0" plus an
+   Enter/Space handler) — it is the ONLY way to restore, so a bare div with an onClick would
+   make restoring unreachable by keyboard. The focus ring below is part of that contract.
+   No conflict with click-to-edit: a dismissed card is already read-only, so
+   .diagnose-row-body never receives .editable. */
+.recommendation-block.rec-dismissed { opacity: 0.62; cursor: pointer; }
+.recommendation-block.rec-dismissed .diagnose-row-title { font-weight: 600; }
+.recommendation-block.rec-dismissed:hover { opacity: 0.9; background: #f8fafc; border-color: #cbd5e1; }
+.recommendation-block.rec-dismissed:focus-visible { outline: 2px solid #5b7aa6; outline-offset: 2px; opacity: 0.9; }
+.rec-dismissed-badge {
+  padding: 3px 10px; font-size: 11px; font-weight: 600;
+  color: #6b7280; background: #f3f4f6; border-radius: 12px;
   white-space: nowrap;
 }
 
@@ -1045,9 +1065,37 @@ select.history-form-input {
 }
 
 /* Diagnose row (per-condition A&P block) */
-.diagnose-row { padding: 4px 0; }
-.diagnose-row-header { display: flex; align-items: center; gap: 6px; margin-bottom: 6px; }
-.diagnose-row-title { font-size: 15px; font-weight: 700; color: #333; flex: 0 1 auto; line-height: 1.4; }
+/* padding:0 — the previous `4px 0` only ever reached the ASSESS card, because
+   .rec-diagnose dissolves this element with `display: contents`. That started assess
+   headers 4px below diagnose headers. */
+.diagnose-row { padding: 0; }
+
+/* CONDITION CARD HEADER — one optical line.
+   Every chip in the header (ICD code, needs-code, Change) AND the ✕ in the action column
+   share a single 24px line box pinned to the FIRST line of the title, so the row stays
+   level whether the title runs to one line or three.
+   Previously: title line-height 1.4 x 15px = 21px -> first-line centre 10.5px, while the
+   action column's `padding-top: 4px` on a 28px button put the ✕ centre at 18px — the ✕ sat
+   7.5px below the title. And `align-items: center` dragged the chips to the centre of a
+   wrapped title's block while the ✕ stayed near the top. */
+.diagnose-row-header { display: flex; align-items: flex-start; gap: 8px; margin-bottom: 8px; min-height: 24px; }
+.diagnose-row-title { font-size: 15px; font-weight: 700; color: #333; flex: 0 1 auto; line-height: 24px; }
+.diagnose-row-header > .diagnose-icd-code,
+.diagnose-row-header > .diagnose-needs-code,
+.diagnose-row-header > .rec-dismissed-badge,
+.diagnose-row-header > .rec-warning-pill,
+.diagnose-row-header > .diagnose-change-btn { height: 24px; display: inline-flex; align-items: center; flex-shrink: 0; }
+
+/* The action column for BOTH condition-card families — the single source of truth for its
+   padding/margin. `margin-top: -2px` centres the 28px ✕ on the 24px line box ((28-24)/2).
+   `margin-right: -6px` is optical: the 28px hit target wraps a 15px glyph, so ~6.5px is
+   transparent padding; on top of the card's 16px padding that put the GLYPH — the only part
+   the eye sees — 23.5px from the right border but 17.5px from the top. Pulling 6px right
+   makes both insets 17.5px (the glyph sits on the corner diagonal) and lands it flush with
+   the right edge of the picker/body column below. The hit target still stops 11px from the
+   border, so nothing is clipped. */
+.recommendation-block.rec-diagnose > .recommendation-actions,
+.recommendation-block.rec-assess > .recommendation-actions { padding-top: 0; margin-top: -2px; margin-right: -6px; }
 .diagnose-search-btn { padding: 2px 10px; font-size: 11px; font-weight: 600; color: #059669; background: #ecfdf5; border: 1px dashed #059669; border-radius: 10px; cursor: pointer; }
 .diagnose-search-btn:hover { background: #d1fae5; border-style: solid; }
 .diagnose-delete-btn { width: 20px; height: 20px; border: none; background: none; color: #999; font-size: 16px; cursor: pointer; display: flex; align-items: center; justify-content: center; border-radius: 4px; flex-shrink: 0; }
@@ -1065,6 +1113,16 @@ select.history-form-input {
 /* Trailing ICD code: a small filled light-green pill after the diagnosis name
    (a flex sibling of the title so it stays cleanly centered). */
 .diagnose-icd-code { display: inline-flex; align-items: center; flex-shrink: 0; font-size: 12px; font-weight: 700; color: #059669; background: #ecfdf3; border-radius: 6px; padding: 2px 8px; letter-spacing: 0.2px; white-space: nowrap; }
+/* Needs-a-code chip — a deliberate mirror of .diagnose-icd-code above (same type, same 6px
+   radius, same padding, same letter-spacing, NO border) with the amber pair swapped in, so a
+   card shows either a green code chip or this one in the SAME slot at the SAME size and
+   coded/uncoded reads straight down the column. Amber reused from .rec-warning-pill, so no
+   new colour enters the system.
+   This is a NEW class rather than a restyle of .rec-warning-pill on purpose: that class has 7
+   other live uses ("Background too long", "Assessment too long", "Missing: X" on the
+   medication / allergy / Rx / order cards) which keep the louder bordered pill, because those
+   are genuine problems rather than a routine "not picked yet". */
+.diagnose-needs-code { display: inline-flex; align-items: center; flex-shrink: 0; font-size: 12px; font-weight: 700; color: #c2410c; background: #fff7ed; border-radius: 6px; padding: 2px 8px; letter-spacing: 0.2px; white-space: nowrap; }
 .diagnose-suggestions { margin-top: 10px; }
 .diagnose-suggestions-list { display: flex; flex-direction: column; gap: 4px; margin-top: 6px; }
 .diagnose-suggestion-btn {
@@ -1122,25 +1180,36 @@ select.history-form-input {
 /* overflow:visible so the search-bar ⋮ menu can drop out over the list below; the
    inner .diagnose-picker-body re-clips the rounded bottom corners the picker's own
    overflow:hidden used to provide (row/More-options hover backgrounds). */
-.diagnose-picker { margin: 16px 0 18px; border: 1px solid #e4e7ec; border-radius: 12px; overflow: visible; background: #fff; }
+/* margin-top 4px (was 16px): with the header's 8px margin-bottom the title→picker gap was
+   24px, which floated the picker in the middle of the card. Now 12px, matching the card's own
+   padding. The 18px BELOW is deliberately kept — the asymmetry groups the picker upward with
+   the title it belongs to and separates it from the assessment text. */
+.diagnose-picker { margin: 4px 0 18px; border: 1px solid #e4e7ec; border-radius: 12px; overflow: visible; background: #fff; }
 .diagnose-picker:focus-within { border-color: #052B49; }
 .diagnose-picker-body { border-radius: 0 0 12px 12px; overflow: hidden; }
-.diagnose-picker-search { display: flex; align-items: center; gap: 12px; padding: 11px 16px; border-bottom: 1px solid #eef1f4; }
+/* The search row deliberately has NO border-bottom. The separator lives on the body's
+   content instead (.diagnose-picker-list / -empty below), so it only exists when there is
+   something below the search box to separate.
+   Why: this picker is `overflow: visible` (so the ⋮ menu can drop out over the list), which
+   means a full-width border-bottom here is NOT clipped by the picker's own border-radius. On a
+   card whose body is empty — a condition with no surfaced candidate codes and no query — the
+   search row becomes the last element, so that border landed exactly on the picker's bottom
+   edge and poked out past the rounded corners as a stray gray line crossing the border. */
+.diagnose-picker-search { display: flex; align-items: center; gap: 12px; padding: 11px 16px; }
 .diagnose-picker-search svg { width: 18px; height: 18px; color: #9aa6b2; flex-shrink: 0; }
 .diagnose-picker-search input { border: none; outline: none; font-size: 14.5px; flex: 1; min-width: 0; font-family: inherit; color: #1f2733; background: none; }
 .diagnose-picker-search input::placeholder { color: #9aa6b2; }
-.diagnose-picker-close { background: none; border: none; padding: 4px; margin: -2px -4px -2px 4px; color: #9aa6b2; cursor: pointer; display: inline-flex; align-items: center; justify-content: center; border-radius: 6px; flex-shrink: 0; line-height: 0; }
-.diagnose-picker-close:hover { color: #374151; background: #f1f3f5; }
-.diagnose-picker-close svg { width: 16px; height: 16px; }
 .diagnose-picker-label { padding: 9px 16px 4px; font-size: 10px; font-weight: 700; letter-spacing: 0.6px; text-transform: uppercase; color: #9aa6b2; }
-.diagnose-picker-list { padding: 0 0 3px; }
+/* Separator under the search box — carried by the content, so an empty body has none.
+   Safely clipped by .diagnose-picker-body's overflow:hidden + bottom radius. */
+.diagnose-picker-list { padding: 0 0 3px; border-top: 1px solid #eef1f4; }
 .diagnose-picker-row { display: flex; align-items: center; gap: 0; padding: 9px 16px; cursor: pointer; transition: background 0.12s; }
 .diagnose-picker-row:hover { background: #f5f8ff; }
 .diagnose-picker-row + .diagnose-picker-row { box-shadow: inset 0 1px 0 #f4f6f9; }
 /* Name leads (shrinks + ellipsizes); code trails it as a small green pill. */
 .diagnose-picker-name { font-size: 14px; font-weight: 500; color: #1f2733; flex: 0 1 auto; min-width: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .diagnose-picker-code { display: inline-flex; align-items: center; flex-shrink: 0; font-size: 11.5px; font-weight: 700; color: #059669; background: #ecfdf3; border-radius: 6px; padding: 2px 8px; margin-left: 8px; letter-spacing: 0.2px; white-space: nowrap; }
-.diagnose-picker-empty { padding: 12px 16px; font-size: 13px; color: #9aa6b2; }
+.diagnose-picker-empty { padding: 12px 16px; font-size: 13px; color: #9aa6b2; border-top: 1px solid #eef1f4; }
 /* Provenance tag on a recommended/candidate code ("Active problem", "Past condition",
    "Detected in note", "More specific option"). Trails the code as a quiet, right-aligned
    metadata column (the code pill leads, right after the diagnosis name). */
@@ -1161,6 +1230,8 @@ select.history-form-input {
 .diagnose-picker-menu-pop::before { content: ""; position: absolute; bottom: 100%; right: 14px; border: 6px solid transparent; border-bottom-color: #fff; filter: drop-shadow(0 -1px 0 #e4e7ec); }
 .diagnose-picker-menu-item { display: flex; align-items: flex-start; gap: 10px; width: 100%; background: none; border: none; font-family: inherit; padding: 9px 10px; border-radius: 8px; cursor: pointer; text-align: left; }
 .diagnose-picker-menu-item:hover { background: #f5f8ff; }
+/* Separates "Move to Wrap Up" from "Keep current diagnosis" — two unrelated exits. */
+.diagnose-picker-menu-sep { height: 1px; background: #eef1f5; margin: 5px 8px; }
 .diagnose-picker-menu-item svg { width: 16px; height: 16px; color: #52606d; flex-shrink: 0; margin-top: 1px; }
 .dpm-title { display: block; font-size: 13.5px; font-weight: 600; color: #1f2733; }
 .dpm-help { display: block; font-size: 11.5px; color: #9aa6b2; line-height: 1.45; margin-top: 2px; }
@@ -1706,8 +1777,13 @@ select.history-form-input {
 .charge-view-desc { font-size: 15px; color: #333; flex: 1; }
 .recommendation-block:has(.charge-view) { align-items: center; }
 .recommendation-block:has(.charge-view) .recommendation-actions { padding-top: 0; }
-.recommendation-block.rec-assess:not(:has(.editing)) { align-items: center; }
-.recommendation-block.rec-assess:not(:has(.editing)) .recommendation-actions { padding-top: 0; }
+/* Assess cards align their ✕ to the TOP, level with the diagnosis name, matching the
+   diagnose card. (Was `center`, which floated the ✕ to the middle of the right edge on a
+   tall card — the same glyph in a different place on the two condition-card types.)
+   NOTE: the action column's padding/margin is owned by ONE rule, in the condition-card
+   header block below. Do not re-declare padding-top for .recommendation-actions here —
+   a more specific rule silently wins and reintroduces a 4px vertical offset. */
+.recommendation-block.rec-assess:not(:has(.editing)) { align-items: flex-start; }
 .charge-result-code { font-weight: 700; color: #052B49; white-space: nowrap; }
 .charge-result-name { color: #555; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 

--- a/hyperscribe/scribe/static/summary.js
+++ b/hyperscribe/scribe/static/summary.js
@@ -104,7 +104,7 @@ const _validationErrorMessage = (c, reason, context = 'approving') => {
   if (reason === 'imaging_incomplete') return `This imaging order is missing required fields (image code, service provider, ordering provider, or diagnosis codes). ${suffix}`;
   if (reason === 'lab_incomplete') return `This lab order is missing required fields (lab partner or tests). ${suffix}`;
   if (reason === 'perform_incomplete') return `This perform command is missing a CPT code. ${suffix}`;
-  if (reason === 'diagnose_uncoded') return `This diagnosis needs an ICD-10 code. Pick one (or reject it) before ${context}.`;
+  if (reason === 'diagnose_uncoded') return `This diagnosis needs an ICD-10 code. Pick one from the list (or dismiss the card with the ✕) before ${context}.`;
   return `This command has invalid values. ${suffix}`;
 };
 
@@ -676,9 +676,15 @@ export function Scribe({ noteId, patientId, staffId, staffName, providerName, pr
   }, [commands]);
 
   // --- Charge matrix view-models (derived from commands) ---
+  // `!c.data?.rejected` guards BOTH condition families explicitly. For diagnose the
+  // `accepted` test below already covers it (accepted is derived as coded && !rejected), but
+  // for assess the test is `accepted !== false` and assess data usually has no `accepted`
+  // field at all — so without this clause a dismissed existing-condition card would stay
+  // linkable to charges. This predicate is duplicated in linkableNoteDiagnoses and in
+  // onReorderDiagnoses' `isDx`; all three must stay identical or the size guard there bails.
   const chargeMatrixDiagnoses = useMemo(() => commands
     .filter(c => (c.command_type === 'diagnose' || c.command_type === 'assess')
-      && (c.data?.icd10_code || c.data?.code) && c._localId
+      && (c.data?.icd10_code || c.data?.code) && c._localId && !c.data?.rejected
       && (c.already_documented || c.command_uuid
           // diagnose: must be explicitly accepted (absent = unreviewed AI rec → hide)
           // assess:   absent accepted = manually added via old code → show; only hide on false
@@ -710,7 +716,7 @@ export function Scribe({ noteId, patientId, staffId, staffName, providerName, pr
   // data.icd10_code), which the referral linker must see.
   const linkableNoteDiagnoses = useMemo(() => commands
     .filter(c => (c.command_type === 'diagnose' || c.command_type === 'assess')
-      && (c.data?.icd10_code || c.data?.code) && c._localId
+      && (c.data?.icd10_code || c.data?.code) && c._localId && !c.data?.rejected
       && (c.already_documented || c.command_uuid
           || (c.command_type === 'assess' ? c.data?.accepted !== false : c.data?.accepted)))
     .map(c => ({
@@ -897,7 +903,7 @@ export function Scribe({ noteId, patientId, staffId, staffName, providerName, pr
     // nextUuids.length — otherwise the size guard always bails.
     const idOf = c => c._localId;
     const isDx = c => (c.command_type === 'diagnose' || c.command_type === 'assess')
-      && (c.data?.icd10_code || c.data?.code) && c._localId
+      && (c.data?.icd10_code || c.data?.code) && c._localId && !c.data?.rejected
       && (c.already_documented || c.command_uuid
           || (c.command_type === 'assess' ? c.data?.accepted !== false : c.data?.accepted));
     const dxBy = new Map(prev.filter(isDx).map(c => [idOf(c), c]));
@@ -1789,8 +1795,14 @@ export function Scribe({ noteId, patientId, staffId, staffName, providerName, pr
           next = { ...cmd, command_type: type, data: newData, display: newData.condition_name || '' };
         } else if (type === 'diagnose') {
           const display = newData.icd10_display || newData.condition_header || cmd.display;
-          const accepted = newData.icd10_code ? (newData.accepted !== undefined ? newData.accepted : true) : false;
           const rejected = newData.rejected || false;
+          // `accepted` is now fully DERIVED: a coded, non-dismissed condition is accepted.
+          // There is no separate accept gesture — picking a code from the picker is the accept
+          // (which is all the old Accept button could ever have meant: it was permanently
+          // disabled while uncoded, so it was never clickable). The field is still written
+          // because the pre-insert filter, the diagnose→assess flip and the print filter all
+          // read it.
+          const accepted = !!newData.icd10_code && !rejected;
           next = { ...cmd, command_type: type, data: { ...newData, accepted, rejected }, display };
         } else if (type === 'assess') {
           next = { ...cmd, data: newData };
@@ -2660,6 +2672,10 @@ export function Scribe({ noteId, patientId, staffId, staffName, providerName, pr
       // it. A coded diagnose that matched an active problem has already flipped to
       // `assess` upstream (which is exempt — it carries condition_id, not a code).
       if (c.command_type === 'diagnose' && !(c.data && c.data.icd10_code) && !(c.data && c.data.rejected)) return false;
+      // A dismissed existing-condition card must not reach the chart either. The assess ✕ now
+      // marks `data.rejected` (recoverable) instead of deleting the row, so unlike before there
+      // can be dismissed assess commands still present in `commands` at insert time.
+      if (c.command_type === 'assess' && c.data && c.data.rejected) return false;
       return true;
     });
     // Pre-existing finalized notes (signed before the explicit
@@ -3229,22 +3245,26 @@ export function Scribe({ noteId, patientId, staffId, staffName, providerName, pr
       (c.command_type === 'refer' && _isReferIncomplete(c.data))
     )
   ).length;
-  const UNDECIDED_LABELS = { diagnose: 'diagnosis', medication_statement: 'medication', allergy: 'allergy', prescribe: 'prescription', refill: 'prescription', adjust_prescription: 'prescription', refer: 'referral' };
+  const UNDECIDED_LABELS = { medication_statement: 'medication', allergy: 'allergy', prescribe: 'prescription', refill: 'prescription', adjust_prescription: 'prescription', refer: 'referral' };
+  // "Undecided" now covers only the recommendation families that still have Accept/Reject.
+  // Condition cards have no accept/reject to be undecided about — their equivalent gate is
+  // "has a code been picked?", counted separately as uncodedConditionCount below.
   const undecidedTypes = [];
-  for (const c of commands) {
-    if (!c.already_documented && c.display && c.command_type === 'diagnose' && !c.data.accepted && !c.data.rejected) {
-      if (!undecidedTypes.includes(c.command_type)) undecidedTypes.push(c.command_type);
-    }
-  }
   for (const c of recommendations) {
     if (!c.already_documented && c.display && !c.accepted && !c.rejected) {
       if (!undecidedTypes.includes(c.command_type)) undecidedTypes.push(c.command_type);
     }
   }
-  const undecidedRecommendationCount = commands.filter(c =>
-    !c.already_documented && c.display && c.command_type === 'diagnose' && !c.data.accepted && !c.data.rejected
-  ).length + recommendations.filter(c =>
+  const undecidedRecommendationCount = recommendations.filter(c =>
     !c.already_documented && c.display && !c.accepted && !c.rejected
+  ).length;
+  // Condition gate: a surfaced condition must either carry an ICD-10 code or be dismissed
+  // before the note can be signed. This REPLACES the old "not accepted nor rejected" count for
+  // diagnose cards — it must not simply be dropped, because the uncoded filter in handleInsert
+  // only removes such a card from `insertable`, which without a gate would be silent data loss.
+  const uncodedConditionCount = commands.filter(c =>
+    !c.already_documented && c.display && c.command_type === 'diagnose'
+    && !(c.data && c.data.icd10_code) && !(c.data && c.data.rejected)
   ).length;
   const hasUnsavedEdits = editingFields.size > 0;
 
@@ -3399,9 +3419,17 @@ export function Scribe({ noteId, patientId, staffId, staffName, providerName, pr
               Regenerate${!selectedTemplate ? ' (select visit type)' : ''}
             </button>
           `}
-          ${recommendations.length > 0 && html`
+          ${/* This toggle is the ONLY way back to a dismissed condition card, so its render
+               gate has to account for condition cards too. It used to be
+               `recommendations.length > 0`, and that array holds only the
+               medication/allergy/Rx/referral/task families — condition cards live in
+               `commands`. With hideRejected defaulting to true, a note whose only
+               recommendations were conditions showed no toggle at all, so a dismissed
+               condition was invisible with no route back. That was survivable while the card
+               carried its own Accept button to restore it; it no longer does. */ ''}
+          ${(recommendations.length > 0 || commands.some(c => (c.command_type === 'diagnose' || c.command_type === 'assess') && c.data && c.data.rejected)) && html`
             <label class="hide-rejected-label hide-rejected-label--top-bar" onClick=${canEdit ? () => setHideRejected(prev => !prev) : undefined}>
-              Hide Rejected Recommendations
+              Hide Dismissed Recommendations
               <div class="toggle-switch${hideRejected ? ' on' : ''}">
                 <div class="toggle-knob" />
               </div>
@@ -3678,6 +3706,11 @@ export function Scribe({ noteId, patientId, staffId, staffName, providerName, pr
                   ${undecidedRecommendationCount} ${undecidedRecommendationCount === 1 ? 'recommendation needs' : 'recommendations need'} a decision, ${undecidedRecommendationCount === 1 ? 'it has' : 'they have'} not been accepted nor rejected: ${undecidedTypes.map(t => UNDECIDED_LABELS[t] || t).join(', ')}
                 </div>
               `}
+              ${uncodedConditionCount > 0 && html`
+                <div class="summary-footer-warning">
+                  ${uncodedConditionCount} ${uncodedConditionCount === 1 ? 'condition still needs' : 'conditions still need'} a diagnosis code — pick one from the list, or dismiss the card with the ✕.
+                </div>
+              `}
               ${hasUnsavedEdits && html`
                 <div class="summary-footer-warning">
                   ${editingFields.size} unsaved ${editingFields.size === 1 ? 'edit' : 'edits'} \u2014 save or cancel to continue.
@@ -3689,7 +3722,7 @@ export function Scribe({ noteId, patientId, staffId, staffName, providerName, pr
               ${(chargeErrors && chargeErrors.length)
                 ? html`<div class="summary-footer-warning cm-sign-error">Some charges could not be saved (${chargeErrors.length}). Please review the charges and try again.</div>`
                 : null}
-              <button class="insert-btn" disabled=${undecidedRecommendationCount > 0 || hasUnsavedEdits || !canEdit} onClick=${() => setConfirming(true)}>${wasFinalized ? (hasRxCommands ? 'Save changes and review prescriptions' : 'Save changes') : (hasRxCommands ? 'Accept and review prescriptions' : 'Accept and sign')}</button>
+              <button class="insert-btn" disabled=${undecidedRecommendationCount > 0 || uncodedConditionCount > 0 || hasUnsavedEdits || !canEdit} onClick=${() => setConfirming(true)}>${wasFinalized ? (hasRxCommands ? 'Save changes and review prescriptions' : 'Save changes') : (hasRxCommands ? 'Accept and review prescriptions' : 'Accept and sign')}</button>
               ${!wasFinalized && html`<div class="approve-warning">This action is permanent and cannot be undone.</div>`}
             </div>
           `}


### PR DESCRIPTION
## What & why

The **Reject / Accept** pair on A&P condition cards was redundant, and provably so:

- `handleSelect` already set `accepted: true` the moment a code was picked from the picker.
- `handleEdit` force-set `accepted = false` whenever there was no `icd10_code`.

Together those meant the **Accept button on an uncoded card was permanently disabled and could never be clicked**. Its only reachable use was restoring a rejected card — so the pair cost ~180px of the card header and added a decision the picker already satisfied.

**New model:** selecting a diagnosis from the list of options *is* the accept; a single ✕ in the upper right *is* the reject.

Design was iterated over three rounds against a rendered high-fidelity mockup before any product code was touched. The mockup was a throwaway artifact and is not included here.

**Scope: condition cards only** (`diagnose` + `assess`). Medications, allergies, prescriptions, referrals, tasks and orders keep `Reject`/`Accept` and `renderRecActions` **untouched**.

## Behaviour

- `accepted` is now fully **derived** (`coded && !dismissed`). Still written, because the pre-insert filter, the diagnose→assess flip and the print filter all read it.
- ✕ marks `data.rejected`; the existing top-bar toggle governs visibility (relabelled **"Hide Dismissed Recommendations"**).
- A dismissed card is dimmed, carries **no controls**, and is itself the restore target — rendered as a real focusable button (`role="button"`, `tabindex="0"`, Enter/Space). That is a correctness requirement, not polish: it is the only route back.
- **Assess ✕ now dismisses recoverably instead of deleting the row.** The two condition-card types show an identical ✕ in an identical place, so they must not differ in permanence — an assess card carries AI-written assessment text a mis-click shouldn't destroy.
- Picker ⋮ menu gains **"Keep current diagnosis"**, offered only when re-coding an already-coded card. It replaces the picker's own ✕, so exactly one ✕ appears on a card and it unambiguously means "dismiss this condition". Escape still cancels.
- **Sign gate split**: conditions are gated on *"has a code been picked?"* (`uncodedConditionCount`) rather than folded into the accept/reject undecided count. Deliberately not just dropped — the uncoded filter in `handleInsert` only removes such a card from `insertable`, which without a gate would be **silent data loss**.

## Visual

- Card header now shares **one 24px line box**: title line-height, every chip and the ✕ all adopt it, and chips pin to the title's **first** line. Previously the ✕ sat **7.5px below** the title (21px line box vs a 4px-padded 28px button), and a wrapped title dragged the chips to the block centre while the ✕ stayed high.
- Action column pulled **6px right** so the 15px *glyph* — not the 28px hit target — is 17.5px from both card borders: on the corner diagonal, and flush with the picker column. Hit target still stops 11px from the border, so nothing is clipped.
- Amber `Missing: Diagnosis Code` pill → **`Needs Diagnosis Code` chip** mirroring the green ICD-10 chip on *every* computed property. A card now shows a green code chip or an amber needs-code chip in the same slot at the same size, so coded/uncoded is scannable down the column.
- Title→picker gap **24px → 12px**; the 18px below is kept so the asymmetry groups the picker with the title it belongs to.
- Picker's search-row separator moved onto the body content, fixing a stray gray line across the rounded corner on cards with no candidate codes.

## Bugs fixed

1. **Dismissed conditions were unrecoverable.** The visibility toggle only rendered when `recommendations.length > 0`, and that array excludes condition cards (they live in `commands`). With `hideRejected` defaulting to `true`, a note whose only recommendations were conditions showed **no toggle at all**. Survivable only while the card carried its own Accept button — removing that turned it into data-shaped loss.
2. **Dismissed conditions stayed linkable to charges.** The three charge-matrix predicates gate on `accepted`, and for `assess` the test is `accepted !== false` — assess data has no `accepted` field, so `undefined` passed. All three now also check `!data.rejected`. (Found during implementation, not in the plan.)
3. **Assess headers started 4px below diagnose headers.** `.diagnose-row`'s `4px 0` padding only ever reached assess cards, since `.rec-diagnose` dissolves that element with `display: contents`.

## Note for reviewers

`.rec-warning-pill` was **not** restyled — it has 7 other live uses (`Background too long`, `Assessment too long`, `Missing: X` on the other card families) which keep the louder bordered pill, since those are genuine problems rather than a routine "not picked yet". The new chip is a separate class.

## Testing

- `1483` tests pass unchanged (`tests/hyperscribe/scribe/`). Behaviour is frontend-only, so a failure there would have meant the data contract moved.
- Geometry verified by **measuring rendered layout against the shipped stylesheet** — ✕ and chip centres vs the title's first line, glyph insets, chip parity — rather than by reading CSS. That caught two of the offsets above that reasoning had missed.

⚠️ **Not yet exercised against a live Canvas instance.** There is no JS test harness for this UI, so the interaction behaviour is unverified. Worth walking before merge — especially **(4)** and **(6)**, which are the assess behaviour change and the charge-matrix fix that wasn't in the original plan:

1. Pick a code → card codes *and* settles in one action
2. `✎ Change` → ⋮ offers *Move to Wrap Up* + *Keep current diagnosis*; no picker ✕
3. ✕ dismiss → toggle off → **Tab to the card and press Enter** to restore
4. Same ✕/restore on an **assess** (existing-condition) card
5. Sign gate: uncoded condition blocks with the new copy; a dismissed one does not
6. **Charges panel: a dismissed condition disappears from the linkable list**

Plugin version bumped to `2026-07-27 v0.4.41`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)