### PR TITLE
fix(scribe): dismissing a duplicate condition card no longer blocks approval (KOALA-6555)

### DIFF
--- a/hyperscribe/CANVAS_MANIFEST.json
+++ b/hyperscribe/CANVAS_MANIFEST.json
@@ -1,6 +1,6 @@
 {
   "sdk_version": "0.164.0",
-  "plugin_version": "2026-07-28 v0.4.42",
+  "plugin_version": "2026-07-29 v0.4.43",
   "name": "hyperscribe",
   "description": "Create commands based on the content of an audio discussion between a patient and a provider.",
   "url_permissions": [
@@ -322,9 +322,9 @@
     "VisitTemplates"
   ],
   "tags": {
-    "version_date": "2026-07-27",
-    "version_branch": "koala-5808",
-    "version_semantic": "0.4.41"
+    "version_date": "2026-07-29",
+    "version_branch": "koala-6555",
+    "version_semantic": "0.4.43"
   },
   "custom_data": {
     "namespace": "canvas_medical__scribe",

--- a/hyperscribe/scribe/static/command-drop.js
+++ b/hyperscribe/scribe/static/command-drop.js
@@ -1,0 +1,51 @@
+// Why a command was left out of the /insert-commands batch — the single source of
+// truth for "is this drop the user's choice, or a silent failure we must surface?"
+//
+// handleInsert splits `commands` into `insertable` and `dropped`. Some drops are
+// deliberate (the user unchecked the row, the row is empty, the user dismissed the
+// card); one is not (the row failed validation and would be lost without a word).
+// Only the last kind may block Approve.
+//
+// KOALA-6555: this module exists because that distinction used to be hand-written in
+// two places — the COMMANDS_FILTERED audit reason and the `droppedForValidation`
+// filter — and they drifted. When the ✕ on a condition card started marking
+// `data.rejected` instead of deleting the row, a new *intentional* drop reason was
+// created; neither copy was taught about it, so dismissing a duplicate condition
+// classified as a validation failure and made the note permanently unsignable.
+// Both call sites now read from here, so a new drop reason cannot be added to one
+// without the other.
+//
+// Zero imports on purpose (same as bmi.js / questionnaire-score.js): summary.js is
+// not importable under Node, so this is the only way the classification can carry
+// real unit tests (tests/static/command-drop.test.mjs).
+
+// The two condition-card families. Both render a ✕ that marks `data.rejected` rather
+// than deleting the row, so the assessment text survives a mis-click and the card can
+// be restored (see renderConditionActions in soap-group.js).
+export const CONDITION_COMMAND_TYPES = new Set(['assess', 'diagnose']);
+
+// True when the provider dismissed a condition card with the ✕. Deliberately scoped to
+// the condition families rather than testing `data.rejected` on any type: suppressing a
+// validation error is only sound for a type that ALSO has a matching "rejected ⇒ not
+// insertable" gate. A type that starts writing `data.rejected` without one would
+// otherwise inherit silent error suppression and its command would be dropped from the
+// batch with no message — the exact failure mode `droppedForValidation` exists to catch.
+export const isDismissedCondition = (c) =>
+  CONDITION_COMMAND_TYPES.has(c?.command_type) && !!(c?.data && c.data.rejected);
+
+// Classify a dropped command. `empty_display` / `deselected` / `dismissed` are the
+// user's choices; `validation` means the row would be silently lost and Approve must
+// halt so the provider can fix it.
+//
+// Order matters and mirrors the precedence the audit log has always used: an empty row
+// reports `empty_display` even if it is also deselected or dismissed.
+export const dropReason = (c) => {
+  if (!c?.display) return 'empty_display';
+  if (c.selected === false) return 'deselected';
+  if (isDismissedCondition(c)) return 'dismissed';
+  return 'validation';
+};
+
+// The gate for "should this drop block Approve?" — everything except `validation` is a
+// choice the user made on purpose.
+export const isIntentionalDrop = (c) => dropReason(c) !== 'validation';

--- a/hyperscribe/scribe/static/summary.js
+++ b/hyperscribe/scribe/static/summary.js
@@ -3,6 +3,7 @@ import { useState, useEffect, useCallback, useRef, useMemo } from 'https://esm.s
 import htm from 'https://esm.sh/htm@3.1.1';
 import { SoapGroup, parseAPBlocks, matchCondition } from '/plugin-io/api/hyperscribe/scribe/static/soap-group.js';
 import { collectQuestionnaireScores } from '/plugin-io/api/hyperscribe/scribe/static/questionnaire-score.js';
+import { dropReason, isIntentionalDrop, isDismissedCondition } from '/plugin-io/api/hyperscribe/scribe/static/command-drop.js';
 import { useRecording } from '/plugin-io/api/hyperscribe/scribe/static/recording-hook.js';
 import { useFieldDictation } from '/plugin-io/api/hyperscribe/scribe/static/dictation-hook.js';
 import { initAuditLog, logEvent } from '/plugin-io/api/hyperscribe/scribe/static/audit-log.js';
@@ -144,6 +145,12 @@ function codedNoteDiagnoses(commands) {
   const diags = [];
   for (const c of commands || []) {
     if (c.command_type !== 'diagnose' && c.command_type !== 'assess') continue;
+    // KOALA-6555: a dismissed condition card keeps its ICD-10 code in `data`, but it is
+    // NOT going on the chart. Letting it into this set lets the approve-time linker cite
+    // a diagnosis that never gets inserted — and, via the uniqueness test in
+    // resolveReferralIndication, a dismissed near-duplicate can also make a genuine
+    // match look ambiguous and suppress a link that should have been made.
+    if (isDismissedCondition(c)) continue;
     const d = c.data || {};
     const code = (d.icd10_code || d.code || '').trim();
     if (!code) continue;
@@ -2720,7 +2727,7 @@ export function Scribe({ noteId, patientId, staffId, staffName, providerName, pr
     if (dropped.length > 0) {
       logEvent('COMMANDS_FILTERED', { dropped: dropped.map(c => ({
         type: c.command_type, display: (c.display || '').slice(0, 80), sectionKey: c.section_key,
-        reason: !c.display ? 'empty_display' : c.selected === false ? 'deselected' : 'validation',
+        reason: dropReason(c),
       })) });
     }
     // Batch B — re-link referrals to the provider's final diagnosis code before
@@ -2745,9 +2752,15 @@ export function Scribe({ noteId, patientId, staffId, staffName, providerName, pr
     // a saved command with smart punctuation in sig (OrderRow Save has no
     // ASCII screen) is dropped from `insertable` and the rest of the batch
     // POSTs successfully — modal closes, user has no idea the Rx was lost.
-    // Filter dropped commands to `validation` reasons (empty_display and
-    // deselected are intentional user choices, not silent failures).
-    const droppedForValidation = dropped.filter(c => c.display && c.selected !== false);
+    // Filter dropped commands to `validation` reasons. empty_display, deselected and
+    // dismissed are intentional user choices, not silent failures — see dropReason in
+    // command-drop.js, which the COMMANDS_FILTERED reason above shares so the two
+    // classifications cannot drift. KOALA-6555: they did drift. The assess ✕ started
+    // marking `data.rejected` (excluded from `insertable` at the gate above), which made
+    // a dismissed condition card look like a silent validation failure here and hard-
+    // blocked Approve forever — with a generic "invalid values" error naming a card the
+    // provider could not even see, since hideRejected defaults to true.
+    const droppedForValidation = dropped.filter(c => !isIntentionalDrop(c));
     const allValidationFailures = [
       ...droppedForValidation.map(c => ({ command: c, reason: _commandValidationReason(c) })),
       ...droppedRecs.map(c => ({ command: c, reason: getAcceptedRecFailureReason(c) })),
@@ -3244,6 +3257,10 @@ export function Scribe({ noteId, patientId, staffId, staffName, providerName, pr
     .filter(entry => entry.command.section_key === FROM_THE_NOTE_SECTION);
 
   const insertableCount = commands.filter(c => {
+    // KOALA-6555: a dismissed condition card is not inserted, so it must not be counted
+    // in the "Inserting N commands into note..." label. The diagnose arm already covers
+    // this implicitly (`accepted` is derived as coded && !rejected); assess needs it said.
+    if (isDismissedCondition(c)) return false;
     if (c.command_type === 'diagnose') return c.data?.icd10_code && c.data?.accepted && c.display;
     return !c.already_documented && c.display;
   }).length

--- a/tests/hyperscribe/scribe/api/test_session_view.py
+++ b/tests/hyperscribe/scribe/api/test_session_view.py
@@ -2073,6 +2073,82 @@ def test_summary_js_diagnose_to_assess_upstream_flip() -> None:
     )
 
 
+def test_summary_js_dismissed_condition_is_not_a_validation_failure() -> None:
+    """KOALA-6555: dismissing a duplicate condition card made the note permanently
+    unsignable.
+
+    ``fd595251`` gave condition cards a ✕ that marks ``data.rejected`` instead of
+    deleting the row, and added a matching gate to the ``insertable`` filter so a
+    dismissed card never reaches the chart. Correct so far. But that created a THIRD
+    kind of intentional drop, and the two consumers that interpret ``dropped`` were
+    not taught about it:
+
+      * the ``COMMANDS_FILTERED`` audit reason, and
+      * ``droppedForValidation``, which halts Approve.
+
+    So a dismissed assess classified as a silent validation failure. Approve hard-
+    blocked with the generic "This command has invalid values", naming a card the
+    provider could not see (``hideRejected`` defaults to true) — and because
+    ``NoteLockGuard`` gates the ``LKD`` transition on ``ScribeSummary.approved``, the
+    note could never be signed. 11 notes across 5 providers on brigade.
+
+    The durable fix is that both consumers now read one shared pure classifier,
+    ``dropReason`` in ``command-drop.js``, so a new drop reason cannot be added to one
+    site without the other. The behavioral cases live in
+    ``tests/static/command-drop.test.mjs`` (real unit tests — ``command-drop.js`` has
+    zero imports and is node-importable, which ``summary.js`` is not).
+
+    This is the structural half, matching the other summary.js pins in this module.
+    Three assertions:
+      1. ``summary.js`` imports the shared classifier.
+      2. ``droppedForValidation`` delegates to it rather than hand-rolling the
+         predicate — the hand-rolled copy IS the bug.
+      3. The ``COMMANDS_FILTERED`` reason delegates to it too, so the audit signal
+         and the halt decision cannot disagree again. (The old inline ternary
+         reporting ``'validation'`` for a dismissed card is what made this P0 hard
+         to triage in the first place.)
+
+    Caveat: structural, not behavioral. It does not execute the React code.
+    """
+    from pathlib import Path
+
+    summary_js = Path(__file__).resolve().parents[4] / "hyperscribe" / "scribe" / "static" / "summary.js"
+    src = summary_js.read_text()
+
+    # (1) The shared classifier must be imported.
+    assert "command-drop.js" in src, (
+        "summary.js no longer imports command-drop.js. The drop classification must "
+        "stay in one shared module: KOALA-6555 happened because the 'is this drop "
+        "intentional?' rule was hand-written in two places that drifted apart when "
+        "the condition-card ✕ started marking data.rejected."
+    )
+
+    # (2) droppedForValidation must delegate, not re-implement.
+    dfv_pattern = re.compile(r"droppedForValidation\s*=\s*dropped\.filter\(\s*c\s*=>\s*!isIntentionalDrop\(c\)\s*\)")
+    assert dfv_pattern.search(src) is not None, (
+        "`droppedForValidation` is not delegating to `isIntentionalDrop` from "
+        "command-drop.js. Re-implementing the predicate inline is exactly what "
+        "caused KOALA-6555: the inline version tested only `c.display && "
+        "c.selected !== false`, so a dismissed condition card (display set, "
+        "`selected` true-or-absent, `data.rejected` true) counted as a silent "
+        "validation failure and permanently blocked Approve."
+    )
+
+    # (3) The audit reason must come from the same classifier.
+    assert "reason: dropReason(c)" in src, (
+        "The COMMANDS_FILTERED audit no longer reports `dropReason(c)`. Keep the "
+        "audit reason and the Approve-halt decision on the same classifier — a "
+        "dismissed condition logged as reason 'validation' is the misleading signal "
+        "that made KOALA-6555 hard to triage (106 bogus assess/validation events "
+        "across 11 notes)."
+    )
+    assert "'deselected' : 'validation'" not in src, (
+        "Found the pre-KOALA-6555 inline drop-reason ternary in summary.js. It "
+        "predates the `dismissed` reason and mislabels every dismissed condition "
+        "card as a validation failure; use `dropReason(c)` from command-drop.js."
+    )
+
+
 def test_summary_js_commit_recommendations_helper_centralizes_prime() -> None:
     """KOALA-5634 single-helper invariant for ref-prime ordering.
 

--- a/tests/static/command-drop.test.mjs
+++ b/tests/static/command-drop.test.mjs
@@ -1,0 +1,119 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  dropReason,
+  isIntentionalDrop,
+  isDismissedCondition,
+} from '../../hyperscribe/scribe/static/command-drop.js';
+
+// The record shape taken verbatim from the cached ScribeSummary rows of the notes that
+// KOALA-6555 made unsignable on brigade: command_type assess, data.rejected true,
+// data.accepted ALSO true (dismissAssess does not clear it), empty narrative, a populated
+// condition_id, no `selected` key at all, and no command_uuid.
+const STUCK_DISMISSED_ASSESS = {
+  command_type: 'assess',
+  display: 'Chronic kidney disease, stage 3a',
+  section_key: 'assessment_and_plan',
+  command_uuid: null,
+  already_documented: false,
+  data: {
+    rejected: true,
+    accepted: true,
+    narrative: '',
+    condition_id: 'c0ffee00-0000-4000-8000-000000000000',
+  },
+};
+
+test('KOALA-6555: a dismissed assess card is an intentional drop, not a validation failure', () => {
+  // This is the regression. Before the fix, this command classified as 'validation',
+  // which hard-blocked Approve with "This command has invalid values" and left the note
+  // permanently unsignable — naming a card hidden by the hideRejected default.
+  assert.equal(dropReason(STUCK_DISMISSED_ASSESS), 'dismissed');
+  assert.equal(isIntentionalDrop(STUCK_DISMISSED_ASSESS), true);
+});
+
+test('a dismissed assess is still intentional when the backend supplied selected: true', () => {
+  // Backend proposals ship `selected: true` (CommandProposal.selected defaults True), so
+  // the classification must not lean on `selected` being absent.
+  const withSelected = { ...STUCK_DISMISSED_ASSESS, selected: true };
+  assert.equal(dropReason(withSelected), 'dismissed');
+  assert.equal(isIntentionalDrop(withSelected), true);
+});
+
+test('a dismissed diagnose card is also an intentional drop', () => {
+  const dismissedDiagnose = {
+    command_type: 'diagnose',
+    display: 'Other specified polyneuropathies',
+    data: { rejected: true, accepted: false, icd10_code: 'G62.89' },
+  };
+  assert.equal(dropReason(dismissedDiagnose), 'dismissed');
+  assert.equal(isIntentionalDrop(dismissedDiagnose), true);
+});
+
+test('a live condition card that gets dropped is still a validation failure', () => {
+  const liveAssess = {
+    command_type: 'assess',
+    display: 'Type 2 diabetes mellitus',
+    data: { narrative: 'Stable on metformin.', condition_id: 'abc' },
+  };
+  assert.equal(dropReason(liveAssess), 'validation');
+  assert.equal(isIntentionalDrop(liveAssess), false);
+
+  // rejected: false must not be read as dismissed (restoreAssess writes exactly this).
+  const restored = { ...liveAssess, data: { ...liveAssess.data, rejected: false } };
+  assert.equal(dropReason(restored), 'validation');
+});
+
+test('empty_display takes precedence over dismissed and deselected', () => {
+  // Preserves the precedence the COMMANDS_FILTERED audit has always used.
+  const noDisplay = { ...STUCK_DISMISSED_ASSESS, display: '' };
+  assert.equal(dropReason(noDisplay), 'empty_display');
+  assert.equal(dropReason({ command_type: 'assess', display: '', selected: false }), 'empty_display');
+  assert.equal(dropReason({ command_type: 'perform', display: undefined }), 'empty_display');
+});
+
+test('deselected takes precedence over dismissed', () => {
+  const both = { ...STUCK_DISMISSED_ASSESS, selected: false };
+  assert.equal(dropReason(both), 'deselected');
+  assert.equal(isIntentionalDrop(both), true);
+});
+
+test('an unchecked row is deselected', () => {
+  const deselected = { command_type: 'perform', display: '99213 — Office visit', selected: false };
+  assert.equal(dropReason(deselected), 'deselected');
+  assert.equal(isIntentionalDrop(deselected), true);
+});
+
+test('data.rejected on a NON-condition type does not suppress its validation error', () => {
+  // The narrow scoping is the point. A prescribe row is dropped by the Rx-completeness
+  // gate, not by any rejected gate, so suppressing its error here would silently lose the
+  // prescription — the failure mode droppedForValidation exists to catch. A blanket
+  // `!c.data?.rejected` filter would have masked it.
+  for (const type of ['prescribe', 'refill', 'adjust_prescription', 'refer', 'imaging_order', 'lab_order']) {
+    const cmd = { command_type: type, display: 'Lisinopril 10 mg', data: { rejected: true } };
+    assert.equal(isDismissedCondition(cmd), false, `${type} must not count as a dismissed condition`);
+    assert.equal(dropReason(cmd), 'validation', `${type} must still report a validation failure`);
+    assert.equal(isIntentionalDrop(cmd), false);
+  }
+});
+
+test('tolerates missing or malformed commands without throwing', () => {
+  // Condition cards have reached this code with no `data` before (KOALA-5687), and an
+  // unguarded read there blanks the whole Scribe tab.
+  assert.equal(dropReason({ command_type: 'assess', display: 'Asthma' }), 'validation');
+  assert.equal(dropReason({ command_type: 'assess', display: 'Asthma', data: null }), 'validation');
+  assert.equal(dropReason(undefined), 'empty_display');
+  assert.equal(dropReason(null), 'empty_display');
+  assert.equal(dropReason({}), 'empty_display');
+  assert.equal(isDismissedCondition(undefined), false);
+  assert.equal(isDismissedCondition({ command_type: 'assess' }), false);
+  assert.equal(isDismissedCondition({ command_type: 'assess', data: null }), false);
+});
+
+test('isDismissedCondition only recognises the two condition families', () => {
+  assert.equal(isDismissedCondition({ command_type: 'assess', data: { rejected: true } }), true);
+  assert.equal(isDismissedCondition({ command_type: 'diagnose', data: { rejected: true } }), true);
+  assert.equal(isDismissedCondition({ command_type: 'task', data: { rejected: true } }), false);
+  assert.equal(isDismissedCondition({ command_type: 'assess', data: { rejected: false } }), false);
+});


### PR DESCRIPTION
[KOALA-6555](https://canvasmedical.atlassian.net/browse/KOALA-6555) — P0 regression. Pylon #31325, #31372.

## The bug

Dismissing a duplicate Assessment card made the note **permanently unsignable**. Approve hard-blocked with the generic _"This command has invalid values. Open it to fix before approving."_ — naming a card the provider **could not see**, since `hideRejected` defaults to `true`. `NoteLockGuard` gates the `LKD` transition on `ScribeSummary.approved`, so signing was unreachable. 11 notes across 5 providers on brigade; one provider retried 8 times in ~12 minutes, another note logged 14 attempts.

Dismissing is currently the *only* way to remove an unwanted condition card, so the single action available to a provider facing a duplicate was the action that broke the note.

## Root cause — an asymmetry with `diagnose`, not a missing guard

`fd595251` gave condition cards a ✕ that marks `data.rejected` instead of deleting the row, and added a matching gate to the `insertable` filter so a dismissed card never reaches the chart. **That part was correct.** But it created a *third* kind of intentional drop, and neither consumer that interprets `dropped` was taught about it — the `COMMANDS_FILTERED` audit reason and `droppedForValidation`, which halts Approve. Both hand-rolled the same three-way classification, and they drifted.

Line `2706`'s trailing `&& !(c.data && c.data.rejected)` is a double negative, so a dismissed **diagnose** *passes* the gate, stays in `insertable`, never enters `dropped`, and is stripped later at `2786`. The new **assess** gate was a hard `return false` with no equivalent late strip, so it landed in `dropped` and read as a silent validation failure.

Verified against the stuck record's exact shape:

| | pre-fix | post-fix |
|---|---|---|
| `dropReason` | `validation` | `dismissed` |
| blocks Approve | **yes** | no |

## The fix

Extract the classification into **`command-drop.js`** (zero imports, so it is node-importable and can carry real unit tests — `summary.js` cannot be imported under Node) and have both consumers read `dropReason` / `isIntentionalDrop` from it. A new drop reason can no longer be added to one site without the other.

The exemption is scoped to the two condition families rather than a blanket `!c.data?.rejected`. Suppressing a validation error is only sound for a type that *also* has a matching "rejected ⇒ not insertable" gate; a blanket test would hand any future type that starts writing `data.rejected` silent error suppression without the exclusion — the lost-prescription mode `droppedForValidation` exists to catch. There is a test pinning that scoping.

**Two related fixes from the same root cause:**

- `codedNoteDiagnoses` fed dismissed-but-coded cards to the approve-time referral linker, so a referral could be committed citing a diagnosis that never gets inserted — and via the uniqueness test in `resolveReferralIndication`, a dismissed near-duplicate could make a genuine match look ambiguous and suppress a link that *should* have been made.
- `insertableCount` over-counted dismissed assess rows in the "Inserting N commands into note…" label.

## Deliberate deviations from the ticket's suggested fix

- **No `assess` branch in `_commandValidationReason`.** It would be dead code: assess can only fail two gates, and `droppedForValidation` already excludes the other one (`!display`).
- **Scoped, not blanket** exemption — see above.

## Ticket claims that needed correcting

- `selected` **is** set to `true` on backend proposals (`CommandProposal.selected` defaults `True`), so the fix must not lean on it being absent. There's a test for the `selected: true` variant.
- The `hideRejected` toggle **does** render for an assess-only dismissal — `summary.js:3510` already includes `'assess'`. The documented provider workaround is genuinely reachable.
- `background` is **not** server-validated (`AssessParser.validate` checks only `narrative`; SDK `AssessCommand.background` has no `max_length`), so only `narrative` matters for the length issue.

## Testing

- `tests/static/command-drop.test.mjs` — 11 new tests in the only CI-covered JS location (`node --test 'tests/static/**/*.test.mjs'`), using the stuck record's exact cached shape as the regression case. **28/28 pass.**
- `test_session_view.py` — structural pin matching this file's existing `summary.js` pin convention, including a negative assertion against the old inline ternary. **209/209 pass.**
- `./lint.sh` (ruff check, ruff format, mypy, pytest) green.

**Not verified:** no live repro. The ticket's own "Steps to reproduce" section is unfilled, and its mechanism was derived from deployed source rather than observed. Everything here comes from source, the SDK models, and the two test suites — a manual pass is still worth doing (see below).

## Release notes

Purely client-side. `ScribeSummary.commands` is an opaque `JSONField` round-tripped verbatim and `NoteLockGuard` only reads `approved`, so **no migration or backfill**.

But it is **not self-healing**: `approved` only flips via the client POST, so each of the 11 stuck notes needs someone to open the Scribe tab and click Approve once. Static JS is served with no cache-busting or `Cache-Control`, so that pass needs a **hard reload**.

Manifest bumped to `2026-07-29 v0.4.43`. Also repairs the `tags` block, which had drifted (`2026-07-27` / `0.4.41` while `plugin_version` already read `v0.4.42`).

## Manual verification still to do

- [ ] Dismiss a duplicate condition → Approve succeeds
- [ ] Dismissed condition is absent from the chart after insert
- [ ] Restore-by-click still works, and the Hide Dismissed toggle still appears
- [ ] A genuinely invalid command (e.g. incomplete Rx) still blocks Approve with its specific message

## Follow-ups worth filing separately

- Condition cards have **no delete**, only dismiss (`renderConditionActions` accepts only `onDismiss`).
- A non-dismissed assess with `narrative > 2048` has no client gate and 400s the whole insert batch server-side.
- `AssessParser.build` passes `condition_id=data.get("condition_id") or ""` with no presence check.
- `dismissAssess` leaves `accepted: true` beside `rejected: true`. Currently harmless — all consumers check `rejected` first — but contradictory, and it touches 3+ read sites, so it was left out of a P0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[KOALA-6555]: https://canvasmedical.atlassian.net/browse/KOALA-6555?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ