### PR TITLE
feat(scribe): polish the finalized read-only note view (KOALA-5631)

### DIFF
--- a/hyperscribe/scribe/static/soap-group.js
+++ b/hyperscribe/scribe/static/soap-group.js
@@ -819,7 +819,6 @@ export function SoapGroup({ title, groupColor, sections, commandBySectionKey, on
              (key === 'prescription' && visibleRecs.some(r => r.command_type === 'prescribe')));
           const DEDICATED_SECTION_KEYS = new Set(['current_medications', 'allergies']);
           const HISTORY_SECTION_KEYS = new Set(['past_medical_history', 'past_surgical_history', 'family_history']);
-          const isCoveredHistory = coveredKeys.has(key) && HISTORY_SECTION_KEYS.has(key);
           if (coveredKeys.has(key) && !hasRecsForKey && !DEDICATED_SECTION_KEYS.has(key) && !HISTORY_SECTION_KEYS.has(key)) return null;
           const cmds = commandBySectionKey && commandBySectionKey[key];
 
@@ -1509,7 +1508,16 @@ export function SoapGroup({ title, groupColor, sections, commandBySectionKey, on
           // plan commands), so raw `s.text` is always a duplicate — and it becomes a stale,
           // uneditable duplicate once every card is moved to Wrap Up (which empties
           // assessment_and_plan of commands and drops rendering into this fallback).
-          const showHistoryText = s.text && !isCoveredHistory && key !== 'assessment_and_plan';
+          // Never print raw note text for a key a review command already renders
+          // inside its card (chart_review covers allergies / current_medications /
+          // immunizations; history_review covers the four history keys; see
+          // getCoveredKeys). Same reasoning as the assessment_and_plan exclusion
+          // above: the card is the live, editable copy, so the raw section text is
+          // a stale uneditable duplicate. This used to check covered HISTORY keys
+          // only, which left current_medications, allergies, and social_history
+          // printing a second, unstyled copy below their card whenever the
+          // dedicated branch above found nothing to render (KOALA-5631 follow-up).
+          const showHistoryText = s.text && !coveredKeys.has(key) && key !== 'assessment_and_plan';
           // social_history has no manual input affordance (not in NARRATIVE_SECTIONS,
           // no SECTION_TO_HISTORY_TYPE entry), so an empty Social History section is a
           // dead, un-fillable header. Hide it whenever it has nothing to show; the AI

--- a/hyperscribe/scribe/static/styles.css
+++ b/hyperscribe/scribe/static/styles.css
@@ -426,6 +426,92 @@ h2 { margin-bottom: 4px; }
   cursor: not-allowed;
 }
 
+/* Finalized notes (approved === true). Every card is on the note and nothing is
+   editable, so amend mode's per-card dim + padlock + "Already in chart" badge
+   describe 100% of the view and inform nothing — a signed note ends up looking
+   like a form someone greyed out. soap-group.js still EMITS all of that chrome
+   (it's correct while amending, where the dim contrasts locked rows against
+   still-editable ones — see rowLocked/ICON_LOCK in soap-group.js); this block
+   suppresses it for the finished document. Everything here is scoped to
+   --finalized, which only exists when approved, so amend mode and the
+   locked-but-incomplete state (.summary-container--readonly above) are
+   untouched. Purely subtractive: no geometry, border, or spacing changes. */
+
+/* full contrast: drop the dim and the padlock */
+.summary-container--finalized .command-locked {
+  opacity: 1;
+  filter: none;
+}
+.summary-container--finalized .command-row-icon-lock {
+  display: none;
+}
+
+/* medication and allergy rows dim THEMSELVES as well, via the `documented`
+   class their view branch adds when already_documented (medication-row.js,
+   allergy-row.js) — the same "already on the note" signal applied a second time
+   at row level, stacking with .command-locked above. Both have to be cleared or
+   these two card types stay grey while everything around them goes full
+   contrast. They already set cursor: default, so only the opacity needs
+   overriding. */
+.summary-container--finalized .medication-row.documented,
+.summary-container--finalized .allergy-row.documented {
+  opacity: 1;
+}
+
+/* the settled badge is redundant here: in read-only mode SoapGroup already
+   filters to only the commands that made it onto the note, so "Already in
+   chart" is true of everything on screen. */
+.summary-container--finalized .rec-settled {
+  display: none;
+}
+
+/* collapse the now-empty action gutter, but KEEP over-limit warning pills —
+   they share this container and flag genuinely truncated content (an
+   over-2048-character background/assessment), which must never be hidden. */
+.summary-container--finalized .recommendation-actions:not(:has(.rec-warning-pill)) {
+  display: none;
+}
+/* this padding existed only to clear the padlock */
+.summary-container--finalized .from-the-note-label {
+  padding-right: 0;
+}
+
+/* no phantom hover on cards that can't be opened. Selector shapes mirror the
+   originals below so specificity wins — the .content-block hover rule is
+   (0,4,0), so a plain descendant override would lose to it. */
+.summary-container--finalized .content-block:not(.recommendation-block):not(:has(.editing)):hover {
+  background: #fff;
+}
+.summary-container--finalized .recommendation-block .medication-row:hover:not(.editing):not(.documented),
+.summary-container--finalized .recommendation-block .allergy-row:hover:not(.editing):not(.documented),
+.summary-container--finalized .recommendation-block .order-row:hover:not(.editing) {
+  background: transparent;
+}
+
+/* rows set cursor: pointer unconditionally; nothing here opens */
+.summary-container--finalized .command-row,
+.summary-container--finalized .vitals-row,
+.summary-container--finalized .medication-row,
+.summary-container--finalized .allergy-row,
+.summary-container--finalized .task-row,
+.summary-container--finalized .order-row,
+.summary-container--finalized .charge-row,
+.summary-container--finalized .history-review-row,
+.summary-container--finalized .questionnaire-view {
+  cursor: default;
+}
+
+/* charges table: the grips, ghost column, and empty-add cell are already
+   !readOnly-gated in charge-matrix.js, so only their styling residue is left */
+.summary-container--finalized .cm-lock,
+.summary-container--finalized .cm-grip-empty,
+.summary-container--finalized .cm-ghost-check {
+  display: none;
+}
+.summary-container--finalized .cm-row-locked .cm-dxlabel {
+  color: #1f2937;
+}
+
 .readonly-banner {
   display: flex;
   align-items: center;

--- a/hyperscribe/scribe/static/summary.js
+++ b/hyperscribe/scribe/static/summary.js
@@ -590,6 +590,12 @@ export function Scribe({ noteId, patientId, staffId, staffName, providerName, pr
   const [diagnosisSuggestions, setDiagnosisSuggestions] = useState(initSummary?.diagnosis_suggestions ?? {});
   const [progress, setProgress] = useState({ step: -1, total: 0, label: '' });
   const [verificationResult, setVerificationResult] = useState(null);
+  // Run-once latch for the load-time auto-verify below. It used to lean on
+  // `verificationResult` being non-null, but that only worked because a clean
+  // verify still set a result; now that success is silent on load, the effect
+  // needs its own latch or it would re-POST /verify-commands every time
+  // syncNoteCommands hands back fresh `commands` / `recommendations` arrays.
+  const autoVerifiedRef = useRef(false);
   const [validationError, setValidationError] = useState(null);
   const [chargeErrors, setChargeErrors] = useState([]);
 
@@ -616,7 +622,10 @@ export function Scribe({ noteId, patientId, staffId, staffName, providerName, pr
   // `mode === 'ai'` gate at the top-bar render) since the transport can't
   // change mid-session.
   const [captureMode, setCaptureMode] = useState('conversation');
-  const [transcriptCollapsed, setTranscriptCollapsed] = useState(false);
+  // Collapsed by default on an already-finalized note: the transcript is capture
+  // scaffolding, and a finished note should open on the note, not on 40+ lines of
+  // dialogue. Still one click away, and the header shows the entry count.
+  const [transcriptCollapsed, setTranscriptCollapsed] = useState(initSummary?.approved ?? false);
   // Auto-scroll the transcript body to the latest entry whenever live capture
   // is producing or refining content. We deliberately don't try to "respect"
   // a user's scroll-up while recording — clinicians want to keep seeing the
@@ -1291,6 +1300,12 @@ export function Scribe({ noteId, patientId, staffId, staffName, providerName, pr
           }
           if (cached.approved) {
             setApproved(true);
+            // Same default as the `initialData` path applies at mount (see
+            // transcriptCollapsed's initializer): a note that ARRIVES finalized
+            // opens on the note, not on the transcript. Set here rather than in an
+            // effect on `approved` so it can't also fire when the user signs
+            // in-session and yank the panel closed under them.
+            setTranscriptCollapsed(true);
           }
           // Treat cached.approved as implying was_finalized for pre-existing
           // finalized notes that predate the explicit latch.
@@ -1382,12 +1397,13 @@ export function Scribe({ noteId, patientId, staffId, staffName, providerName, pr
 
   // Auto-verify on load when approved with command UUIDs.
   useEffect(() => {
-    if (!approved || verificationResult) return;
+    if (!approved || verificationResult || autoVerifiedRef.current) return;
     const withUuids = [
       ...commands.filter(c => c.command_uuid && !isFromNoteCommand(c)),
       ...recommendations.filter(c => c.command_uuid),
     ];
     if (withUuids.length === 0) return;
+    autoVerifiedRef.current = true;
     const attempted = withUuids.map(c => ({
       command_uuid: c.command_uuid,
       command_type: c.command_type,
@@ -1404,9 +1420,12 @@ export function Scribe({ noteId, patientId, staffId, staffName, providerName, pr
         const data = await res.json();
         if (cancelled) return;
         const failedCount = data.failed?.length || 0;
-        setVerificationResult(failedCount > 0
-          ? { ok: false, verified: data.verified || [], failed: data.failed }
-          : { ok: true, verified: data.verified || [], failed: [] });
+        // Only surface failures on LOAD. "All N command(s) inserted successfully"
+        // is real feedback at the moment of signing (set unconditionally on the
+        // handleInsert success path), but on every later visit to a finished note
+        // it's just workflow residue. Failures still surface in both paths.
+        if (failedCount === 0) return;
+        setVerificationResult({ ok: false, verified: data.verified || [], failed: data.failed });
       } catch (err) {
         console.error('Auto-verify failed:', err);
       }
@@ -3409,7 +3428,7 @@ export function Scribe({ noteId, patientId, staffId, staffName, providerName, pr
   const progressPct = Math.max(((progressIndex + 1) / TOTAL_PROGRESS_STEPS) * 100, 5);
 
   return html`
-    <div class=${`summary-container${readOnlyReason === 'locked' ? ' summary-container--readonly' : ''}${!isAuthor ? ' summary-container--readonly-viewer' : ''}`}>
+    <div class=${`summary-container${approved ? ' summary-container--finalized' : ''}${readOnlyReason === 'locked' ? ' summary-container--readonly' : ''}${!isAuthor ? ' summary-container--readonly-viewer' : ''}`}>
       ${isNoteEditable && wasFinalized && html`
         <div class=${`summary-status-pill summary-status-pill--${approved ? 'finalized' : 'amending'}`} role="status" aria-live="polite">
           <svg class="summary-status-pill-icon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">


### PR DESCRIPTION
## Problem

Once a note is finalized, the Scribe view reads as *disabled* rather than *done* — every card at 60% opacity, a padlock in each corner, an "Already in chart ✓" badge on each row.

That treatment belongs to **amend mode**, where the dim distinguishes rows already on the note from rows you can still edit. The predicate behind it (`rowReadOnly && already_documented`) happens to be true for *every* card once `approved === true`, so it applies to everything and communicates nothing. Same for the settled badge: read-only mode already filters to only inserted items (`soap-group.js:776-781`), so "Already in chart" describes 100% of what's on screen.

## Approach

Gate the chrome behind a new `.summary-container--finalized` class rather than rewriting the 30+ sites in `soap-group.js` that emit it.

Those sites are correct while amending — only the finished-document *presentation* changes. Scoping every rule under a class that exists solely when `approved === true` makes it structurally impossible to affect amend mode or the locked-but-incomplete state, and no predicate governing editability (`rowLocked`, `readOnly`, `<fieldset disabled>`, server-side `_authorize_edit`) is touched. The trade-off is dead DOM: the padlock SVG and badge still render, hidden. Removing those nodes is a clean follow-up against a design that's already settled.

`approved` comes from the summary payload rather than the viewer, so the author's finalized view and a colleague's read-only view of the same note both get the treatment from one condition.

## Changes

**`styles.css`** — one `.summary-container--finalized` block: full contrast, no padlock, no settled badge, no hover backgrounds, no pointer cursors on cards that can't open, and the charges-table editing residue (grips, ghost checks, lock column) cleared.

Medication and allergy rows needed a second rule. Their view branches (`medication-row.js:145`, `allergy-row.js:146`) add a `documented` class carrying an **independent** 0.55 opacity that stacks with the card-level dim — so clearing only `.command-locked` left those two card types grey while everything around them went full contrast.

**`summary.js`** — three small edits: the container class, transcript collapsed by default on a note that *arrives* finalized (set in both the `initialData` and cache-restore paths, so it can't fire when someone signs in-session and yank the panel shut), and the success verification banner no longer reappearing on revisit. It still shows at the moment of signing, and failures still surface in both paths. That change removed the effect's run-once latch, so it gets an explicit `autoVerifiedRef` — otherwise it would re-POST `/verify-commands` every time `syncNoteCommands` returns fresh arrays.

**`soap-group.js`** — generalize the raw-section-text guard from covered *history* keys to any key a review command covers. `HISTORY_SECTION_KEYS` omits `current_medications`, `allergies`, and `social_history`, so each rendered a second, unstyled copy below its card whenever the dedicated branch found nothing to show. Same reasoning as the existing `assessment_and_plan` exclusion directly above it: the card is the live, editable copy; the raw text is a stale duplicate.

## Reviewer notes

- **The `soap-group.js` change is the one to scrutinize.** It's the only change that also affects the **editing** view, and it has no test coverage — the logic sits inside a large Preact render. Happy to add a structural pin in `test_session_view.py` alongside the existing `summary.js` marker pins if that's wanted.
- Nothing editable is lost by the suppression: the removed copy was a `<p>`; the live copy is the Chart Review / History Review card.
- `current_medications` and `allergies` never reach that fallback while editing — `onAddMedication` / `onAddAllergy` are non-null there and satisfy the guard at `soap-group.js:1287`.

## Verification

`./lint.sh` passes (ruff, ruff format, mypy, 2900 pytest). `node --test 'tests/static/**/*.test.mjs'` passes 28.

Reviewed against a real finalized note during development, which is how the `.documented` double-dim surfaced.

**Not yet exercised in a running instance** — worth covering before merge:
- [ ] Amend mode: click "Make changes" and confirm padlocks and dimming **return** on already-documented rows
- [ ] Note locked with Scribe incomplete: container dim and "click Amend to finish" banner unchanged
- [ ] The duplicate-suppression fix on a note with `_chart_review` / `_history_review` content
- [ ] Transcript collapsed on load; success banner present at signing, absent on reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)