### PR TITLE
fix(scribe): recover dictated PRN medications from the transcript (KOALA-6644)

### DIFF
--- a/hyperscribe/scribe/api/session_view.py
+++ b/hyperscribe/scribe/api/session_view.py
@@ -47,6 +47,7 @@ from hyperscribe.scribe.clients.nabla.backend import NablaBackend
 from hyperscribe.scribe.backend import (
     ClinicalNote,
     CodingEntry,
+    CommandProposal,
     Condition,
     NoteSection,
     Observation,
@@ -86,6 +87,7 @@ from hyperscribe.scribe.commands.problem_list_match import (
 )
 from hyperscribe.scribe.recommendations import make_llm_client, prescription_dispense_enabled, recommend_commands
 from hyperscribe.scribe.recommendations._referral_diagnosis import link_referral_diagnoses
+from hyperscribe.scribe.recommendations._transcript_windows import PRN_PATTERN, find_keyword_matches
 from hyperscribe.scribe.recommendations.diagnosis_llm_resolver import (
     BlockContext as DiagnosisBlockContext,
     resolve_uncoded_blocks,
@@ -1368,6 +1370,7 @@ class ScribeSessionView(StaffSessionAuthMixin, SimpleAPI):
         # ── Step 3: Recommend commands ──
         _save_progress(note_id, 3, total, SUMMARY_STEPS[3])
         recommendations_list: list[dict[str, Any]] = []
+        rec_proposals: list[CommandProposal] = []
         api_key = self.secrets.get("AnthropicAPIKey", "")
         if api_key:
             try:
@@ -1403,6 +1406,29 @@ class ScribeSessionView(StaffSessionAuthMixin, SimpleAPI):
                 ]
             except Exception:
                 log.exception("recommend_commands failed (non-critical)")
+
+        # KOALA-6644: the defect was invisible — a dropped PRN produced no error, no log
+        # line and no audit row, so the only signal was absence. Record how many as-needed
+        # mentions the transcript carried against how many medications were actually
+        # recovered from it. Mentions with zero recoveries is the remaining-silent-drop
+        # case, and is what a later remediation sweep can select on.
+        #
+        # Deliberately outside the try above: that block swallows the entire recommendation
+        # stage as "non-critical", so emitting inside it would lose the telemetry in exactly
+        # the runs where a medication went missing. Emitted only when the transcript
+        # mentioned as-needed dosing at all, so the audit log stays signal-dense (mirrors
+        # VITALS_FIELD_REFUSED). Counts only — no drug names, no sigs, no transcript text.
+        if note_uuid and transcript:
+            prn_mentions = len(find_keyword_matches(transcript, PRN_PATTERN))
+            if prn_mentions:
+                audit_event(
+                    note_uuid,
+                    "MEDS_PRN_TRANSCRIPT",
+                    {
+                        "prn_mentions": prn_mentions,
+                        "recovered_from_transcript": sum(1 for p in rec_proposals if p.from_transcript),
+                    },
+                )
 
         # ── Step 3b: Check medication interactions ──
         interaction_warnings: list[dict[str, Any]] = []

--- a/hyperscribe/scribe/api/session_view.py
+++ b/hyperscribe/scribe/api/session_view.py
@@ -1307,6 +1307,7 @@ class ScribeSessionView(StaffSessionAuthMixin, SimpleAPI):
                 "selected": p.selected,
                 "section_key": p.section_key,
                 "already_documented": p.already_documented,
+                "from_transcript": p.from_transcript,
             }
             for p in proposals
         ]
@@ -1396,6 +1397,7 @@ class ScribeSessionView(StaffSessionAuthMixin, SimpleAPI):
                         "selected": p.selected,
                         "section_key": p.section_key,
                         "already_documented": p.already_documented,
+                        "from_transcript": p.from_transcript,
                     }
                     for p in rec_proposals
                 ]
@@ -1641,6 +1643,7 @@ class ScribeSessionView(StaffSessionAuthMixin, SimpleAPI):
                             "selected": p.selected,
                             "section_key": p.section_key,
                             "already_documented": p.already_documented,
+                            "from_transcript": p.from_transcript,
                         }
                         for p in proposals
                     ],
@@ -1669,9 +1672,26 @@ class ScribeSessionView(StaffSessionAuthMixin, SimpleAPI):
         zip_codes = resolve_zip_codes(patient_id, rec_note_id) or None
         allowlist = self.secrets.get(Constants.SECRET_SCRIBE_PRESCRIPTION_STAFFERS, "")
         dispense_engine_enabled = prescription_dispense_enabled(allowlist, _note_provider_id(rec_note_id))
+        # The medication recommenders fall back to the transcript when the generated note has
+        # dropped a PRN, so this endpoint must supply it too — otherwise re-running
+        # recommendations standalone silently reintroduces KOALA-6644.
+        transcript_data = data.get("transcript", {})
+        if not transcript_data.get("items") and rec_note_id:
+            try:
+                transcript_data = _load_transcript(rec_note_id)
+            except Exception:
+                # Recovering PRNs is an enhancement over the note-only path; never let a
+                # missing or unreadable transcript fail the whole endpoint.
+                log.exception("Could not load transcript for recommendations; falling back to note only")
+                transcript_data = {}
+        transcript = _parse_transcript(transcript_data) if transcript_data.get("items") else None
         try:
             proposals = recommend_commands(
-                note, api_key, zip_codes=zip_codes, dispense_engine_enabled=dispense_engine_enabled
+                note,
+                api_key,
+                zip_codes=zip_codes,
+                transcript=transcript,
+                dispense_engine_enabled=dispense_engine_enabled,
             )
         except Exception:
             log.exception("recommend_commands failed")
@@ -1695,6 +1715,7 @@ class ScribeSessionView(StaffSessionAuthMixin, SimpleAPI):
                             "selected": p.selected,
                             "section_key": p.section_key,
                             "already_documented": p.already_documented,
+                            "from_transcript": p.from_transcript,
                         }
                         for p in proposals
                     ],

--- a/hyperscribe/scribe/backend/models.py
+++ b/hyperscribe/scribe/backend/models.py
@@ -110,6 +110,7 @@ class CommandProposal:
         selected: bool = True,
         section_key: str = "",
         already_documented: bool = False,
+        from_transcript: bool = False,
     ) -> None:
         self.command_type = command_type
         self.display = display
@@ -117,6 +118,9 @@ class CommandProposal:
         self.selected = selected
         self.section_key = section_key
         self.already_documented = already_documented
+        # True when this proposal was recovered from the visit transcript because the
+        # generated note omitted it. Drives the "from transcript" badge in the review UI.
+        self.from_transcript = from_transcript
 
 
 class PatientContext:

--- a/hyperscribe/scribe/commands/medication_statement.py
+++ b/hyperscribe/scribe/commands/medication_statement.py
@@ -11,6 +11,7 @@ from canvas_sdk.v1.data.note import Note
 
 from hyperscribe.scribe.backend.models import CommandProposal
 from hyperscribe.scribe.commands.base import CommandParser
+from hyperscribe.scribe.recommendations._transcript_windows import PRN_PATTERN
 
 _BULLET_RE = re.compile(r"^(?:\d+[.)]\s*|[-*]\s+)")
 
@@ -69,21 +70,30 @@ class MedicationParser(CommandParser):
         patient = note.patient
         if patient is None:
             return
-        active_labels = set(
-            MedicationCoding.objects.filter(
-                medication__patient=patient,
-                medication__status="active",
-            ).values_list("display", flat=True)
-        )
-        active_labels_lower = {label.lower() for label in active_labels if label}
+        # Pull the drug label together with the sig of any statement documenting it, in one
+        # query, so an as-needed proposal can be told apart from a scheduled chart order.
+        chart_rows = MedicationCoding.objects.filter(
+            medication__patient=patient,
+            medication__status="active",
+        ).values_list("display", "medication__medication_statements__sig_original_input")
+        chart_orders = [(label.lower(), (sig or "").lower()) for label, sig in chart_rows if label]
         for proposal in med_proposals:
             med_text = proposal.data.get("medication_text", "").lower()
             if not med_text:
                 continue
-            for label in active_labels_lower:
-                if med_text in label or label in med_text:
-                    proposal.already_documented = True
-                    break
+            matches = [sig for label, sig in chart_orders if med_text in label or label in med_text]
+            if not matches:
+                continue
+            if PRN_PATTERN.search(proposal.data.get("sig") or ""):
+                # KOALA-6644: a drug-name match cannot establish that an as-needed order is
+                # already charted — the chart entry is often the *scheduled* order for the
+                # same drug, which is exactly how dictated PRNs were being lost. Suppress
+                # only on positive evidence that the chart already carries a PRN order.
+                # Re-offering a PRN the chart already has is a visible, dismissible
+                # annoyance; hiding a dictated one is a silent charting miss.
+                if not any(PRN_PATTERN.search(sig) for sig in matches):
+                    continue
+            proposal.already_documented = True
 
     def build(self, data: dict[str, Any], note_uuid: str, command_uuid: str) -> _BaseCommand:
         medication_text = str(data.get("medication_text", ""))

--- a/hyperscribe/scribe/recommendations/_transcript_windows.py
+++ b/hyperscribe/scribe/recommendations/_transcript_windows.py
@@ -19,6 +19,24 @@ from hyperscribe.scribe.backend.models import NoteSection, Transcript, Transcrip
 # that a medication named a while before its directions still lands in the same window.
 WINDOW_MS = 120_000
 
+# As-needed / PRN phrasing, used to locate the parts of a transcript where a PRN order may
+# have been dictated.
+#
+# Deliberately tuned for recall, not precision. This pattern only decides which transcript
+# excerpts get shown to the LLM; the LLM still decides whether an excerpt actually contains
+# a medication. So a false positive costs a few tokens, while a false negative reproduces
+# the very bug this exists to fix. Non-medication phrases like "follow up as needed" do
+# match here on purpose — they are filtered by the extraction prompt, not by this regex.
+_PRN_PHRASES = [
+    r"\bas[\s-]+needed\b",
+    r"\bp\.?\s?r\.?\s?n\.?\b",
+    r"\bwhen[\s-]+needed\b",
+    r"\bif[\s-]+needed\b",
+    r"\bas[\s-]+necessary\b",
+    r"\bas[\s-]+required\b",
+]
+PRN_PATTERN = re.compile("|".join(_PRN_PHRASES), re.IGNORECASE)
+
 
 def find_keyword_matches(transcript: Transcript, pattern: re.Pattern[str]) -> list[int]:
     """Return midpoint timestamps (ms) of transcript items matching ``pattern``."""
@@ -88,3 +106,20 @@ def collect_windows(transcript: Transcript | None, pattern: re.Pattern[str]) -> 
 def format_note_sections(sections: list[NoteSection]) -> str:
     """Format note sections as markdown headings for the LLM prompt."""
     return "\n\n".join(f"## {section.title}\n{section.text}" for section in sections)
+
+
+def build_user_prompt(sections: list[NoteSection], windows_text: str = "") -> str:
+    """Compose note sections plus, when supplied, the matching transcript excerpts.
+
+    With no windows the result is exactly the note-sections-only prompt these recommenders
+    sent before transcript recovery existed, so a visit with no keyword hits is unaffected.
+    """
+    note_text = format_note_sections(sections)
+    if not windows_text:
+        return note_text
+    return (
+        "## Clinical Note Sections\n\n"
+        f"{note_text}\n\n"
+        "## Transcript Excerpts (as-needed medication language detected)\n\n"
+        f"{windows_text}"
+    )

--- a/hyperscribe/scribe/recommendations/_transcript_windows.py
+++ b/hyperscribe/scribe/recommendations/_transcript_windows.py
@@ -1,0 +1,90 @@
+"""Shared transcript-windowing helpers for recommenders that read the transcript.
+
+Most recommenders extract from the Nabla-generated note. That is lossy: whatever the
+summarization step omits can never be recovered downstream. When a recommender needs the
+transcript as well, sending the whole thing is wasteful and dilutes the prompt, so the
+pattern is to locate the relevant moments by keyword and send only those windows.
+
+``TaskRecommender`` established this pattern; these helpers are the vendor- and
+domain-neutral parts of it, factored out so other recommenders can reuse them.
+"""
+
+from __future__ import annotations
+
+import re
+
+from hyperscribe.scribe.backend.models import NoteSection, Transcript, TranscriptItem
+
+# Half-width of the window kept around each keyword hit. Two minutes is generous enough
+# that a medication named a while before its directions still lands in the same window.
+WINDOW_MS = 120_000
+
+
+def find_keyword_matches(transcript: Transcript, pattern: re.Pattern[str]) -> list[int]:
+    """Return midpoint timestamps (ms) of transcript items matching ``pattern``."""
+    matches: list[int] = []
+    for item in transcript.items:
+        if pattern.search(item.text):
+            midpoint = (item.start_offset_ms + item.end_offset_ms) // 2
+            matches.append(midpoint)
+    return matches
+
+
+def merge_windows(timestamps: list[int], window_ms: int = WINDOW_MS) -> list[tuple[int, int]]:
+    """Merge overlapping [t - window, t + window] intervals."""
+    if not timestamps:
+        return []
+    intervals = sorted((max(0, t - window_ms), t + window_ms) for t in timestamps)
+    merged = [intervals[0]]
+    for start, end in intervals[1:]:
+        if start <= merged[-1][1]:
+            merged[-1] = (merged[-1][0], max(merged[-1][1], end))
+        else:
+            merged.append((start, end))
+    return merged
+
+
+def extract_window_items(transcript: Transcript, windows: list[tuple[int, int]]) -> list[list[TranscriptItem]]:
+    """For each window, collect overlapping transcript items."""
+    result: list[list[TranscriptItem]] = []
+    for w_start, w_end in windows:
+        items = [item for item in transcript.items if item.end_offset_ms >= w_start and item.start_offset_ms <= w_end]
+        result.append(items)
+    return result
+
+
+def format_transcript_windows(window_items: list[list[TranscriptItem]]) -> str:
+    """Format window items into a human-readable string for the LLM prompt."""
+    parts: list[str] = []
+    for i, items in enumerate(window_items, 1):
+        if not items:
+            continue
+        start_ms = items[0].start_offset_ms
+        end_ms = items[-1].end_offset_ms
+        start_fmt = f"{start_ms // 60000}:{(start_ms % 60000) // 1000:02d}"
+        end_fmt = f"{end_ms // 60000}:{(end_ms % 60000) // 1000:02d}"
+        lines: list[str] = []
+        for item in items:
+            speaker = item.speaker.capitalize() if item.speaker else "Unknown"
+            lines.append(f"{speaker}: {item.text}")
+        parts.append(f"[Window {i}: {start_fmt} - {end_fmt}]\n" + "\n".join(lines))
+    return "\n\n".join(parts)
+
+
+def collect_windows(transcript: Transcript | None, pattern: re.Pattern[str]) -> str:
+    """Return formatted transcript windows around every ``pattern`` hit, or "" if none.
+
+    Convenience wrapper over the four steps above, for recommenders that only want the
+    prompt-ready text.
+    """
+    if not transcript or not transcript.items:
+        return ""
+    timestamps = find_keyword_matches(transcript, pattern)
+    if not timestamps:
+        return ""
+    return format_transcript_windows(extract_window_items(transcript, merge_windows(timestamps)))
+
+
+def format_note_sections(sections: list[NoteSection]) -> str:
+    """Format note sections as markdown headings for the LLM prompt."""
+    return "\n\n".join(f"## {section.title}\n{section.text}" for section in sections)

--- a/hyperscribe/scribe/recommendations/_transcript_windows.py
+++ b/hyperscribe/scribe/recommendations/_transcript_windows.py
@@ -108,6 +108,34 @@ def format_note_sections(sections: list[NoteSection]) -> str:
     return "\n\n".join(f"## {section.title}\n{section.text}" for section in sections)
 
 
+def _drug_token(medication_name: str) -> str:
+    """The drug word of a stated medication name, lowercased — "Lorazepam 0.5 mg" -> "lorazepam"."""
+    words: list[str] = re.findall(r"[A-Za-z]{4,}", medication_name)
+    return words[0].lower() if words else ""
+
+
+def note_documents_as_needed(sections: list[NoteSection], medication_name: str) -> bool:
+    """True when a note section already documents this drug WITH as-needed dosing.
+
+    Used to correct the model's ``from_transcript`` claim. Asking the LLM whether an entry was
+    absent from the note proved unreliable in the partial-loss case: when Nabla drops a PRN from
+    CURRENT_MEDICATIONS but keeps it in ASSESSMENT_AND_PLAN, the model reports it as
+    transcript-recovered even though the note still carries it.
+
+    The test is name AND as-needed, never name alone. A drug frequently appears in the note under
+    a *scheduled* order while its as-needed order is the one that went missing — the reported
+    lorazepam case — and a name-only test would clear the flag on a genuine recovery.
+    """
+    token = _drug_token(medication_name)
+    if not token:
+        return False
+    for section in sections:
+        for line in section.text.split("\n"):
+            if token in line.lower() and PRN_PATTERN.search(line):
+                return True
+    return False
+
+
 def build_user_prompt(sections: list[NoteSection], windows_text: str = "") -> str:
     """Compose note sections plus, when supplied, the matching transcript excerpts.
 

--- a/hyperscribe/scribe/recommendations/medication_statement.py
+++ b/hyperscribe/scribe/recommendations/medication_statement.py
@@ -134,9 +134,11 @@ class MedicationRecommender(BaseRecommender):
                         "sig": sanitize_sig(med.sig),
                     },
                     section_key="_recommended",
-                    # A transcript-recovered medication was never shown to the provider in the
-                    # generated note, so it must not be selected on their behalf.
-                    selected=not med.from_transcript,
+                    # No `selected` gating: every recommendation already requires an explicit
+                    # provider Accept before insertion (handleInsert filters `accepted`), so a
+                    # transcript-recovered medication is never charted on their behalf.
+                    # `from_transcript` drives the review-UI badge telling them it came from
+                    # what was said rather than from the generated note.
                     from_transcript=med.from_transcript,
                 )
             )

--- a/hyperscribe/scribe/recommendations/medication_statement.py
+++ b/hyperscribe/scribe/recommendations/medication_statement.py
@@ -10,11 +10,34 @@ from canvas_sdk.commands.constants import CodeSystems
 
 from hyperscribe.scribe.backend.models import ClinicalNote, CommandProposal, NoteSection, Transcript
 from hyperscribe.scribe.recommendations._medication_match import resolve_medication_detail, sanitize_sig
+from hyperscribe.scribe.recommendations._transcript_windows import (
+    PRN_PATTERN,
+    build_user_prompt,
+    collect_windows,
+)
 from hyperscribe.scribe.recommendations.base import BaseRecommender
 from hyperscribe.scribe.recommendations.schemas import MedicationRecommendationList
 from hyperscribe.structures.medication_detail import MedicationDetail
 
 _RELEVANT_KEYS = {"current_medications", "history_of_present_illness", "assessment_and_plan", "plan"}
+
+# Appended to the base prompt only when PRN transcript excerpts are actually supplied, so a
+# visit with no as-needed language sends exactly the prompt it sent before (KOALA-6644).
+_PRN_RECOVERY_PROMPT = (
+    " COMPLETENESS: prioritize capturing every medication discussed. Omitting one compromises "
+    "patient care, so prefer including a medication you are unsure about over leaving it out. "
+    "AS-NEEDED (PRN) ORDERS: the transcript excerpts below are the parts of the visit recording "
+    "where as-needed language was heard. The clinical note is a summary and sometimes omits PRN "
+    "medications entirely. Extract any medication that appears in the transcript excerpts even "
+    "when it is absent from the note sections, and set from_transcript=true for exactly those "
+    "entries (false for anything present in the note). Set is_prn=true for as-needed orders. "
+    "SAME DRUG, TWO ORDERS: a patient may take the same medication BOTH on a fixed schedule AND "
+    "as needed — for example a scheduled nightly dose plus '0.5 mg every four hours as needed for "
+    "agitation'. Those are two distinct entries and you must emit both; never merge them, and "
+    "never let a scheduled order stand in for an as-needed one. "
+    "Do NOT extract a medication from an excerpt where the as-needed phrase does not refer to a "
+    "drug at all (e.g. 'follow up as needed', 'call us if needed')."
+)
 
 _SYSTEM_PROMPT = (
     "You are a clinical data extraction assistant. "
@@ -30,11 +53,8 @@ _SYSTEM_PROMPT = (
 )
 
 
-def _build_user_prompt(sections: list[NoteSection]) -> str:
-    parts: list[str] = []
-    for section in sections:
-        parts.append(f"## {section.title}\n{section.text}")
-    return "\n\n".join(parts)
+def _build_user_prompt(sections: list[NoteSection], windows_text: str = "") -> str:
+    return build_user_prompt(sections, windows_text)
 
 
 def _resolve_medication(
@@ -57,13 +77,16 @@ class MedicationRecommender(BaseRecommender):
         all_keys = [s.key for s in note.sections]
         log.info(f"MedicationRecommender: note section keys={all_keys}, filtering by {_RELEVANT_KEYS}")
         sections = [s for s in note.sections if s.key.lower() in _RELEVANT_KEYS and s.text.strip()]
-        if not sections:
-            log.info("MedicationRecommender: no matching sections, skipping")
+        # The note is a Nabla summary and drops PRN medications as the list grows, so pull the
+        # as-needed moments straight from the transcript as a recall backstop (KOALA-6644).
+        windows_text = collect_windows(transcript, PRN_PATTERN)
+        if not sections and not windows_text:
+            log.info("MedicationRecommender: no matching sections and no PRN transcript windows, skipping")
             return []
 
         client.reset_prompts()
-        client.set_system_prompt([_SYSTEM_PROMPT])
-        client.set_user_prompt([_build_user_prompt(sections)])
+        client.set_system_prompt([_SYSTEM_PROMPT + (_PRN_RECOVERY_PROMPT if windows_text else "")])
+        client.set_user_prompt([_build_user_prompt(sections, windows_text)])
         client.set_schema(MedicationRecommendationList)
 
         try:
@@ -111,6 +134,10 @@ class MedicationRecommender(BaseRecommender):
                         "sig": sanitize_sig(med.sig),
                     },
                     section_key="_recommended",
+                    # A transcript-recovered medication was never shown to the provider in the
+                    # generated note, so it must not be selected on their behalf.
+                    selected=not med.from_transcript,
+                    from_transcript=med.from_transcript,
                 )
             )
         return proposals

--- a/hyperscribe/scribe/recommendations/medication_statement.py
+++ b/hyperscribe/scribe/recommendations/medication_statement.py
@@ -14,6 +14,7 @@ from hyperscribe.scribe.recommendations._transcript_windows import (
     PRN_PATTERN,
     build_user_prompt,
     collect_windows,
+    note_documents_as_needed,
 )
 from hyperscribe.scribe.recommendations.base import BaseRecommender
 from hyperscribe.scribe.recommendations.schemas import MedicationRecommendationList
@@ -140,11 +141,21 @@ class MedicationRecommender(BaseRecommender):
                     # `from_transcript` drives the review-UI badge telling them it came from
                     # what was said rather than from the generated note.
                     #
-                    # Gated on windows_text because the model will set the flag even when no
-                    # excerpts were supplied at all, which would badge a medication as
-                    # transcript-recovered on a note where no transcript was ever read.
-                    # Provenance has to be a fact we establish, not one the LLM asserts.
-                    from_transcript=med.from_transcript and bool(windows_text),
+                    # Provenance has to be a fact we establish, not one the LLM asserts. Two
+                    # deterministic corrections, both measured on real notes:
+                    #  * windows_text — the model sets the flag even when no excerpts were
+                    #    supplied, which would badge a medication as recovered on a note where
+                    #    no transcript was ever read.
+                    #  * note_documents_as_needed — on partial loss (Nabla drops the PRN from
+                    #    CURRENT_MEDICATIONS but keeps it in ASSESSMENT_AND_PLAN) the model
+                    #    reports recovery even though the note still carries the order. Roughly
+                    #    half the affected notes in the ticket are partial, so this is the
+                    #    common case, not an edge.
+                    from_transcript=(
+                        med.from_transcript
+                        and bool(windows_text)
+                        and not note_documents_as_needed(sections, med.medication_name)
+                    ),
                 )
             )
         return proposals

--- a/hyperscribe/scribe/recommendations/medication_statement.py
+++ b/hyperscribe/scribe/recommendations/medication_statement.py
@@ -139,7 +139,12 @@ class MedicationRecommender(BaseRecommender):
                     # transcript-recovered medication is never charted on their behalf.
                     # `from_transcript` drives the review-UI badge telling them it came from
                     # what was said rather than from the generated note.
-                    from_transcript=med.from_transcript,
+                    #
+                    # Gated on windows_text because the model will set the flag even when no
+                    # excerpts were supplied at all, which would badge a medication as
+                    # transcript-recovered on a note where no transcript was ever read.
+                    # Provenance has to be a fact we establish, not one the LLM asserts.
+                    from_transcript=med.from_transcript and bool(windows_text),
                 )
             )
         return proposals

--- a/hyperscribe/scribe/recommendations/prescription.py
+++ b/hyperscribe/scribe/recommendations/prescription.py
@@ -10,11 +10,36 @@ from canvas_sdk.clients.llms.libraries import LlmAnthropic
 from hyperscribe.scribe.backend.models import ClinicalNote, CommandProposal, NoteSection, Transcript
 from hyperscribe.scribe.recommendations._dosage import derive_dispense_fields
 from hyperscribe.scribe.recommendations._medication_match import resolve_medication_detail, sanitize_sig
+from hyperscribe.scribe.recommendations._transcript_windows import (
+    PRN_PATTERN,
+    build_user_prompt,
+    collect_windows,
+)
 from hyperscribe.scribe.recommendations.base import BaseRecommender
 from hyperscribe.scribe.recommendations.schemas import PrescriptionRecommendationList
 from hyperscribe.structures.medication_detail import MedicationDetail
 
 _RELEVANT_KEYS = {"assessment_and_plan", "plan", "history_of_present_illness", "prescription"}
+
+# Appended to whichever base prompt is in play — including the baseline one used when the
+# dispense engine is gated off — so no provider is left on the un-fixed path (KOALA-6644).
+# Only appended when PRN transcript excerpts are actually supplied.
+_PRN_RECOVERY_PROMPT = (
+    " COMPLETENESS: prioritize capturing every prescription discussed. Omitting one compromises "
+    "patient care, so prefer including a prescription you are unsure about over leaving it out. "
+    "AS-NEEDED (PRN) ORDERS: the transcript excerpts below are the parts of the visit recording "
+    "where as-needed language was heard. The clinical note is a summary and sometimes omits PRN "
+    "medications entirely. Extract any newly prescribed medication that appears in the transcript "
+    "excerpts even when it is absent from the note sections, and set from_transcript=true for "
+    "exactly those entries (false for anything present in the note). Set is_prn=true for "
+    "as-needed orders. "
+    "SAME DRUG, TWO ORDERS: the same medication may be ordered BOTH on a fixed schedule AND as "
+    "needed — for example a scheduled nightly dose plus '0.5 mg every four hours as needed for "
+    "agitation'. Those are two distinct entries and you must emit both; never merge them, and "
+    "never let a scheduled order stand in for an as-needed one. "
+    "Do NOT extract a medication from an excerpt where the as-needed phrase does not refer to a "
+    "drug at all (e.g. 'follow up as needed', 'call us if needed')."
+)
 
 _SYSTEM_PROMPT = (
     "You are a clinical data extraction assistant. "
@@ -58,11 +83,8 @@ _SYSTEM_PROMPT_BASELINE = (
 )
 
 
-def _build_user_prompt(sections: list[NoteSection]) -> str:
-    parts: list[str] = []
-    for section in sections:
-        parts.append(f"## {section.title}\n{section.text}")
-    return "\n\n".join(parts)
+def _build_user_prompt(sections: list[NoteSection], windows_text: str = "") -> str:
+    return build_user_prompt(sections, windows_text)
 
 
 def _resolve_prescription(
@@ -90,13 +112,17 @@ class PrescriptionRecommender(BaseRecommender):
         all_keys = [s.key for s in note.sections]
         log.info(f"PrescriptionRecommender: note section keys={all_keys}, filtering by {_RELEVANT_KEYS}")
         sections = [s for s in note.sections if s.key.lower() in _RELEVANT_KEYS and s.text.strip()]
-        if not sections:
-            log.info("PrescriptionRecommender: no matching sections, skipping")
+        # The note is a Nabla summary and drops PRN medications as the list grows, so pull the
+        # as-needed moments straight from the transcript as a recall backstop (KOALA-6644).
+        windows_text = collect_windows(transcript, PRN_PATTERN)
+        if not sections and not windows_text:
+            log.info("PrescriptionRecommender: no matching sections and no PRN transcript windows, skipping")
             return []
 
+        base_prompt = _SYSTEM_PROMPT if self.dispense_engine_enabled else _SYSTEM_PROMPT_BASELINE
         client.reset_prompts()
-        client.set_system_prompt([_SYSTEM_PROMPT if self.dispense_engine_enabled else _SYSTEM_PROMPT_BASELINE])
-        client.set_user_prompt([_build_user_prompt(sections)])
+        client.set_system_prompt([base_prompt + (_PRN_RECOVERY_PROMPT if windows_text else "")])
+        client.set_user_prompt([_build_user_prompt(sections, windows_text)])
         client.set_schema(PrescriptionRecommendationList)
 
         try:
@@ -178,6 +204,10 @@ class PrescriptionRecommender(BaseRecommender):
                     display=display,
                     data=data,
                     section_key="_recommended",
+                    # A transcript-recovered prescription was never shown to the provider in the
+                    # generated note, so it must not be selected on their behalf.
+                    selected=not med.from_transcript,
+                    from_transcript=med.from_transcript,
                 )
             )
         return proposals

--- a/hyperscribe/scribe/recommendations/prescription.py
+++ b/hyperscribe/scribe/recommendations/prescription.py
@@ -204,9 +204,11 @@ class PrescriptionRecommender(BaseRecommender):
                     display=display,
                     data=data,
                     section_key="_recommended",
-                    # A transcript-recovered prescription was never shown to the provider in the
-                    # generated note, so it must not be selected on their behalf.
-                    selected=not med.from_transcript,
+                    # No `selected` gating: every recommendation already requires an explicit
+                    # provider Accept before insertion (handleInsert filters `accepted`), so a
+                    # transcript-recovered prescription is never charted on their behalf.
+                    # `from_transcript` drives the review-UI badge telling them it came from
+                    # what was said rather than from the generated note.
                     from_transcript=med.from_transcript,
                 )
             )

--- a/hyperscribe/scribe/recommendations/prescription.py
+++ b/hyperscribe/scribe/recommendations/prescription.py
@@ -10,36 +10,11 @@ from canvas_sdk.clients.llms.libraries import LlmAnthropic
 from hyperscribe.scribe.backend.models import ClinicalNote, CommandProposal, NoteSection, Transcript
 from hyperscribe.scribe.recommendations._dosage import derive_dispense_fields
 from hyperscribe.scribe.recommendations._medication_match import resolve_medication_detail, sanitize_sig
-from hyperscribe.scribe.recommendations._transcript_windows import (
-    PRN_PATTERN,
-    build_user_prompt,
-    collect_windows,
-)
 from hyperscribe.scribe.recommendations.base import BaseRecommender
 from hyperscribe.scribe.recommendations.schemas import PrescriptionRecommendationList
 from hyperscribe.structures.medication_detail import MedicationDetail
 
 _RELEVANT_KEYS = {"assessment_and_plan", "plan", "history_of_present_illness", "prescription"}
-
-# Appended to whichever base prompt is in play — including the baseline one used when the
-# dispense engine is gated off — so no provider is left on the un-fixed path (KOALA-6644).
-# Only appended when PRN transcript excerpts are actually supplied.
-_PRN_RECOVERY_PROMPT = (
-    " COMPLETENESS: prioritize capturing every prescription discussed. Omitting one compromises "
-    "patient care, so prefer including a prescription you are unsure about over leaving it out. "
-    "AS-NEEDED (PRN) ORDERS: the transcript excerpts below are the parts of the visit recording "
-    "where as-needed language was heard. The clinical note is a summary and sometimes omits PRN "
-    "medications entirely. Extract any newly prescribed medication that appears in the transcript "
-    "excerpts even when it is absent from the note sections, and set from_transcript=true for "
-    "exactly those entries (false for anything present in the note). Set is_prn=true for "
-    "as-needed orders. "
-    "SAME DRUG, TWO ORDERS: the same medication may be ordered BOTH on a fixed schedule AND as "
-    "needed — for example a scheduled nightly dose plus '0.5 mg every four hours as needed for "
-    "agitation'. Those are two distinct entries and you must emit both; never merge them, and "
-    "never let a scheduled order stand in for an as-needed one. "
-    "Do NOT extract a medication from an excerpt where the as-needed phrase does not refer to a "
-    "drug at all (e.g. 'follow up as needed', 'call us if needed')."
-)
 
 _SYSTEM_PROMPT = (
     "You are a clinical data extraction assistant. "
@@ -83,8 +58,11 @@ _SYSTEM_PROMPT_BASELINE = (
 )
 
 
-def _build_user_prompt(sections: list[NoteSection], windows_text: str = "") -> str:
-    return build_user_prompt(sections, windows_text)
+def _build_user_prompt(sections: list[NoteSection]) -> str:
+    parts: list[str] = []
+    for section in sections:
+        parts.append(f"## {section.title}\n{section.text}")
+    return "\n\n".join(parts)
 
 
 def _resolve_prescription(
@@ -109,20 +87,27 @@ class PrescriptionRecommender(BaseRecommender):
     def recommend(
         self, note: ClinicalNote, client: LlmAnthropic, transcript: Transcript | None = None
     ) -> list[CommandProposal]:
+        # `transcript` is deliberately unused. KOALA-6644 recovers PRN medications that Nabla
+        # dropped from the generated note, but only into the medication list — see
+        # MedicationRecommender. Recovery is NOT done here on purpose:
+        #
+        # Nabla states continuation as "Continue <drug> as needed ...", so the "Continue"
+        # marker lives on the very line that gets dropped. A PRN recovered from the transcript
+        # therefore arrives with no evidence of whether it is being started or merely
+        # reconciled, and measurements on real notes had this path proposing NEW prescriptions
+        # for five medications the patient was already taking. Missing documentation is
+        # recoverable; a duplicate prescription is not, so the risk is asymmetric and the
+        # ticket's own confirmed case was a medication-list loss.
         all_keys = [s.key for s in note.sections]
         log.info(f"PrescriptionRecommender: note section keys={all_keys}, filtering by {_RELEVANT_KEYS}")
         sections = [s for s in note.sections if s.key.lower() in _RELEVANT_KEYS and s.text.strip()]
-        # The note is a Nabla summary and drops PRN medications as the list grows, so pull the
-        # as-needed moments straight from the transcript as a recall backstop (KOALA-6644).
-        windows_text = collect_windows(transcript, PRN_PATTERN)
-        if not sections and not windows_text:
-            log.info("PrescriptionRecommender: no matching sections and no PRN transcript windows, skipping")
+        if not sections:
+            log.info("PrescriptionRecommender: no matching sections, skipping")
             return []
 
-        base_prompt = _SYSTEM_PROMPT if self.dispense_engine_enabled else _SYSTEM_PROMPT_BASELINE
         client.reset_prompts()
-        client.set_system_prompt([base_prompt + (_PRN_RECOVERY_PROMPT if windows_text else "")])
-        client.set_user_prompt([_build_user_prompt(sections, windows_text)])
+        client.set_system_prompt([_SYSTEM_PROMPT if self.dispense_engine_enabled else _SYSTEM_PROMPT_BASELINE])
+        client.set_user_prompt([_build_user_prompt(sections)])
         client.set_schema(PrescriptionRecommendationList)
 
         try:
@@ -204,12 +189,6 @@ class PrescriptionRecommender(BaseRecommender):
                     display=display,
                     data=data,
                     section_key="_recommended",
-                    # No `selected` gating: every recommendation already requires an explicit
-                    # provider Accept before insertion (handleInsert filters `accepted`), so a
-                    # transcript-recovered prescription is never charted on their behalf.
-                    # `from_transcript` drives the review-UI badge telling them it came from
-                    # what was said rather than from the generated note.
-                    from_transcript=med.from_transcript,
                 )
             )
         return proposals

--- a/hyperscribe/scribe/recommendations/schemas.py
+++ b/hyperscribe/scribe/recommendations/schemas.py
@@ -65,21 +65,6 @@ class PrescriptionRecommendation(BaseModelLlmJson):
     quantity_to_dispense: str | None = Field(default=None, description="Quantity to dispense")
     refills: int | None = Field(default=None, description="Number of refills")
     keywords: str = Field(description="Comma-separated synonyms for searching (max 5)")
-    is_prn: bool = Field(
-        default=False,
-        description=(
-            "True when this is an as-needed (PRN) order — taken for a symptom rather than on a fixed "
-            "schedule. A PRN order and a scheduled order for the same drug are two separate entries."
-        ),
-    )
-    from_transcript: bool = Field(
-        default=False,
-        description=(
-            "True when this prescription appears in the transcript excerpts but NOT in the clinical "
-            "note sections. Set this honestly: it tells the provider the entry was recovered from "
-            "what was said rather than from the generated note."
-        ),
-    )
 
 
 class PrescriptionRecommendationList(BaseModelLlmJson):

--- a/hyperscribe/scribe/recommendations/schemas.py
+++ b/hyperscribe/scribe/recommendations/schemas.py
@@ -10,6 +10,21 @@ class MedicationRecommendation(BaseModelLlmJson):
         description="Directions/sig exactly as stated in the note; leave null if no directions are stated",
     )
     keywords: str = Field(description="Comma-separated synonyms for searching (max 5)")
+    is_prn: bool = Field(
+        default=False,
+        description=(
+            "True when this is an as-needed (PRN) order — taken for a symptom rather than on a fixed "
+            "schedule. A PRN order and a scheduled order for the same drug are two separate entries."
+        ),
+    )
+    from_transcript: bool = Field(
+        default=False,
+        description=(
+            "True when this medication appears in the transcript excerpts but NOT in the clinical "
+            "note sections. Set this honestly: it tells the provider the entry was recovered from "
+            "what was said rather than from the generated note."
+        ),
+    )
 
 
 class MedicationRecommendationList(BaseModelLlmJson):
@@ -50,6 +65,21 @@ class PrescriptionRecommendation(BaseModelLlmJson):
     quantity_to_dispense: str | None = Field(default=None, description="Quantity to dispense")
     refills: int | None = Field(default=None, description="Number of refills")
     keywords: str = Field(description="Comma-separated synonyms for searching (max 5)")
+    is_prn: bool = Field(
+        default=False,
+        description=(
+            "True when this is an as-needed (PRN) order — taken for a symptom rather than on a fixed "
+            "schedule. A PRN order and a scheduled order for the same drug are two separate entries."
+        ),
+    )
+    from_transcript: bool = Field(
+        default=False,
+        description=(
+            "True when this prescription appears in the transcript excerpts but NOT in the clinical "
+            "note sections. Set this honestly: it tells the provider the entry was recovered from "
+            "what was said rather than from the generated note."
+        ),
+    )
 
 
 class PrescriptionRecommendationList(BaseModelLlmJson):

--- a/hyperscribe/scribe/recommendations/task.py
+++ b/hyperscribe/scribe/recommendations/task.py
@@ -12,7 +12,12 @@ from hyperscribe.scribe.backend.models import (
     ClinicalNote,
     CommandProposal,
     Transcript,
-    TranscriptItem,
+)
+from hyperscribe.scribe.recommendations._transcript_windows import (
+    extract_window_items,
+    find_keyword_matches,
+    format_transcript_windows,
+    merge_windows,
 )
 from hyperscribe.scribe.recommendations.base import BaseRecommender
 from hyperscribe.scribe.recommendations.schemas import TaskRecommendationList
@@ -21,7 +26,6 @@ _TASK_KEYWORDS = [
     r"\btasks?\b",
 ]
 _KEYWORD_PATTERN = re.compile("|".join(_TASK_KEYWORDS), re.IGNORECASE)
-_WINDOW_MS = 120_000  # 2 minutes
 
 _SYSTEM_PROMPT = (
     "You are a clinical task extraction assistant.\n\n"
@@ -48,53 +52,7 @@ _SYSTEM_PROMPT = (
 
 def find_task_matches(transcript: Transcript) -> list[int]:
     """Return midpoint timestamps (ms) of transcript items containing task keywords."""
-    matches: list[int] = []
-    for item in transcript.items:
-        if _KEYWORD_PATTERN.search(item.text):
-            midpoint = (item.start_offset_ms + item.end_offset_ms) // 2
-            matches.append(midpoint)
-    return matches
-
-
-def merge_windows(timestamps: list[int], window_ms: int = _WINDOW_MS) -> list[tuple[int, int]]:
-    """Merge overlapping [t - window, t + window] intervals."""
-    if not timestamps:
-        return []
-    intervals = sorted((max(0, t - window_ms), t + window_ms) for t in timestamps)
-    merged = [intervals[0]]
-    for start, end in intervals[1:]:
-        if start <= merged[-1][1]:
-            merged[-1] = (merged[-1][0], max(merged[-1][1], end))
-        else:
-            merged.append((start, end))
-    return merged
-
-
-def extract_window_items(transcript: Transcript, windows: list[tuple[int, int]]) -> list[list[TranscriptItem]]:
-    """For each window, collect overlapping transcript items."""
-    result: list[list[TranscriptItem]] = []
-    for w_start, w_end in windows:
-        items = [item for item in transcript.items if item.end_offset_ms >= w_start and item.start_offset_ms <= w_end]
-        result.append(items)
-    return result
-
-
-def format_transcript_windows(window_items: list[list[TranscriptItem]]) -> str:
-    """Format window items into a human-readable string for the LLM prompt."""
-    parts: list[str] = []
-    for i, items in enumerate(window_items, 1):
-        if not items:
-            continue
-        start_ms = items[0].start_offset_ms
-        end_ms = items[-1].end_offset_ms
-        start_fmt = f"{start_ms // 60000}:{(start_ms % 60000) // 1000:02d}"
-        end_fmt = f"{end_ms // 60000}:{(end_ms % 60000) // 1000:02d}"
-        lines: list[str] = []
-        for item in items:
-            speaker = item.speaker.capitalize() if item.speaker else "Unknown"
-            lines.append(f"{speaker}: {item.text}")
-        parts.append(f"[Window {i}: {start_fmt} - {end_fmt}]\n" + "\n".join(lines))
-    return "\n\n".join(parts)
+    return find_keyword_matches(transcript, _KEYWORD_PATTERN)
 
 
 def _build_user_prompt(windows_text: str, note: ClinicalNote) -> str:

--- a/hyperscribe/scribe/static/medication-row.js
+++ b/hyperscribe/scribe/static/medication-row.js
@@ -225,6 +225,7 @@ export function MedicationRow({ command, commandIndex, onEdit, onDelete, readOnl
         <div class="order-view-name">${command.display}</div>
         ${command.data.sig && html`<div class="order-view-sig">${command.data.sig}</div>`}
         ${alertFacilityEnabled && command.data.alert_facility && html`<span class="badge badge-alert">Alert Facility</span>`}
+        ${command.from_transcript && html`<span class="badge badge-transcript" title="Heard in the recording but missing from the generated note — review before accepting">From transcript</span>`}
       </div>
     </div>
   `;

--- a/hyperscribe/scribe/static/order-row.js
+++ b/hyperscribe/scribe/static/order-row.js
@@ -1900,6 +1900,7 @@ export function OrderRow({ command, commandIndex, onEdit, onDelete, readOnly, pa
             <div class="order-view-name">${command.display}</div>
             ${d.sig && html`<div class="order-view-sig">Sig: ${d.sig}</div>`}
             ${detailParts.length > 0 && html`<div class="order-view-details">${detailParts.join(' · ')}</div>`}
+            ${command.from_transcript && html`<span class="badge badge-transcript" title="Heard in the recording but missing from the generated note — review before accepting">From transcript</span>`}
           </div>
         </div>
         ${interactionWarning && html`<${InteractionWarningInline} warning=${interactionWarning} />`}

--- a/hyperscribe/scribe/static/order-row.js
+++ b/hyperscribe/scribe/static/order-row.js
@@ -1900,7 +1900,6 @@ export function OrderRow({ command, commandIndex, onEdit, onDelete, readOnly, pa
             <div class="order-view-name">${command.display}</div>
             ${d.sig && html`<div class="order-view-sig">Sig: ${d.sig}</div>`}
             ${detailParts.length > 0 && html`<div class="order-view-details">${detailParts.join(' · ')}</div>`}
-            ${command.from_transcript && html`<span class="badge badge-transcript" title="Heard in the recording but missing from the generated note — review before accepting">From transcript</span>`}
           </div>
         </div>
         ${interactionWarning && html`<${InteractionWarningInline} warning=${interactionWarning} />`}

--- a/hyperscribe/scribe/static/styles.css
+++ b/hyperscribe/scribe/static/styles.css
@@ -893,6 +893,16 @@ h2 { margin-bottom: 4px; }
 .order-view-sig { font-size: 13px; color: #555; font-style: italic; }
 .order-view-details { font-size: 12px; color: #888; }
 
+/* KOALA-6644: provenance pill for a medication recovered from the transcript because the
+   generated note omitted it. Informational blue rather than the orange rec-warning-pill —
+   nothing is wrong with the entry, the provider just has not seen it in the note and should
+   read it before accepting. */
+.badge-transcript {
+  font-size: 11px; font-weight: 600; padding: 3px 10px; border-radius: 12px;
+  background: #eff6ff; color: #1d4ed8; border: 1px solid #bfdbfe;
+  white-space: nowrap; align-self: flex-start; cursor: help;
+}
+
 
 .order-checkbox-label { display: flex; align-items: center; gap: 6px; font-size: 13px; color: #555; cursor: pointer; padding: 4px 0; }
 .order-lab-form { display: flex; flex-direction: column; gap: 6px; }

--- a/tests/hyperscribe/scribe/api/test_session_view.py
+++ b/tests/hyperscribe/scribe/api/test_session_view.py
@@ -6774,3 +6774,172 @@ def test_summary_js_verify_count_excludes_from_note_commands() -> None:
     assert "c.section_key === FROM_THE_NOTE_SECTION" in src, (
         "isFromNoteCommand must recognize the from_the_note section key."
     )
+
+
+# --- /generate-summary MEDS_PRN_TRANSCRIPT telemetry (KOALA-6644) -------------------
+#
+# The PRN drop was completely invisible: no error, no log line, no audit row. These pin
+# the counter that makes it observable, and keep it silent on the happy path.
+
+
+def _prn_summary_view(mock_note: MagicMock, mock_transcript: MagicMock, mock_get_cache: MagicMock, text: str) -> Any:
+    """Wire /generate-summary with a one-item transcript containing ``text``."""
+    mock_get_cache.return_value = _mock_cache()
+    mock_note.objects.values_list.return_value.get.return_value = 91
+    mock_transcript.objects.filter.return_value.values.return_value.first.return_value = {
+        "items": [{"text": text, "speaker": "doctor", "start_offset_ms": 0, "end_offset_ms": 5000}],
+        "finalized": True,
+    }
+    view = _helper_instance()
+    view.secrets["AnthropicAPIKey"] = "test-key"
+    view.request = SimpleNamespace(body=json.dumps({"note_id": "91", "note_uuid": "91"}))
+    return view
+
+
+def _plain_backend() -> MagicMock:
+    """A backend returning a note with no vitals and no normalized data."""
+    backend = MagicMock()
+    backend.generate_note.return_value = ClinicalNote(
+        title="Note", sections=[NoteSection(key="plan", title="Plan", text="continue")]
+    )
+    backend.generate_normalized_data.return_value = NormalizedData(conditions=[], observations=[])
+    return backend
+
+
+def _prn_audit_payloads(mock_audit: MagicMock) -> list[dict[str, Any]]:
+    """Extract MEDS_PRN_TRANSCRIPT payloads from the audit_event mock."""
+    calls = [(c.args[1], c.args[2] if len(c.args) > 2 else {}) for c in mock_audit.call_args_list]
+    return [payload for event_type, payload in calls if event_type == "MEDS_PRN_TRANSCRIPT"]
+
+
+@patch("hyperscribe.scribe.api.session_view._note_provider_id", return_value="")
+@patch("hyperscribe.scribe.api.session_view.prefill_assess_backgrounds_for_proposals")
+@patch("hyperscribe.scribe.api.session_view.resolve_zip_codes", return_value=[])
+@patch("hyperscribe.scribe.api.session_view.annotate_duplicates")
+@patch("hyperscribe.scribe.api.session_view.suggest_diagnoses")
+@patch("hyperscribe.scribe.api.session_view.recommend_commands")
+@patch("hyperscribe.scribe.api.session_view.audit_event")
+@patch("hyperscribe.scribe.api.session_view.ScribeSummary")
+@patch("hyperscribe.scribe.api.session_view.ScribeTranscript")
+@patch("hyperscribe.scribe.api.session_view.Note")
+@patch("hyperscribe.scribe.api.session_view.get_cache")
+@patch("hyperscribe.scribe.api.session_view.get_backend_from_secrets")
+def test_generate_summary_records_recovered_prn_count(
+    get_backend: MagicMock,
+    mock_get_cache: MagicMock,
+    mock_note: MagicMock,
+    mock_transcript: MagicMock,
+    _mock_summary: MagicMock,
+    mock_audit: MagicMock,
+    mock_recommend: MagicMock,
+    mock_suggest: MagicMock,
+    _mock_annotate: MagicMock,
+    _mock_zip: MagicMock,
+    _mock_prefill: MagicMock,
+    _mock_provider: MagicMock,
+) -> None:
+    """An as-needed mention plus a transcript-recovered proposal is counted."""
+    get_backend.return_value = _plain_backend()
+    mock_suggest.return_value = {}
+    mock_recommend.return_value = [
+        CommandProposal(
+            command_type="medication_statement",
+            display="Lorazepam 0.5 mg",
+            data={"medication_text": "Lorazepam 0.5 mg", "sig": "as needed"},
+            from_transcript=True,
+        ),
+        CommandProposal(
+            command_type="medication_statement",
+            display="Lisinopril 10 mg",
+            data={"medication_text": "Lisinopril 10 mg", "sig": "daily"},
+        ),
+    ]
+
+    view = _prn_summary_view(
+        mock_note, mock_transcript, mock_get_cache, "lorazepam 0.5 mg every four hours as needed for anxiety"
+    )
+    view.post_generate_summary()
+
+    payloads = _prn_audit_payloads(mock_audit)
+    assert len(payloads) == 1, f"expected one MEDS_PRN_TRANSCRIPT event, got {mock_audit.call_args_list}"
+    assert payloads[0] == {"prn_mentions": 1, "recovered_from_transcript": 1}
+
+
+@patch("hyperscribe.scribe.api.session_view._note_provider_id", return_value="")
+@patch("hyperscribe.scribe.api.session_view.prefill_assess_backgrounds_for_proposals")
+@patch("hyperscribe.scribe.api.session_view.resolve_zip_codes", return_value=[])
+@patch("hyperscribe.scribe.api.session_view.annotate_duplicates")
+@patch("hyperscribe.scribe.api.session_view.suggest_diagnoses")
+@patch("hyperscribe.scribe.api.session_view.recommend_commands")
+@patch("hyperscribe.scribe.api.session_view.audit_event")
+@patch("hyperscribe.scribe.api.session_view.ScribeSummary")
+@patch("hyperscribe.scribe.api.session_view.ScribeTranscript")
+@patch("hyperscribe.scribe.api.session_view.Note")
+@patch("hyperscribe.scribe.api.session_view.get_cache")
+@patch("hyperscribe.scribe.api.session_view.get_backend_from_secrets")
+def test_generate_summary_records_prn_mention_with_no_recovery(
+    get_backend: MagicMock,
+    mock_get_cache: MagicMock,
+    mock_note: MagicMock,
+    mock_transcript: MagicMock,
+    _mock_summary: MagicMock,
+    mock_audit: MagicMock,
+    mock_recommend: MagicMock,
+    mock_suggest: MagicMock,
+    _mock_annotate: MagicMock,
+    _mock_zip: MagicMock,
+    _mock_prefill: MagicMock,
+    _mock_provider: MagicMock,
+) -> None:
+    """Mentions with zero recoveries still emit — this is the remaining-silent-drop signal.
+
+    It is the case a later remediation sweep needs to select on, so it must be recorded
+    rather than inferred from absence.
+    """
+    get_backend.return_value = _plain_backend()
+    mock_suggest.return_value = {}
+    mock_recommend.return_value = []
+
+    view = _prn_summary_view(mock_note, mock_transcript, mock_get_cache, "take ibuprofen as needed for pain")
+    view.post_generate_summary()
+
+    payloads = _prn_audit_payloads(mock_audit)
+    assert len(payloads) == 1
+    assert payloads[0] == {"prn_mentions": 1, "recovered_from_transcript": 0}
+
+
+@patch("hyperscribe.scribe.api.session_view._note_provider_id", return_value="")
+@patch("hyperscribe.scribe.api.session_view.prefill_assess_backgrounds_for_proposals")
+@patch("hyperscribe.scribe.api.session_view.resolve_zip_codes", return_value=[])
+@patch("hyperscribe.scribe.api.session_view.annotate_duplicates")
+@patch("hyperscribe.scribe.api.session_view.suggest_diagnoses")
+@patch("hyperscribe.scribe.api.session_view.recommend_commands")
+@patch("hyperscribe.scribe.api.session_view.audit_event")
+@patch("hyperscribe.scribe.api.session_view.ScribeSummary")
+@patch("hyperscribe.scribe.api.session_view.ScribeTranscript")
+@patch("hyperscribe.scribe.api.session_view.Note")
+@patch("hyperscribe.scribe.api.session_view.get_cache")
+@patch("hyperscribe.scribe.api.session_view.get_backend_from_secrets")
+def test_generate_summary_silent_when_no_prn_language(
+    get_backend: MagicMock,
+    mock_get_cache: MagicMock,
+    mock_note: MagicMock,
+    mock_transcript: MagicMock,
+    _mock_summary: MagicMock,
+    mock_audit: MagicMock,
+    mock_recommend: MagicMock,
+    mock_suggest: MagicMock,
+    _mock_annotate: MagicMock,
+    _mock_zip: MagicMock,
+    _mock_prefill: MagicMock,
+    _mock_provider: MagicMock,
+) -> None:
+    """No as-needed phrasing means no event, keeping the audit log signal-dense."""
+    get_backend.return_value = _plain_backend()
+    mock_suggest.return_value = {}
+    mock_recommend.return_value = []
+
+    view = _prn_summary_view(mock_note, mock_transcript, mock_get_cache, "blood pressure is stable today")
+    view.post_generate_summary()
+
+    assert _prn_audit_payloads(mock_audit) == []

--- a/tests/hyperscribe/scribe/commands/test_medication_statement.py
+++ b/tests/hyperscribe/scribe/commands/test_medication_statement.py
@@ -192,7 +192,7 @@ def test_annotate_duplicates_match(
 
     # Use spec=QuerySet so calling nonexistent methods (e.g. .committed()) raises AttributeError.
     mock_qs = MagicMock(spec=QuerySet)
-    mock_qs.values_list.return_value = ["Lisinopril 10mg Tablet"]
+    mock_qs.values_list.return_value = [("Lisinopril 10mg Tablet", "take 1 tablet daily")]
     mock_coding_cls.objects.filter.return_value = mock_qs
 
     proposals = [
@@ -214,7 +214,123 @@ def test_annotate_duplicates_match(
         medication__patient=mock_patient,
         medication__status="active",
     )
-    mock_qs.values_list.assert_called_once_with("display", flat=True)
+    mock_qs.values_list.assert_called_once_with("display", "medication__medication_statements__sig_original_input")
+
+
+# --- annotate_duplicates: KOALA-6644 PRN vs scheduled ---
+
+
+def _prn_dedup_setup(mock_coding_cls: MagicMock, chart_rows: list[tuple[str, str | None]]) -> MagicMock:
+    """Wire a mocked chart medication list and return the note."""
+    mock_patient = MagicMock()
+    mock_note = MagicMock()
+    mock_note.patient = mock_patient
+    mock_qs = MagicMock(spec=QuerySet)
+    mock_qs.values_list.return_value = chart_rows
+    mock_coding_cls.objects.filter.return_value = mock_qs
+    return mock_note
+
+
+def _lorazepam_prn_proposal() -> CommandProposal:
+    """The dictated as-needed lorazepam order from the ticket's confirmed case."""
+    return CommandProposal(
+        command_type="medication_statement",
+        display="Lorazepam 0.5 mg",
+        data={
+            "medication_text": "Lorazepam 0.5 mg",
+            "sig": "0.5 mg every four hours as needed for anxiety or agitation",
+        },
+        from_transcript=True,
+    )
+
+
+@patch("hyperscribe.scribe.commands.medication_statement.MedicationCoding")
+def test_annotate_duplicates_keeps_prn_when_chart_order_is_scheduled(mock_coding_cls: MagicMock) -> None:
+    """A PRN order is not "already documented" just because the drug name is on the chart.
+
+    Note dbid 119673: lorazepam was on the chart as a scheduled pre-shower dose. Marking the
+    dictated PRN as already_documented hides it in the review UI, which is how the order was
+    lost. This is the guard that makes PRN recovery actually reach the provider.
+    """
+    mock_note = _prn_dedup_setup(
+        mock_coding_cls,
+        [("Lorazepam 0.5 MG Tablet", "one tablet daily, one hour before showers on Mondays and Wednesdays")],
+    )
+    proposals = [_lorazepam_prn_proposal()]
+
+    MedicationParser().annotate_duplicates(proposals, mock_note)
+
+    assert proposals[0].already_documented is False
+
+
+@patch("hyperscribe.scribe.commands.medication_statement.MedicationCoding")
+def test_annotate_duplicates_marks_prn_when_chart_already_has_a_prn_order(mock_coding_cls: MagicMock) -> None:
+    """When the chart already carries an as-needed order, the duplicate is still suppressed."""
+    mock_note = _prn_dedup_setup(
+        mock_coding_cls,
+        [("Lorazepam 0.5 MG Tablet", "0.5 mg q4h as needed for anxiety")],
+    )
+    proposals = [_lorazepam_prn_proposal()]
+
+    MedicationParser().annotate_duplicates(proposals, mock_note)
+
+    assert proposals[0].already_documented is True
+
+
+@patch("hyperscribe.scribe.commands.medication_statement.MedicationCoding")
+def test_annotate_duplicates_keeps_prn_when_chart_sig_is_unknown(mock_coding_cls: MagicMock) -> None:
+    """With no sig recorded there is no evidence the PRN is charted, so keep it visible."""
+    mock_note = _prn_dedup_setup(mock_coding_cls, [("Lorazepam 0.5 MG Tablet", None)])
+    proposals = [_lorazepam_prn_proposal()]
+
+    MedicationParser().annotate_duplicates(proposals, mock_note)
+
+    assert proposals[0].already_documented is False
+
+
+@patch("hyperscribe.scribe.commands.medication_statement.MedicationCoding")
+def test_annotate_duplicates_marks_prn_when_any_matching_order_is_prn(mock_coding_cls: MagicMock) -> None:
+    """A drug carrying both a scheduled and an as-needed chart order suppresses the duplicate."""
+    mock_note = _prn_dedup_setup(
+        mock_coding_cls,
+        [
+            ("Lorazepam 0.5 MG Tablet", "one tablet nightly"),
+            ("Lorazepam 0.5 MG Tablet", "0.5 mg as needed for agitation"),
+        ],
+    )
+    proposals = [_lorazepam_prn_proposal()]
+
+    MedicationParser().annotate_duplicates(proposals, mock_note)
+
+    assert proposals[0].already_documented is True
+
+
+@patch("hyperscribe.scribe.commands.medication_statement.MedicationCoding")
+def test_annotate_duplicates_scheduled_proposal_behavior_is_unchanged(mock_coding_cls: MagicMock) -> None:
+    """A non-PRN proposal still dedupes on drug name alone, as it always has."""
+    mock_note = _prn_dedup_setup(mock_coding_cls, [("Lisinopril 10 MG Tablet", "0.5 mg as needed")])
+    proposals = [
+        CommandProposal(
+            command_type="medication_statement",
+            display="Lisinopril 10 mg",
+            data={"medication_text": "Lisinopril 10 mg", "sig": "one tablet daily"},
+        )
+    ]
+
+    MedicationParser().annotate_duplicates(proposals, mock_note)
+
+    assert proposals[0].already_documented is True
+
+
+@patch("hyperscribe.scribe.commands.medication_statement.MedicationCoding")
+def test_annotate_duplicates_prn_not_on_chart_at_all(mock_coding_cls: MagicMock) -> None:
+    """A PRN for a drug absent from the chart is untouched."""
+    mock_note = _prn_dedup_setup(mock_coding_cls, [("Metformin 500 MG Tablet", "twice daily")])
+    proposals = [_lorazepam_prn_proposal()]
+
+    MedicationParser().annotate_duplicates(proposals, mock_note)
+
+    assert proposals[0].already_documented is False
 
 
 def test_annotate_duplicates_no_medications() -> None:

--- a/tests/hyperscribe/scribe/recommendations/test_medication_statement.py
+++ b/tests/hyperscribe/scribe/recommendations/test_medication_statement.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock, patch
 
 from canvas_sdk.clients.llms.structures import LlmResponse, LlmTokens
 
-from hyperscribe.scribe.backend.models import ClinicalNote, NoteSection
+from hyperscribe.scribe.backend.models import ClinicalNote, NoteSection, Transcript, TranscriptItem
 from hyperscribe.scribe.recommendations.medication_statement import (
     MedicationRecommender,
     _build_user_prompt,
@@ -280,3 +280,227 @@ def test_recommend_multiple_medications(mock_resolve: MagicMock) -> None:
     assert proposals[0].data["fdb_code"]["code"] == "111"
     assert proposals[1].display == "Metformin 500mg"
     assert proposals[1].data["fdb_code"]["code"] == "222"
+
+
+# ── KOALA-6644: PRN recovery from the transcript ─────────────────────────
+#
+# Nabla's note-generation step drops as-needed medications, and the loss rate rises with the
+# number of PRNs dictated. Since extraction read only the generated note, a dropped PRN was
+# unrecoverable and nothing errored. These cover the transcript fallback.
+
+
+def _prn_transcript() -> Transcript:
+    """A transcript dictating six PRN medications, as in the ticket's confirmed case."""
+    dictated = [
+        "lorazepam 0.5 mg every four hours as needed for anxiety or agitation",
+        "acetaminophen 650 mg as needed for pain",
+        "ondansetron 4 mg as needed for nausea",
+        "albuterol two puffs as needed for shortness of breath",
+        "melatonin 3 mg as needed at bedtime",
+        "polyethylene glycol 17 g as needed for constipation",
+    ]
+    return Transcript(
+        items=[
+            TranscriptItem(
+                text=text,
+                speaker="doctor",
+                start_offset_ms=60_000 + i * 10_000,
+                end_offset_ms=65_000 + i * 10_000,
+            )
+            for i, text in enumerate(dictated)
+        ]
+    )
+
+
+def _note_with_scheduled_lorazepam_only() -> ClinicalNote:
+    """The generated note as Nabla produced it: a scheduled dose, none of the PRNs.
+
+    Mirrors note dbid 119673 — lorazepam appears, but as the patient's scheduled pre-shower
+    dose rather than the dictated as-needed order.
+    """
+    return _make_note(
+        [
+            NoteSection(
+                key="current_medications",
+                title="Meds Discussed",
+                text="- Lorazepam: one tablet daily, one hour before showers on Mondays and Wednesdays only",
+            ),
+        ]
+    )
+
+
+@patch("hyperscribe.scribe.recommendations.medication_statement._resolve_medication")
+def test_recommend_sends_prn_transcript_windows_to_the_llm(mock_resolve: MagicMock) -> None:
+    """As-needed transcript excerpts and the PRN instructions reach the model."""
+    mock_resolve.return_value = None
+    client = _make_client({"medications": []})
+
+    MedicationRecommender().recommend(_note_with_scheduled_lorazepam_only(), client, transcript=_prn_transcript())
+
+    user_prompt = client.set_user_prompt.call_args[0][0][0]
+    system_prompt = client.set_system_prompt.call_args[0][0][0]
+    assert "## Transcript Excerpts (as-needed medication language detected)" in user_prompt
+    assert "every four hours as needed for anxiety or agitation" in user_prompt
+    # the note is still supplied — the transcript augments it, never replaces it
+    assert "one hour before showers" in user_prompt
+    assert "SAME DRUG, TWO ORDERS" in system_prompt
+    assert "from_transcript=true" in system_prompt
+
+
+@patch("hyperscribe.scribe.recommendations.medication_statement._resolve_medication")
+def test_recommend_without_transcript_omits_prn_instructions(mock_resolve: MagicMock) -> None:
+    """No transcript means the prompt is exactly what it was before PRN recovery existed."""
+    mock_resolve.return_value = None
+    client = _make_client({"medications": []})
+
+    MedicationRecommender().recommend(_note_with_scheduled_lorazepam_only(), client)
+
+    user_prompt = client.set_user_prompt.call_args[0][0][0]
+    system_prompt = client.set_system_prompt.call_args[0][0][0]
+    assert "Transcript Excerpts" not in user_prompt
+    assert "SAME DRUG, TWO ORDERS" not in system_prompt
+
+
+@patch("hyperscribe.scribe.recommendations.medication_statement._resolve_medication")
+def test_recommend_transcript_only_medication_without_prn_language(mock_resolve: MagicMock) -> None:
+    """A transcript with no as-needed phrasing adds nothing to the prompt."""
+    mock_resolve.return_value = None
+    client = _make_client({"medications": []})
+    transcript = Transcript(
+        items=[
+            TranscriptItem(text="blood pressure looks good", speaker="doctor", start_offset_ms=0, end_offset_ms=5000)
+        ]
+    )
+
+    MedicationRecommender().recommend(_note_with_scheduled_lorazepam_only(), client, transcript=transcript)
+
+    assert "Transcript Excerpts" not in client.set_user_prompt.call_args[0][0][0]
+
+
+@patch("hyperscribe.scribe.recommendations.medication_statement._resolve_medication")
+def test_recommend_recovered_medication_is_proposed_unselected(mock_resolve: MagicMock) -> None:
+    """A medication recovered from the transcript is offered but not pre-selected.
+
+    The provider never saw it in the generated note, so it must not be charted on their
+    behalf — but it must be visible and one click away.
+    """
+    mock_resolve.return_value = None
+    client = _make_client(
+        {
+            "medications": [
+                {
+                    "medicationName": "Lorazepam 0.5 mg",
+                    "sig": "0.5 mg every four hours as needed for anxiety or agitation",
+                    "keywords": "lorazepam, ativan",
+                    "isPrn": True,
+                    "fromTranscript": True,
+                },
+            ]
+        }
+    )
+
+    proposals = MedicationRecommender().recommend(
+        _note_with_scheduled_lorazepam_only(), client, transcript=_prn_transcript()
+    )
+
+    assert len(proposals) == 1
+    assert proposals[0].from_transcript is True
+    assert proposals[0].selected is False
+
+
+@patch("hyperscribe.scribe.recommendations.medication_statement._resolve_medication")
+def test_recommend_note_derived_medication_stays_selected(mock_resolve: MagicMock) -> None:
+    """A medication present in the note keeps the pre-existing selected-by-default behavior."""
+    mock_resolve.return_value = None
+    client = _make_client(
+        {
+            "medications": [
+                {"medicationName": "Lisinopril 10 mg", "sig": "daily", "keywords": "lisinopril"},
+            ]
+        }
+    )
+
+    proposals = MedicationRecommender().recommend(_note_with_scheduled_lorazepam_only(), client)
+
+    assert proposals[0].from_transcript is False
+    assert proposals[0].selected is True
+
+
+@patch("hyperscribe.scribe.recommendations.medication_statement._resolve_medication")
+def test_recommend_keeps_scheduled_and_prn_orders_for_the_same_drug(mock_resolve: MagicMock) -> None:
+    """The lorazepam case: a scheduled order must not stand in for the as-needed one.
+
+    Both entries survive as separate proposals, with only the recovered one unselected.
+    """
+    mock_resolve.return_value = None
+    client = _make_client(
+        {
+            "medications": [
+                {
+                    "medicationName": "Lorazepam 0.5 mg",
+                    "sig": "one tablet daily, one hour before showers on Mondays and Wednesdays",
+                    "keywords": "lorazepam",
+                },
+                {
+                    "medicationName": "Lorazepam 0.5 mg",
+                    "sig": "0.5 mg every four hours as needed for anxiety or agitation",
+                    "keywords": "lorazepam",
+                    "isPrn": True,
+                    "fromTranscript": True,
+                },
+            ]
+        }
+    )
+
+    proposals = MedicationRecommender().recommend(
+        _note_with_scheduled_lorazepam_only(), client, transcript=_prn_transcript()
+    )
+
+    assert len(proposals) == 2
+    scheduled, prn = proposals
+    assert scheduled.selected is True
+    assert scheduled.from_transcript is False
+    assert prn.selected is False
+    assert prn.from_transcript is True
+    assert "as needed" in prn.data["sig"]
+
+
+@patch("hyperscribe.scribe.recommendations.medication_statement._resolve_medication")
+def test_recommend_runs_when_note_has_no_relevant_section_but_prns_were_dictated(
+    mock_resolve: MagicMock,
+) -> None:
+    """Nabla dropping the medication section entirely must not skip extraction.
+
+    Previously an empty section list returned [] before the LLM was ever called, so a note
+    whose medications section Nabla omitted lost every dictated PRN silently.
+    """
+    mock_resolve.return_value = None
+    client = _make_client(
+        {
+            "medications": [
+                {
+                    "medicationName": "Acetaminophen 650 mg",
+                    "sig": "650 mg as needed for pain",
+                    "keywords": "acetaminophen",
+                    "isPrn": True,
+                    "fromTranscript": True,
+                },
+            ]
+        }
+    )
+
+    proposals = MedicationRecommender().recommend(_make_note([]), client, transcript=_prn_transcript())
+
+    client.request.assert_called_once()
+    assert len(proposals) == 1
+    assert proposals[0].selected is False
+
+
+def test_recommend_skips_when_no_sections_and_no_prn_language() -> None:
+    """With neither a relevant section nor as-needed phrasing, the LLM is never called."""
+    client = _make_client({"medications": []})
+
+    proposals = MedicationRecommender().recommend(_make_note([]), client)
+
+    assert proposals == []
+    client.request.assert_not_called()

--- a/tests/hyperscribe/scribe/recommendations/test_medication_statement.py
+++ b/tests/hyperscribe/scribe/recommendations/test_medication_statement.py
@@ -500,3 +500,57 @@ def test_recommend_skips_when_no_sections_and_no_prn_language() -> None:
 
     assert proposals == []
     client.request.assert_not_called()
+
+
+@patch("hyperscribe.scribe.recommendations.medication_statement._resolve_medication")
+def test_recommend_ignores_from_transcript_when_no_excerpts_supplied(mock_resolve: MagicMock) -> None:
+    """The model sets from_transcript even with no transcript; provenance must not trust it.
+
+    Observed on real data: with no transcript passed at all, the LLM still returned
+    fromTranscript=true, which would badge a medication as recovered on a note where no
+    transcript was ever read. Provenance is a fact we establish, not one the model asserts.
+    """
+    mock_resolve.return_value = None
+    client = _make_client(
+        {
+            "medications": [
+                {
+                    "medicationName": "Albuterol inhaler",
+                    "sig": "approximately twice a week",
+                    "keywords": "albuterol",
+                    "fromTranscript": True,
+                },
+            ]
+        }
+    )
+
+    proposals = MedicationRecommender().recommend(_note_with_scheduled_lorazepam_only(), client)
+
+    assert proposals[0].from_transcript is False
+
+
+@patch("hyperscribe.scribe.recommendations.medication_statement._resolve_medication")
+def test_recommend_ignores_from_transcript_when_transcript_has_no_prn_language(
+    mock_resolve: MagicMock,
+) -> None:
+    """A transcript with no as-needed phrasing supplies no excerpts, so nothing is recovered."""
+    mock_resolve.return_value = None
+    transcript = Transcript(
+        items=[TranscriptItem(text="blood pressure is stable", speaker="doctor", start_offset_ms=0, end_offset_ms=4000)]
+    )
+    client = _make_client(
+        {
+            "medications": [
+                {
+                    "medicationName": "Lisinopril 10 mg",
+                    "sig": "daily",
+                    "keywords": "lisinopril",
+                    "fromTranscript": True,
+                },
+            ]
+        }
+    )
+
+    proposals = MedicationRecommender().recommend(_note_with_scheduled_lorazepam_only(), client, transcript=transcript)
+
+    assert proposals[0].from_transcript is False

--- a/tests/hyperscribe/scribe/recommendations/test_medication_statement.py
+++ b/tests/hyperscribe/scribe/recommendations/test_medication_statement.py
@@ -405,7 +405,6 @@ def test_recommend_recovered_medication_is_proposed_unselected(mock_resolve: Mag
 
     assert len(proposals) == 1
     assert proposals[0].from_transcript is True
-    assert proposals[0].selected is False
 
 
 @patch("hyperscribe.scribe.recommendations.medication_statement._resolve_medication")
@@ -423,7 +422,6 @@ def test_recommend_note_derived_medication_stays_selected(mock_resolve: MagicMoc
     proposals = MedicationRecommender().recommend(_note_with_scheduled_lorazepam_only(), client)
 
     assert proposals[0].from_transcript is False
-    assert proposals[0].selected is True
 
 
 @patch("hyperscribe.scribe.recommendations.medication_statement._resolve_medication")
@@ -458,9 +456,7 @@ def test_recommend_keeps_scheduled_and_prn_orders_for_the_same_drug(mock_resolve
 
     assert len(proposals) == 2
     scheduled, prn = proposals
-    assert scheduled.selected is True
     assert scheduled.from_transcript is False
-    assert prn.selected is False
     assert prn.from_transcript is True
     assert "as needed" in prn.data["sig"]
 
@@ -493,7 +489,7 @@ def test_recommend_runs_when_note_has_no_relevant_section_but_prns_were_dictated
 
     client.request.assert_called_once()
     assert len(proposals) == 1
-    assert proposals[0].selected is False
+    assert proposals[0].from_transcript is True
 
 
 def test_recommend_skips_when_no_sections_and_no_prn_language() -> None:

--- a/tests/hyperscribe/scribe/recommendations/test_medication_statement.py
+++ b/tests/hyperscribe/scribe/recommendations/test_medication_statement.py
@@ -554,3 +554,87 @@ def test_recommend_ignores_from_transcript_when_transcript_has_no_prn_language(
     proposals = MedicationRecommender().recommend(_note_with_scheduled_lorazepam_only(), client, transcript=transcript)
 
     assert proposals[0].from_transcript is False
+
+
+def test_recommend_clears_provenance_when_the_note_still_documents_the_prn() -> None:
+    """Partial loss: Nabla drops the PRN from the med list but keeps it in the A&P.
+
+    Measured on a real note — all six PRNs vanished from CURRENT_MEDICATIONS but survived in
+    ASSESSMENT_AND_PLAN, and the model reported all six as transcript-recovered. The provider
+    would have seen six "From transcript" pills on medications the note actually contained, and
+    the audit counter overstated recoveries. Roughly half the affected notes in the ticket are
+    partial, so this is the common case.
+    """
+    note = _make_note(
+        [
+            NoteSection(
+                key="current_medications",
+                title="Meds Discussed",
+                text="- lorazepam, one tablet daily, one hour before showers on Mondays and Wednesdays",
+            ),
+            NoteSection(
+                key="assessment_and_plan",
+                title="Assessment & Plan",
+                text=(
+                    "Anxiety/agitation\n"
+                    "- Add lorazepam 0.5 mg every four hours as needed for anxiety or agitation.\n"
+                    "Insomnia\n"
+                    "- Melatonin 3 mg as needed at bedtime."
+                ),
+            ),
+        ]
+    )
+    client = _make_client(
+        {
+            "medications": [
+                {
+                    "medicationName": "Lorazepam 0.5 mg",
+                    "sig": "every four hours as needed for anxiety",
+                    "keywords": "lorazepam",
+                    "isPrn": True,
+                    "fromTranscript": True,
+                },
+                {
+                    "medicationName": "Melatonin 3 mg",
+                    "sig": "as needed at bedtime",
+                    "keywords": "melatonin",
+                    "isPrn": True,
+                    "fromTranscript": True,
+                },
+            ]
+        }
+    )
+
+    with patch("hyperscribe.scribe.recommendations.medication_statement._resolve_medication", return_value=None):
+        proposals = MedicationRecommender().recommend(note, client, transcript=_prn_transcript())
+
+    # both are in the A&P, so neither was recovered from anywhere
+    assert [p.from_transcript for p in proposals] == [False, False]
+
+
+def test_recommend_keeps_provenance_when_the_note_only_has_the_scheduled_order() -> None:
+    """A genuine recovery must survive the guard.
+
+    The note carries lorazepam only as a scheduled pre-shower dose, so the as-needed order really
+    did come from the transcript and must stay flagged.
+    """
+    client = _make_client(
+        {
+            "medications": [
+                {
+                    "medicationName": "Lorazepam 0.5 mg",
+                    "sig": "0.5 mg every four hours as needed for anxiety or agitation",
+                    "keywords": "lorazepam",
+                    "isPrn": True,
+                    "fromTranscript": True,
+                },
+            ]
+        }
+    )
+
+    with patch("hyperscribe.scribe.recommendations.medication_statement._resolve_medication", return_value=None):
+        proposals = MedicationRecommender().recommend(
+            _note_with_scheduled_lorazepam_only(), client, transcript=_prn_transcript()
+        )
+
+    assert proposals[0].from_transcript is True

--- a/tests/hyperscribe/scribe/recommendations/test_prescription.py
+++ b/tests/hyperscribe/scribe/recommendations/test_prescription.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock, patch
 
 from canvas_sdk.clients.llms.structures import LlmResponse, LlmTokens
 
-from hyperscribe.scribe.backend.models import ClinicalNote, NoteSection
+from hyperscribe.scribe.backend.models import ClinicalNote, NoteSection, Transcript, TranscriptItem
 from hyperscribe.scribe.recommendations.prescription import (
     _SYSTEM_PROMPT,
     PrescriptionRecommender,
@@ -467,3 +467,137 @@ def test_recommend_from_prescription_section(mock_resolve: MagicMock) -> None:
     assert proposals[0].display == "Excedrin Extra Strength Tablet"
     assert proposals[0].data["fdb_code"] == "55555"
     client.request.assert_called_once()
+
+
+# ── KOALA-6644: PRN recovery from the transcript ─────────────────────────
+
+
+def _prn_transcript() -> Transcript:
+    """A transcript dictating an as-needed prescription."""
+    return Transcript(
+        items=[
+            TranscriptItem(
+                text="I'll send in ondansetron 4 mg, take one as needed for nausea",
+                speaker="doctor",
+                start_offset_ms=60_000,
+                end_offset_ms=68_000,
+            )
+        ]
+    )
+
+
+def _plan_note() -> ClinicalNote:
+    """A note whose plan section mentions an unrelated new prescription."""
+    return _make_note([NoteSection(key="plan", title="Plan", text="Start sumatriptan 50 mg.")])
+
+
+@patch("hyperscribe.scribe.recommendations.prescription._resolve_prescription")
+def test_recommend_sends_prn_transcript_windows_to_the_llm(mock_resolve: MagicMock) -> None:
+    """As-needed transcript excerpts and the PRN instructions reach the model."""
+    mock_resolve.return_value = None
+    client = _make_client({"prescriptions": []})
+
+    PrescriptionRecommender().recommend(_plan_note(), client, transcript=_prn_transcript())
+
+    user_prompt = client.set_user_prompt.call_args[0][0][0]
+    assert "## Transcript Excerpts (as-needed medication language detected)" in user_prompt
+    assert "as needed for nausea" in user_prompt
+    assert "sumatriptan" in user_prompt
+    assert "SAME DRUG, TWO ORDERS" in client.set_system_prompt.call_args[0][0][0]
+
+
+@patch("hyperscribe.scribe.recommendations.prescription._resolve_prescription")
+def test_recommend_prn_instructions_reach_the_baseline_prompt_too(mock_resolve: MagicMock) -> None:
+    """Providers with the dispense engine gated OFF must get the fix as well.
+
+    prescription.py carries two system prompts; appending PRN guidance to only the default
+    one would leave every provider outside ScribePrescriptionStaffers on the buggy path.
+    """
+    mock_resolve.return_value = None
+
+    for dispense_enabled in (True, False):
+        client = _make_client({"prescriptions": []})
+        PrescriptionRecommender(dispense_engine_enabled=dispense_enabled).recommend(
+            _plan_note(), client, transcript=_prn_transcript()
+        )
+        system_prompt = client.set_system_prompt.call_args[0][0][0]
+        assert "SAME DRUG, TWO ORDERS" in system_prompt, dispense_enabled
+        assert "from_transcript=true" in system_prompt, dispense_enabled
+
+
+@patch("hyperscribe.scribe.recommendations.prescription._resolve_prescription")
+def test_recommend_without_transcript_omits_prn_instructions(mock_resolve: MagicMock) -> None:
+    """No transcript means the prompt is exactly what it was before PRN recovery existed."""
+    mock_resolve.return_value = None
+    client = _make_client({"prescriptions": []})
+
+    PrescriptionRecommender().recommend(_plan_note(), client)
+
+    assert "Transcript Excerpts" not in client.set_user_prompt.call_args[0][0][0]
+    assert "SAME DRUG, TWO ORDERS" not in client.set_system_prompt.call_args[0][0][0]
+
+
+@patch("hyperscribe.scribe.recommendations.prescription._resolve_prescription")
+def test_recommend_recovered_prescription_is_proposed_unselected(mock_resolve: MagicMock) -> None:
+    """A prescription recovered from the transcript is offered but not pre-selected."""
+    mock_resolve.return_value = None
+    client = _make_client(
+        {
+            "prescriptions": [
+                {
+                    "medicationName": "Ondansetron 4 mg",
+                    "sig": "one tablet as needed for nausea",
+                    "keywords": "ondansetron, zofran",
+                    "isPrn": True,
+                    "fromTranscript": True,
+                },
+            ]
+        }
+    )
+
+    proposals = PrescriptionRecommender(dispense_engine_enabled=False).recommend(
+        _plan_note(), client, transcript=_prn_transcript()
+    )
+
+    assert len(proposals) == 1
+    assert proposals[0].from_transcript is True
+    assert proposals[0].selected is False
+
+
+@patch("hyperscribe.scribe.recommendations.prescription._resolve_prescription")
+def test_recommend_note_derived_prescription_stays_selected(mock_resolve: MagicMock) -> None:
+    """A prescription present in the note keeps the selected-by-default behavior."""
+    mock_resolve.return_value = None
+    client = _make_client(
+        {
+            "prescriptions": [
+                {"medicationName": "Sumatriptan 50 mg", "sig": "as directed", "keywords": "sumatriptan"},
+            ]
+        }
+    )
+
+    proposals = PrescriptionRecommender(dispense_engine_enabled=False).recommend(_plan_note(), client)
+
+    assert proposals[0].from_transcript is False
+    assert proposals[0].selected is True
+
+
+@patch("hyperscribe.scribe.recommendations.prescription._resolve_prescription")
+def test_recommend_runs_when_note_has_no_relevant_section_but_prns_were_dictated(
+    mock_resolve: MagicMock,
+) -> None:
+    """A note with no plan section must still extract PRNs heard in the transcript."""
+    mock_resolve.return_value = None
+    client = _make_client({"prescriptions": []})
+
+    PrescriptionRecommender().recommend(_make_note([]), client, transcript=_prn_transcript())
+
+    client.request.assert_called_once()
+
+
+def test_recommend_skips_when_no_sections_and_no_prn_language() -> None:
+    """With neither a relevant section nor as-needed phrasing, the LLM is never called."""
+    client = _make_client({"prescriptions": []})
+
+    assert PrescriptionRecommender().recommend(_make_note([]), client) == []
+    client.request.assert_not_called()

--- a/tests/hyperscribe/scribe/recommendations/test_prescription.py
+++ b/tests/hyperscribe/scribe/recommendations/test_prescription.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock, patch
 from canvas_sdk.clients.llms.structures import LlmResponse, LlmTokens
 
 from hyperscribe.scribe.backend.models import ClinicalNote, NoteSection, Transcript, TranscriptItem
+from hyperscribe.scribe.recommendations.schemas import PrescriptionRecommendation
 from hyperscribe.scribe.recommendations.prescription import (
     _SYSTEM_PROMPT,
     PrescriptionRecommender,
@@ -469,133 +470,45 @@ def test_recommend_from_prescription_section(mock_resolve: MagicMock) -> None:
     client.request.assert_called_once()
 
 
-# ── KOALA-6644: PRN recovery from the transcript ─────────────────────────
+# ── KOALA-6644: recovery is medication-list only, by design ──────────────
 
 
-def _prn_transcript() -> Transcript:
-    """A transcript dictating an as-needed prescription."""
-    return Transcript(
+def test_recommend_does_not_recover_prns_from_the_transcript() -> None:
+    """The prescription path must NOT pull as-needed medications out of the transcript.
+
+    KOALA-6644 recovers dropped PRNs into the medication list only. Nabla writes continuation
+    as "Continue <drug> as needed ...", so the "Continue" marker sits on the line that gets
+    dropped; a PRN recovered here would arrive with no evidence of whether it is being started
+    or merely reconciled. On real notes this path proposed NEW prescriptions for five
+    medications the patient was already taking. Missing documentation is recoverable, a
+    duplicate prescription is not.
+    """
+    transcript = Transcript(
         items=[
             TranscriptItem(
-                text="I'll send in ondansetron 4 mg, take one as needed for nausea",
+                text="ibuprofen 400 mg as needed for pain",
                 speaker="doctor",
-                start_offset_ms=60_000,
-                end_offset_ms=68_000,
+                start_offset_ms=0,
+                end_offset_ms=5000,
             )
         ]
     )
-
-
-def _plan_note() -> ClinicalNote:
-    """A note whose plan section mentions an unrelated new prescription."""
-    return _make_note([NoteSection(key="plan", title="Plan", text="Start sumatriptan 50 mg.")])
-
-
-@patch("hyperscribe.scribe.recommendations.prescription._resolve_prescription")
-def test_recommend_sends_prn_transcript_windows_to_the_llm(mock_resolve: MagicMock) -> None:
-    """As-needed transcript excerpts and the PRN instructions reach the model."""
-    mock_resolve.return_value = None
+    note = _make_note([NoteSection(key="plan", title="Plan", text="Start sumatriptan 50 mg.")])
     client = _make_client({"prescriptions": []})
 
-    PrescriptionRecommender().recommend(_plan_note(), client, transcript=_prn_transcript())
+    PrescriptionRecommender().recommend(note, client, transcript=transcript)
 
     user_prompt = client.set_user_prompt.call_args[0][0][0]
-    assert "## Transcript Excerpts (as-needed medication language detected)" in user_prompt
-    assert "as needed for nausea" in user_prompt
-    assert "sumatriptan" in user_prompt
-    assert "SAME DRUG, TWO ORDERS" in client.set_system_prompt.call_args[0][0][0]
+    system_prompt = client.set_system_prompt.call_args[0][0][0]
+    assert "ibuprofen" not in user_prompt
+    assert "Transcript" not in user_prompt
+    # the note-only prompt is what it always was
+    assert user_prompt == "## Plan\nStart sumatriptan 50 mg."
+    assert system_prompt == _SYSTEM_PROMPT
 
 
-@patch("hyperscribe.scribe.recommendations.prescription._resolve_prescription")
-def test_recommend_prn_instructions_reach_the_baseline_prompt_too(mock_resolve: MagicMock) -> None:
-    """Providers with the dispense engine gated OFF must get the fix as well.
-
-    prescription.py carries two system prompts; appending PRN guidance to only the default
-    one would leave every provider outside ScribePrescriptionStaffers on the buggy path.
-    """
-    mock_resolve.return_value = None
-
-    for dispense_enabled in (True, False):
-        client = _make_client({"prescriptions": []})
-        PrescriptionRecommender(dispense_engine_enabled=dispense_enabled).recommend(
-            _plan_note(), client, transcript=_prn_transcript()
-        )
-        system_prompt = client.set_system_prompt.call_args[0][0][0]
-        assert "SAME DRUG, TWO ORDERS" in system_prompt, dispense_enabled
-        assert "from_transcript=true" in system_prompt, dispense_enabled
-
-
-@patch("hyperscribe.scribe.recommendations.prescription._resolve_prescription")
-def test_recommend_without_transcript_omits_prn_instructions(mock_resolve: MagicMock) -> None:
-    """No transcript means the prompt is exactly what it was before PRN recovery existed."""
-    mock_resolve.return_value = None
-    client = _make_client({"prescriptions": []})
-
-    PrescriptionRecommender().recommend(_plan_note(), client)
-
-    assert "Transcript Excerpts" not in client.set_user_prompt.call_args[0][0][0]
-    assert "SAME DRUG, TWO ORDERS" not in client.set_system_prompt.call_args[0][0][0]
-
-
-@patch("hyperscribe.scribe.recommendations.prescription._resolve_prescription")
-def test_recommend_recovered_prescription_is_proposed_unselected(mock_resolve: MagicMock) -> None:
-    """A prescription recovered from the transcript is offered but not pre-selected."""
-    mock_resolve.return_value = None
-    client = _make_client(
-        {
-            "prescriptions": [
-                {
-                    "medicationName": "Ondansetron 4 mg",
-                    "sig": "one tablet as needed for nausea",
-                    "keywords": "ondansetron, zofran",
-                    "isPrn": True,
-                    "fromTranscript": True,
-                },
-            ]
-        }
-    )
-
-    proposals = PrescriptionRecommender(dispense_engine_enabled=False).recommend(
-        _plan_note(), client, transcript=_prn_transcript()
-    )
-
-    assert len(proposals) == 1
-    assert proposals[0].from_transcript is True
-
-
-@patch("hyperscribe.scribe.recommendations.prescription._resolve_prescription")
-def test_recommend_note_derived_prescription_stays_selected(mock_resolve: MagicMock) -> None:
-    """A prescription present in the note keeps the selected-by-default behavior."""
-    mock_resolve.return_value = None
-    client = _make_client(
-        {
-            "prescriptions": [
-                {"medicationName": "Sumatriptan 50 mg", "sig": "as directed", "keywords": "sumatriptan"},
-            ]
-        }
-    )
-
-    proposals = PrescriptionRecommender(dispense_engine_enabled=False).recommend(_plan_note(), client)
-
-    assert proposals[0].from_transcript is False
-
-
-@patch("hyperscribe.scribe.recommendations.prescription._resolve_prescription")
-def test_recommend_runs_when_note_has_no_relevant_section_but_prns_were_dictated(
-    mock_resolve: MagicMock,
-) -> None:
-    """A note with no plan section must still extract PRNs heard in the transcript."""
-    mock_resolve.return_value = None
-    client = _make_client({"prescriptions": []})
-
-    PrescriptionRecommender().recommend(_make_note([]), client, transcript=_prn_transcript())
-
-    client.request.assert_called_once()
-
-
-def test_recommend_skips_when_no_sections_and_no_prn_language() -> None:
-    """With neither a relevant section nor as-needed phrasing, the LLM is never called."""
-    client = _make_client({"prescriptions": []})
-
-    assert PrescriptionRecommender().recommend(_make_note([]), client) == []
-    client.request.assert_not_called()
+def test_prescription_schema_has_no_transcript_provenance_fields() -> None:
+    """No dead schema fields: provenance belongs only to the medication-list path."""
+    fields = set(PrescriptionRecommendation.model_fields)
+    assert "from_transcript" not in fields
+    assert "is_prn" not in fields

--- a/tests/hyperscribe/scribe/recommendations/test_prescription.py
+++ b/tests/hyperscribe/scribe/recommendations/test_prescription.py
@@ -561,7 +561,6 @@ def test_recommend_recovered_prescription_is_proposed_unselected(mock_resolve: M
 
     assert len(proposals) == 1
     assert proposals[0].from_transcript is True
-    assert proposals[0].selected is False
 
 
 @patch("hyperscribe.scribe.recommendations.prescription._resolve_prescription")
@@ -579,7 +578,6 @@ def test_recommend_note_derived_prescription_stays_selected(mock_resolve: MagicM
     proposals = PrescriptionRecommender(dispense_engine_enabled=False).recommend(_plan_note(), client)
 
     assert proposals[0].from_transcript is False
-    assert proposals[0].selected is True
 
 
 @patch("hyperscribe.scribe.recommendations.prescription._resolve_prescription")

--- a/tests/hyperscribe/scribe/recommendations/test_transcript_windows.py
+++ b/tests/hyperscribe/scribe/recommendations/test_transcript_windows.py
@@ -1,0 +1,209 @@
+from __future__ import annotations
+
+import re
+
+from hyperscribe.scribe.backend.models import NoteSection, Transcript, TranscriptItem
+from hyperscribe.scribe.recommendations._transcript_windows import (
+    WINDOW_MS,
+    collect_windows,
+    extract_window_items,
+    find_keyword_matches,
+    format_note_sections,
+    format_transcript_windows,
+    merge_windows,
+)
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────
+
+
+def _item(text: str, start_ms: int, end_ms: int, speaker: str = "doctor") -> TranscriptItem:
+    """Build a transcript item at a fixed offset."""
+    return TranscriptItem(text=text, speaker=speaker, start_offset_ms=start_ms, end_offset_ms=end_ms)
+
+
+def _transcript(*items: TranscriptItem) -> Transcript:
+    """Build a transcript from the given items."""
+    return Transcript(items=list(items))
+
+
+_PATTERN = re.compile(r"\bneedle\b", re.IGNORECASE)
+
+
+# ── find_keyword_matches ─────────────────────────────────────────────────
+
+
+def test_find_keyword_matches_returns_midpoints() -> None:
+    """A matching item yields the midpoint of its own offsets."""
+    transcript = _transcript(_item("pass me the needle", 10_000, 20_000))
+    assert find_keyword_matches(transcript, _PATTERN) == [15_000]
+
+
+def test_find_keyword_matches_no_matches() -> None:
+    """A transcript with no pattern hit yields no timestamps."""
+    transcript = _transcript(_item("nothing relevant here", 0, 1_000))
+    assert find_keyword_matches(transcript, _PATTERN) == []
+
+
+def test_find_keyword_matches_is_pattern_driven() -> None:
+    """The caller's pattern decides matching, including its own case-insensitivity."""
+    transcript = _transcript(_item("NEEDLE", 0, 2_000))
+    assert find_keyword_matches(transcript, _PATTERN) == [1_000]
+    assert find_keyword_matches(transcript, re.compile(r"\bneedle\b")) == []
+
+
+def test_find_keyword_matches_multiple_items() -> None:
+    """Every matching item contributes one timestamp, in transcript order."""
+    transcript = _transcript(
+        _item("needle one", 0, 2_000),
+        _item("irrelevant", 3_000, 4_000),
+        _item("needle two", 10_000, 12_000),
+    )
+    assert find_keyword_matches(transcript, _PATTERN) == [1_000, 11_000]
+
+
+def test_find_keyword_matches_empty_transcript() -> None:
+    """An empty transcript yields no timestamps."""
+    assert find_keyword_matches(_transcript(), _PATTERN) == []
+
+
+# ── merge_windows ────────────────────────────────────────────────────────
+
+
+def test_merge_windows_no_overlap() -> None:
+    """Timestamps further apart than 2x the window stay separate."""
+    assert merge_windows([60_000, 360_000]) == [(0, 180_000), (240_000, 480_000)]
+
+
+def test_merge_windows_overlap() -> None:
+    """Overlapping intervals collapse into one spanning window."""
+    assert merge_windows([100_000, 150_000]) == [(0, 270_000)]
+
+
+def test_merge_windows_empty() -> None:
+    """No timestamps yields no windows."""
+    assert merge_windows([]) == []
+
+
+def test_merge_windows_clamps_to_zero() -> None:
+    """A window starting before the recording begins is clamped to zero."""
+    assert merge_windows([30_000]) == [(0, 150_000)]
+
+
+def test_merge_windows_honors_custom_width() -> None:
+    """An explicit window_ms overrides the module default."""
+    assert merge_windows([50_000], window_ms=1_000) == [(49_000, 51_000)]
+
+
+def test_merge_windows_default_width_is_module_constant() -> None:
+    """The default half-width is WINDOW_MS."""
+    assert merge_windows([WINDOW_MS]) == [(0, 2 * WINDOW_MS)]
+
+
+# ── extract_window_items ─────────────────────────────────────────────────
+
+
+def test_extract_window_items_collects_overlapping() -> None:
+    """Only items overlapping a window are collected, per window."""
+    transcript = _transcript(
+        _item("first", 0, 1_000),
+        _item("second", 5_000, 6_000),
+        _item("third", 500_000, 501_000),
+    )
+    result = extract_window_items(transcript, [(0, 10_000), (490_000, 510_000)])
+    assert [[i.text for i in window] for window in result] == [["first", "second"], ["third"]]
+
+
+def test_extract_window_items_boundary_is_inclusive() -> None:
+    """An item touching a window edge is included."""
+    transcript = _transcript(_item("edge", 10_000, 20_000))
+    assert len(extract_window_items(transcript, [(20_000, 30_000)])[0]) == 1
+    assert len(extract_window_items(transcript, [(0, 10_000)])[0]) == 1
+
+
+def test_extract_window_items_window_with_no_items() -> None:
+    """A window matching nothing yields an empty list, preserving window count."""
+    transcript = _transcript(_item("only", 0, 1_000))
+    assert extract_window_items(transcript, [(0, 500), (900_000, 910_000)]) == [[transcript.items[0]], []]
+
+
+# ── format_transcript_windows ────────────────────────────────────────────
+
+
+def test_format_transcript_windows_labels_speaker_and_time() -> None:
+    """Each window is headed by its mm:ss range and speaker-labelled lines."""
+    items = [[_item("take it as needed", 65_000, 70_000, "doctor")]]
+    result = format_transcript_windows(items)
+    assert result == "[Window 1: 1:05 - 1:10]\nDoctor: take it as needed"
+
+
+def test_format_transcript_windows_empty_items() -> None:
+    """A window with no items is skipped entirely."""
+    assert format_transcript_windows([[]]) == ""
+
+
+def test_format_transcript_windows_no_windows() -> None:
+    """No windows yields an empty string."""
+    assert format_transcript_windows([]) == ""
+
+
+def test_format_transcript_windows_missing_speaker() -> None:
+    """An item with no speaker is labelled Unknown."""
+    items = [[_item("who said this", 0, 1_000, "")]]
+    assert "Unknown: who said this" in format_transcript_windows(items)
+
+
+def test_format_transcript_windows_multiple_windows_are_numbered() -> None:
+    """Windows are numbered from 1 and separated by a blank line."""
+    items = [[_item("one", 0, 1_000)], [_item("two", 600_000, 601_000)]]
+    result = format_transcript_windows(items)
+    assert "[Window 1: 0:00 - 0:01]" in result
+    assert "[Window 2: 10:00 - 10:01]" in result
+    assert "\n\n" in result
+
+
+# ── collect_windows ──────────────────────────────────────────────────────
+
+
+def test_collect_windows_end_to_end() -> None:
+    """The wrapper chains match, merge, extract, and format."""
+    transcript = _transcript(
+        _item("bring the needle", 60_000, 62_000),
+        _item("unrelated chatter", 63_000, 64_000),
+    )
+    result = collect_windows(transcript, _PATTERN)
+    assert "Doctor: bring the needle" in result
+    assert "Doctor: unrelated chatter" in result
+
+
+def test_collect_windows_none_transcript() -> None:
+    """A missing transcript yields an empty string rather than raising."""
+    assert collect_windows(None, _PATTERN) == ""
+
+
+def test_collect_windows_empty_transcript() -> None:
+    """A transcript with no items yields an empty string."""
+    assert collect_windows(_transcript(), _PATTERN) == ""
+
+
+def test_collect_windows_no_pattern_match() -> None:
+    """A transcript that never matches yields an empty string."""
+    transcript = _transcript(_item("nothing to see", 0, 1_000))
+    assert collect_windows(transcript, _PATTERN) == ""
+
+
+# ── format_note_sections ─────────────────────────────────────────────────
+
+
+def test_format_note_sections_renders_headings() -> None:
+    """Sections render as markdown headings joined by a blank line."""
+    sections = [
+        NoteSection(key="plan", title="Plan", text="start lisinopril"),
+        NoteSection(key="hpi", title="HPI", text="chest pain"),
+    ]
+    assert format_note_sections(sections) == "## Plan\nstart lisinopril\n\n## HPI\nchest pain"
+
+
+def test_format_note_sections_empty() -> None:
+    """No sections yields an empty string."""
+    assert format_note_sections([]) == ""

--- a/tests/hyperscribe/scribe/recommendations/test_transcript_windows.py
+++ b/tests/hyperscribe/scribe/recommendations/test_transcript_windows.py
@@ -13,6 +13,7 @@ from hyperscribe.scribe.recommendations._transcript_windows import (
     format_note_sections,
     format_transcript_windows,
     merge_windows,
+    note_documents_as_needed,
 )
 
 
@@ -294,3 +295,59 @@ def test_build_user_prompt_windows_only() -> None:
     result = build_user_prompt([], "[Window 1: 0:00 - 0:05]\nDoctor: morphine as needed")
     assert "Doctor: morphine as needed" in result
     assert "## Transcript Excerpts (as-needed medication language detected)" in result
+
+
+# ── note_documents_as_needed ─────────────────────────────────────────────
+
+
+def test_note_documents_as_needed_finds_prn_line() -> None:
+    """A note line naming the drug with as-needed dosing counts as documented."""
+    sections = [
+        NoteSection(
+            key="assessment_and_plan",
+            title="A&P",
+            text="Anxiety\n- Add lorazepam 0.5 mg every four hours as needed for agitation.",
+        )
+    ]
+    assert note_documents_as_needed(sections, "Lorazepam 0.5 mg") is True
+
+
+def test_note_documents_as_needed_ignores_scheduled_only_mention() -> None:
+    """A scheduled order for the same drug must NOT count as documenting the PRN.
+
+    This is the reported lorazepam case: the note keeps the scheduled pre-shower dose and loses
+    the as-needed order. A name-only test would clear the flag on a genuine recovery.
+    """
+    sections = [
+        NoteSection(
+            key="current_medications",
+            title="Meds",
+            text="- Lorazepam, one tablet daily, one hour before showers on Mondays and Wednesdays",
+        )
+    ]
+    assert note_documents_as_needed(sections, "Lorazepam 0.5 mg") is False
+
+
+def test_note_documents_as_needed_requires_the_same_drug() -> None:
+    """An as-needed line for a different drug does not count."""
+    sections = [NoteSection(key="plan", title="Plan", text="- Melatonin 3 mg as needed at bedtime.")]
+    assert note_documents_as_needed(sections, "Polyethylene glycol 17 grams") is False
+
+
+def test_note_documents_as_needed_across_sections() -> None:
+    """Any supplied section counts, not just the medication list."""
+    sections = [
+        NoteSection(key="current_medications", title="Meds", text="- lisinopril 10 mg once daily"),
+        NoteSection(key="plan", title="Plan", text="- Albuterol inhaler, two puffs as needed for dyspnea."),
+    ]
+    assert note_documents_as_needed(sections, "Albuterol inhaler") is True
+
+
+def test_note_documents_as_needed_unparseable_name() -> None:
+    """A name with no usable drug word cannot be matched, so it is not documented."""
+    assert note_documents_as_needed([NoteSection(key="plan", title="P", text="x as needed")], "5 mg") is False
+
+
+def test_note_documents_as_needed_empty_sections() -> None:
+    """No sections means nothing is documented."""
+    assert note_documents_as_needed([], "Lorazepam 0.5 mg") is False

--- a/tests/hyperscribe/scribe/recommendations/test_transcript_windows.py
+++ b/tests/hyperscribe/scribe/recommendations/test_transcript_windows.py
@@ -4,7 +4,9 @@ import re
 
 from hyperscribe.scribe.backend.models import NoteSection, Transcript, TranscriptItem
 from hyperscribe.scribe.recommendations._transcript_windows import (
+    PRN_PATTERN,
     WINDOW_MS,
+    build_user_prompt,
     collect_windows,
     extract_window_items,
     find_keyword_matches,
@@ -207,3 +209,88 @@ def test_format_note_sections_renders_headings() -> None:
 def test_format_note_sections_empty() -> None:
     """No sections yields an empty string."""
     assert format_note_sections([]) == ""
+
+
+# ── PRN_PATTERN ──────────────────────────────────────────────────────────
+
+
+def test_prn_pattern_matches_as_needed_spellings() -> None:
+    """The common as-needed spellings and abbreviations are all recognised."""
+    for phrase in (
+        "0.5 mg every four hours as needed for anxiety",
+        "one tablet as-needed",
+        "ibuprofen PRN",
+        "lorazepam prn agitation",
+        "take p.r.n.",
+        "tylenol when needed",
+        "use if needed",
+        "another dose as necessary",
+        "oxygen as required",
+    ):
+        assert PRN_PATTERN.search(phrase), phrase
+
+
+def test_prn_pattern_is_case_insensitive() -> None:
+    """Casing does not affect matching."""
+    assert PRN_PATTERN.search("AS NEEDED")
+    assert PRN_PATTERN.search("As Needed")
+
+
+def test_prn_pattern_tolerates_extra_whitespace() -> None:
+    """Transcription artifacts like doubled spaces still match."""
+    assert PRN_PATTERN.search("take it as  needed")
+
+
+def test_prn_pattern_ignores_unrelated_words() -> None:
+    """Words merely containing the letters p, r, n do not match the PRN abbreviation."""
+    for phrase in ("print the summary", "the person is stable", "prone position", "pruning"):
+        assert not PRN_PATTERN.search(phrase), phrase
+
+
+def test_prn_pattern_matches_non_medication_phrases_by_design() -> None:
+    """Non-medication as-needed phrasing matches on purpose.
+
+    The pattern only decides which transcript excerpts reach the LLM; the extraction prompt
+    is what rejects them. Tuning for recall here is deliberate — a false negative
+    reproduces the PRN loss this exists to prevent, a false positive costs a few tokens.
+    """
+    assert PRN_PATTERN.search("follow up as needed")
+    assert PRN_PATTERN.search("call us if needed")
+
+
+# ── build_user_prompt ────────────────────────────────────────────────────
+
+
+def _sections() -> list[NoteSection]:
+    """Two note sections for prompt assembly."""
+    return [
+        NoteSection(key="current_medications", title="Current Medications", text="- Lisinopril 10 mg daily"),
+        NoteSection(key="plan", title="Plan", text="Continue current regimen."),
+    ]
+
+
+def test_build_user_prompt_without_windows_is_note_only() -> None:
+    """With no transcript excerpts the prompt is exactly the note-sections rendering.
+
+    This is the no-regression guarantee for visits with no as-needed language: the prompt
+    must be byte-identical to what shipped before transcript recovery existed.
+    """
+    sections = _sections()
+    assert build_user_prompt(sections, "") == format_note_sections(sections)
+    assert build_user_prompt(sections) == format_note_sections(sections)
+
+
+def test_build_user_prompt_with_windows_includes_both_sources() -> None:
+    """With excerpts the prompt carries both, under distinguishing headings."""
+    result = build_user_prompt(_sections(), "[Window 1: 0:10 - 0:20]\nDoctor: lorazepam as needed")
+    assert "## Clinical Note Sections" in result
+    assert "Lisinopril 10 mg daily" in result
+    assert "## Transcript Excerpts (as-needed medication language detected)" in result
+    assert "Doctor: lorazepam as needed" in result
+
+
+def test_build_user_prompt_windows_only() -> None:
+    """Excerpts still reach the model when no note section matched."""
+    result = build_user_prompt([], "[Window 1: 0:00 - 0:05]\nDoctor: morphine as needed")
+    assert "Doctor: morphine as needed" in result
+    assert "## Transcript Excerpts (as-needed medication language detected)" in result


### PR DESCRIPTION
https://canvasmedical.atlassian.net/browse/KOALA-6644

## The bug

Canvas Scribe charted medications from the **Nabla-generated note**, never from the
**transcript**. When Nabla's summarization omitted a medication it could never be charted, and
nothing raised an error to the provider, the logs, or the audit trail — the only signal was
absence. Loss rate rises with the number of PRNs dictated; the ticket measured 512 Brigade
notes losing PRN content, 24% at 3+ PRNs.

Both medication recommenders already *received* a `transcript` argument and ignored it.

## What changed

**Recovery (`recommendations/medication_statement.py`)** — scans the transcript for as-needed
phrasing and sends the matching excerpts alongside the note sections, following the windowing
pattern `TaskRecommender` already established. New `is_prn` / `from_transcript` schema fields;
prompt gains completeness pressure, a PRN instruction, and an explicit *same drug, two orders*
rule so a scheduled order can never stand in for an as-needed one.

**Scope: medication list only.** The prescription path deliberately does **not** recover PRNs.
Nabla writes continuation as `Continue <drug> as needed ...`, so the "Continue" marker sits on
the very line that gets dropped — a recovered PRN arrives with no evidence of whether it is
being started or merely reconciled. Measured on real notes, that path proposed new
prescriptions for five medications the patient was already taking. Missing documentation is
recoverable; a duplicate prescription is not, and the ticket's confirmed case was a
medication-list loss. `prescription.py` carries a comment recording this so it is not re-added.

**Dedup fix (`commands/medication_statement.py`)** — `annotate_duplicates` stamped
`already_documented` on a drug-name substring match against the chart, and the UI hides
`already_documented && !command_uuid`. So recovering a PRN was a **no-op** whenever the same
drug was already charted on a schedule, which is exactly the reported case. The chart sig is now
read in the same query and an as-needed proposal is suppressed only on positive evidence that
the chart already carries an as-needed order. Non-PRN proposals dedupe on name exactly as before.

**Provenance is established, not asserted.** Two deterministic corrections, both found by
measuring against real notes rather than by reasoning:

- The model sets `fromTranscript` even when no excerpts were supplied at all, which would badge a
  medication as recovered on a note where no transcript was read.
- On **partial** loss it claims recovery even when the note still carries the order. Measured: Nabla
  dropped all six dictated PRNs from `CURRENT_MEDICATIONS` but kept every one in
  `ASSESSMENT_AND_PLAN`, which this recommender also reads — and all six came back flagged, with the
  audit reporting 6 recoveries where the honest answer was 0. The ticket splits its 512 notes into
  252 dropped entirely and 260 dropped partially, so this is the common case, not an edge.

`note_documents_as_needed()` clears the flag when a supplied section already documents the drug
**with as-needed dosing**. Name *and* as-needed, never name alone: a drug routinely appears in the
note under a scheduled order while its as-needed order is the one that went missing — the reported
lorazepam case — so a name-only test would kill genuine recoveries.

**Telemetry** — `MEDS_PRN_TRANSCRIPT` records as-needed mentions against actual recoveries.
Mentions with zero recoveries is the remaining-silent-drop case and is what a later remediation
sweep can select on. Emitted *outside* the recommendation `try`, which swallows the whole stage
as "non-critical" — inside it, the telemetry would vanish in exactly the runs where a medication
went missing. Counts only: no drug names, no sigs, no transcript text.

Plus a UI pill on recovered rows, and `post_recommend_commands` now supplies the transcript
(without it the standalone endpoint reintroduced the bug).

First commit is a pure refactor lifting the windowing helpers out of `task.py`; `test_task.py`
passes unedited as the proof.

## Validation

Measured against real notes, comparing the same stored note and transcript with the PRN lines
stripped from the note to simulate Nabla's loss. Both directions of the provenance guard:

| condition | med-list proposals | flagged recovered |
|---|---|---|
full note, no transcript | 5 | 0 |
full note, **with** transcript | 10 | **0** — was 6 false positives before the guard |
stripped note, no transcript | 8, several with an empty sig | 0 |
stripped note, **with** transcript | 10 | **5** genuine recoveries, still flagged |

Row 2 is the guard working: the transcript still improves med-list completeness (5 → 10 entries,
because the note filed its PRNs under prescriptions rather than the medication list) while
correctly reporting none of them as recovered, since the note did document them. Row 4 is the guard
not over-reaching: with the PRN lines genuinely gone, recovery fires and stays flagged.

Row 3 is the pre-fix failure in its subtler form — the drug names survive elsewhere in the note but
their directions do not, so the medication list carries entries with no sig at all.

Across all runs the two lorazepam orders stay separate (scheduled unflagged, as-needed flagged) and
decoy phrasing — "we'll follow up as needed", "call the office if needed" — produces no medication.
With no as-needed phrasing anywhere the prompts are byte-identical to before, which the pre-existing
prompt assertions still pin.

**Caveat worth carrying into review:** across three live dictation/fixture runs, Nabla never once
dropped a PRN from *every* section this recommender reads — it kept them in the assessment/plan each
time. Recovery has been exercised only via the controlled strip test. This is a backstop for a
failure mode reproduced from the ticket's data, not one we have caught end-to-end ourselves.

## Not in scope

- **The affected notes are not repaired.** Fix-forward only. A remediation sweep is agreed as
  follow-up work once this is validated in the wild, and there is currently no host for a batch
  job in this plugin.
- **The Nabla-side root cause.** `note_sections_customization` has no entry for
  `CURRENT_MEDICATIONS`, so meds are generated with stock template behaviour. Worth a spike.
- **KOALA-5411** (vitals parser) — same symptom, different mechanism: that data *is* in the note
  and a regex misses it.

## Pre-existing issues found while testing — please don't block on these

Both reproduce on the base branch and need their own tickets:

- A lorazepam order dictated as "one tablet daily" with no strength resolves to **Ativan 1 mg** —
  the resolver falls through to the first FDB candidate. KOALA-5930 only made this fail-safe when
  a strength *was* stated and didn't match. Wrong strength on a benzodiazepine.
- **"Acetaminophen 650 mg" resolves to "Dologen 650 mg-2 mg"**, a combination product rather than
  plain acetaminophen: 650 mg matches the combination's component so it passes the strength check
  while being the wrong drug. Arguably higher severity than this ticket — wrong-drug beats
  missing-drug.

## UAT

**A happy-path run will not test this.** Nabla keeps the PRNs roughly 3 runs in 4 — it kept all
six in both local dictation and fixture runs — and then there is nothing to recover, everything
is correctly unflagged, and the run passes green without touching the change. Testing recovery
requires forcing the note to omit the PRNs (edit `summary.note_data` via the Models tab / the
`debug-cache` endpoint, then re-run `/recommend-commands`). A scenario-by-scenario UAT script
with pass/fail criteria is available — ask and I'll paste it into a comment.
