### PR TITLE
KOALA-5808: restore chart command buttons after Confirm & Add to note

### DIFF
--- a/hyperscribe/scribe/static/summary.js
+++ b/hyperscribe/scribe/static/summary.js
@@ -3045,6 +3045,33 @@ export function Scribe({ noteId, patientId, staffId, staffName, providerName, pr
         //     console.error('Failed to sign note:', signErr);
         //   }
         // }
+        // RESTORE_BUTTONS_BEFORE_CLOSE_MODAL
+        // Restore the chart-section command buttons BEFORE closing the modal.
+        // CLOSE_MODAL does switch the note back to its body tab, which fires a
+        // NOTE_TAB_CHANGE with tab='note' — but we never receive it. home-app
+        // clears the app's frameData and switches the tab in the same commit
+        // (NoteApplicationIframe.onCloseMessage -> NoteTabsContext
+        // .onCloseApplication), and the iframe's ref cleanup nulls the
+        // MessageChannel port during the mutation phase, before the passive
+        // effect that broadcasts the tab change. sendMessage is a silent no-op
+        // by then, so the restore in the NOTE_TAB_CHANGE handler above never
+        // runs and the buttons stay hidden after "Confirm & Add to note" —
+        // recoverable only by a Scribe/Note tab round-trip or a reload.
+        // Awaited, not fire-and-forget: once CLOSE_MODAL lands this component
+        // is unmounted and an in-flight fetch would be cancelled.
+        if (noteId) {
+          try {
+            await fetch(`${API_BASE}/configure-command-buttons`, {
+              method: 'POST',
+              credentials: 'include',
+              body: JSON.stringify({ note_id: noteId, hidden: false }),
+            });
+          } catch (restoreErr) {
+            // Never block the close on this; the sign and tab-switch paths
+            // both re-assert visibility.
+            console.error('Failed to restore command buttons:', restoreErr);
+          }
+        }
         const port = window.__canvasPort && window.__canvasPort();
         if (port) port.postMessage({ type: 'CLOSE_MODAL' });
       }

--- a/tests/hyperscribe/scribe/api/test_session_view.py
+++ b/tests/hyperscribe/scribe/api/test_session_view.py
@@ -1641,6 +1641,65 @@ def test_summary_js_cache_flip_to_approved_true_is_unconditional_on_success() ->
     )
 
 
+def test_summary_js_restores_command_buttons_before_close_modal() -> None:
+    """KOALA-5808: the approve path must restore the chart-section command
+    buttons BEFORE it posts CLOSE_MODAL, because the CLOSE_MODAL tab change
+    never reaches this iframe.
+
+    Why the NOTE_TAB_CHANGE handler doesn't cover it: CLOSE_MODAL does switch
+    the note back to its body tab (NoteTabsContext.onCloseApplication ->
+    setActiveIndex(applications.length)), which fires a NOTE_TAB_CHANGE with
+    tab='note'. But home-app clears the app's frameData in the same commit
+    (NoteApplicationIframe.onCloseMessage), and the iframe ref cleanup nulls
+    the MessageChannel port (useMessageChannelBroker) during the mutation
+    phase - before the passive effect that broadcasts the tab change. The
+    broadcast is a silent no-op, so without an explicit restore here the
+    buttons stay hidden after "Confirm & Add to note", recoverable only by a
+    Scribe/Note tab round-trip or a page reload.
+
+    Structural-static pin, matching the other summary.js pins in this module
+    (no JS test framework for this file). Two assertions:
+      1. The RESTORE_BUTTONS_BEFORE_CLOSE_MODAL marker is present.
+      2. A POST to /configure-command-buttons carrying ``hidden: false``
+         appears BEFORE the ``CLOSE_MODAL`` postMessage. Ordering is the whole
+         point - after the close, this component is unmounted.
+
+    Caveat: structural, not behavioral. It does not execute the React code and
+    cannot prove the fetch is awaited or that the response is honoured.
+    """
+    from pathlib import Path
+
+    summary_js = Path(__file__).resolve().parents[4] / "hyperscribe" / "scribe" / "static" / "summary.js"
+    src = summary_js.read_text()
+
+    # (1) Marker comment - intent / trace breadcrumb.
+    assert "RESTORE_BUTTONS_BEFORE_CLOSE_MODAL" in src, (
+        "summary.js is missing the RESTORE_BUTTONS_BEFORE_CLOSE_MODAL marker. "
+        "Without an explicit restore before CLOSE_MODAL, the chart-section "
+        "command buttons stay hidden after the provider approves the summary - "
+        "the CLOSE_MODAL tab change cannot reach this iframe because its "
+        "MessageChannel port is already closed. Re-add the "
+        "POST /configure-command-buttons {hidden: false} ahead of the "
+        "CLOSE_MODAL postMessage and mark it with this comment."
+    )
+
+    # (2) Structural: the restore POST must precede the CLOSE_MODAL postMessage.
+    close_modal_idx = src.find("type: 'CLOSE_MODAL'")
+    assert close_modal_idx != -1, (
+        "Expected a `type: 'CLOSE_MODAL'` postMessage in summary.js. If the "
+        "approve flow no longer closes the modal, this pin needs updating."
+    )
+
+    restore_pattern = re.compile(r"configure-command-buttons(?:.|\n){0,400}?hidden:\s*false")
+    restore_match = restore_pattern.search(src[:close_modal_idx])
+    assert restore_match, (
+        "No `POST /configure-command-buttons` with `hidden: false` found BEFORE "
+        "the CLOSE_MODAL postMessage in summary.js. Ordering matters: once "
+        "CLOSE_MODAL lands, home-app unmounts this iframe and closes its port, "
+        "so a restore issued after it is dropped and the buttons stay hidden."
+    )
+
+
 def test_summary_js_stamps_accepted_recommendations_after_insert_commands() -> None:
     """KOALA-5634 ADDITIONAL COMMANDS duplicate regression (recommendations leg).
 


### PR DESCRIPTION
Follow-up to #306. That PR merged before this fix was pushed, so it landed on the branch but never made it into `feat/canvas-scribe`.

## The bug

After the provider clicks **Confirm & Add to note**, the chart-section command buttons stay hidden. Recovery requires a Scribe → Note tab round-trip or a page reload. This is the primary Scribe workflow, so it hit on every approval.

## Why the existing restore didn't cover it

`CLOSE_MODAL` *does* switch the note back to its body tab (`NoteTabsContext.onCloseApplication` → `setActiveIndex(applications.length)`), which fires a `NOTE_TAB_CHANGE` with `tab='note'`. We never receive it:

1. home-app clears the app's `frameData` in the same commit (`NoteApplicationIframe.onCloseMessage`).
2. The iframe's ref cleanup nulls the `MessageChannel` port (`useMessageChannelBroker`) during the **mutation** phase.
3. The `NOTE_TAB_CHANGE` broadcast runs in a **passive effect**, i.e. after that.

So `sendMessage` is a silent no-op by the time the tab change is broadcast, and the restore in `summary.js`'s `NOTE_TAB_CHANGE` handler never runs.

## The fix

POST the restore explicitly, immediately before the `CLOSE_MODAL` postMessage.

`await`ed rather than fire-and-forget: once `CLOSE_MODAL` lands the component unmounts and an in-flight fetch would be cancelled. Failures are logged and never block the close — the sign and tab-switch paths both re-assert visibility.

## Testing

- `test_summary_js_restores_command_buttons_before_close_modal` — follows the existing structural-static pin convention for `summary.js` in that module (marker comment + an assertion that the restore POST precedes the `CLOSE_MODAL` postMessage, since ordering is the whole point).
- I verified the pin **fails** against the pre-fix source rather than passing vacuously.
- 2899 Python tests pass; 18 JS tests pass.

## Caveat

The pin is structural, not behavioural — it does not execute the React code and cannot prove the fetch resolves before unmount. Worth confirming on a live instance: approve a Scribe summary and check the chart rail comes back without a tab round-trip.

## Related

- Remaining known limitations are tracked in KOALA-6545 (visibility leaks across users; last-writer-wins across plugins) and KOALA-6546 (refill approve/deny and unmapped review buttons can't be hidden at all).
- Manual note collapse still strands the buttons; that needs a home-app change and is documented in `command_buttons.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)